### PR TITLE
Update the gpud package version

### DIFF
--- a/cmd/gpuhealth/inject.go
+++ b/cmd/gpuhealth/inject.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/urfave/cli"
+
+	"github.com/NVIDIA/gpuhealth/internal/config"
+)
+
+func injectCommand(c *cli.Context) error {
+	component := c.String("component")
+	if component == "" {
+		return fmt.Errorf("component name is required")
+	}
+
+	// Get the server address
+	address := fmt.Sprintf("http://localhost:%d", config.DefaultHealthPort)
+
+	// Check if clear flag is set
+	clearFault := c.Bool("clear")
+	if clearFault {
+		return clearComponentFault(component, address)
+	}
+
+	faultType := c.String("fault-type")
+	if faultType == "" {
+		faultType = "event"
+	}
+
+	faultMessage := c.String("fault-message")
+	if faultMessage == "" {
+		faultMessage = fmt.Sprintf("Injected fault for testing %s component", component)
+	}
+
+	eventType := c.String("event-type")
+	if eventType == "" {
+		eventType = "Fatal"
+	}
+
+	// Create the injection request
+	var requestBody map[string]interface{}
+	switch faultType {
+	case "component-error":
+		requestBody = map[string]interface{}{
+			"component_error": map[string]string{
+				"component": component,
+				"message":   faultMessage,
+			},
+		}
+
+	case "event":
+		requestBody = map[string]interface{}{
+			"event": map[string]string{
+				"component": component,
+				"name":      component,
+				"type":      eventType,
+				"message":   faultMessage,
+			},
+		}
+
+	case "kernel-message", "kmsg":
+		kernelMsg, err := getKernelMessageForComponent(component, faultMessage)
+		if err != nil {
+			return fmt.Errorf("failed to get kernel message for component %s: %w", component, err)
+		}
+		requestBody = map[string]interface{}{
+			"kernel_message": map[string]string{
+				"priority": "KERN_ERR",
+				"message":  kernelMsg,
+			},
+		}
+
+	default:
+		return fmt.Errorf("invalid fault type: %s", faultType)
+	}
+
+	// Marshal to JSON
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Make the POST request to the inject-fault endpoint
+	url := fmt.Sprintf("%s/inject-fault", address)
+	fmt.Printf("Injecting fault into %s component at %s...\n", component, url)
+
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to make request to %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned error status %d", resp.StatusCode)
+	}
+
+	fmt.Printf("Successfully injected fault into %s component\n", component)
+	return nil
+}
+
+// getKernelMessageForComponent returns the appropriate kernel message for a given component
+func getKernelMessageForComponent(component, faultMessage string) (string, error) {
+	switch component {
+	case "accelerator-nvidia-error-xid":
+		// XID 79: GPU has fallen off the bus (critical error)
+		return "NVRM: Xid (PCI:0000:01:00): 79, GPU has fallen off the bus", nil
+
+	case "accelerator-nvidia-error-sxid":
+		// SXID 11001: Fatal ingress invalid command
+		return "nvidia-nvswitch0: SXid (PCI:0000:00:00.0): 11001, Fatal, ingress invalid command", nil
+
+	case "accelerator-nvidia-nccl":
+		// NCCL segfault in libnccl.so
+		return "pt_main_thread[2536443]: segfault at 7f797fe00000 ip 00007f7c7ac69996 sp 00007f7c12fd7c30 error 4 in libnccl.so.2[7f7c7ac00000+d3d3000]", nil
+
+	case "disk":
+		// Filesystem remounted read-only (critical disk error)
+		return "EXT4-fs (dm-0): Remounting filesystem read-only", nil
+
+	case "cpu":
+		// CPU thermal throttling
+		return "CPU0: Package temperature above threshold, cpu clock throttled (total events = 1)", nil
+
+	case "memory":
+		// Memory ECC error
+		return "EDAC MC0: 1 CE memory read error on CPU_SrcID#0_Ha#0_Chan#0_DIMM#0 (channel:0 slot:0 page:0x0 offset:0x0 grain:8 syndrome:0x0)", nil
+
+	case "os":
+		// Out of memory killer
+		return "Out of memory: Kill process 12345 (python3) score 900 or sacrifice child", nil
+
+	default:
+		return "", fmt.Errorf("no kernel message defined for component: %s", component)
+	}
+}
+
+// clearComponentFault sends a request to clear injected faults from a component
+func clearComponentFault(component, address string) error {
+	// Create the clear request
+	requestBody := map[string]interface{}{
+		"component_clear": map[string]string{
+			"component": component,
+		},
+	}
+
+	// Marshal to JSON
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Make the POST request to the inject-fault endpoint with clear action
+	url := fmt.Sprintf("%s/inject-fault", address)
+	fmt.Printf("Clearing fault from %s component at %s...\n", component, url)
+
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to make request to %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned error status %d", resp.StatusCode)
+	}
+
+	fmt.Printf("Successfully cleared fault from %s component\n", component)
+	return nil
+}

--- a/cmd/gpuhealth/root.go
+++ b/cmd/gpuhealth/root.go
@@ -205,6 +205,34 @@ func App() *cli.App {
 				},
 			},
 		},
+		{
+			Name:   "inject",
+			Usage:  "inject faults into components for testing",
+			Action: injectCommand,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "component,c",
+					Usage:    "component name to inject fault into (required)",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:  "fault-type",
+					Usage: "fault type to inject into the component (component-error or event or kernel-message)",
+				},
+				&cli.StringFlag{
+					Name:  "fault-message",
+					Usage: "message to inject into the component",
+				},
+				&cli.StringFlag{
+					Name:  "event-type",
+					Usage: "type of the event to inject into the component",
+				},
+				&cli.BoolFlag{
+					Name:  "clear",
+					Usage: "clear injected faults from the component instead of injecting new ones",
+				},
+			},
+		},
 	}
 
 	return app

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/NVIDIA/gpuhealth
 
 go 1.24.5
 
-replace github.com/leptonai/gpud => gitlab-master.nvidia.com/gpu-health/gpud v0.7.2-0.20250915230151-5b4feb00682d
+replace github.com/leptonai/gpud => gitlab-master.nvidia.com/gpu-health/gpud v0.7.2-0.20250916202408-21570d70aed8
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/NVIDIA/gpuhealth
 
 go 1.24.5
 
-replace github.com/leptonai/gpud => gitlab-master.nvidia.com/gpu-health/gpud v0.7.1
+replace github.com/leptonai/gpud => gitlab-master.nvidia.com/gpu-health/gpud v0.7.2-0.20250915230151-5b4feb00682d
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-gitlab-master.nvidia.com/gpu-health/gpud v0.7.1 h1:/vJN0e/ch7Mh0IGpbLgcM2pcbYJRotBQkqgkCNgb1eU=
-gitlab-master.nvidia.com/gpu-health/gpud v0.7.1/go.mod h1:LHGMXC+wDiDH+xynx/VFE4K53JhRGtOyu1M+lohCAxo=
+gitlab-master.nvidia.com/gpu-health/gpud v0.7.2-0.20250915230151-5b4feb00682d h1:212z6OSOi7/FUDHjX3xbbkvoPksvkWfDiOqpeMUcb/g=
+gitlab-master.nvidia.com/gpu-health/gpud v0.7.2-0.20250915230151-5b4feb00682d/go.mod h1:LHGMXC+wDiDH+xynx/VFE4K53JhRGtOyu1M+lohCAxo=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 h1:4K4tsIXefpVJtvA/8srF4V4y0akAoPHkIslgAkjixJA=

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-gitlab-master.nvidia.com/gpu-health/gpud v0.7.2-0.20250915230151-5b4feb00682d h1:212z6OSOi7/FUDHjX3xbbkvoPksvkWfDiOqpeMUcb/g=
-gitlab-master.nvidia.com/gpu-health/gpud v0.7.2-0.20250915230151-5b4feb00682d/go.mod h1:LHGMXC+wDiDH+xynx/VFE4K53JhRGtOyu1M+lohCAxo=
+gitlab-master.nvidia.com/gpu-health/gpud v0.7.2-0.20250916202408-21570d70aed8 h1:Xf2csozsgbfWMUamFDhZbopZmmpU+SG03v0luFpiGZw=
+gitlab-master.nvidia.com/gpu-health/gpud v0.7.2-0.20250916202408-21570d70aed8/go.mod h1:LHGMXC+wDiDH+xynx/VFE4K53JhRGtOyu1M+lohCAxo=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 h1:4K4tsIXefpVJtvA/8srF4V4y0akAoPHkIslgAkjixJA=

--- a/internal/server/handlers_inject_fault.go
+++ b/internal/server/handlers_inject_fault.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/leptonai/gpud/pkg/errdefs"
+	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
+)
+
+const URLPathInjectFault = "/inject-fault"
+
+// injectFault godoc
+// @Summary Inject fault into the system
+// @Description Injects a fault (such as kernel messages) into the system for testing purposes
+// @ID injectFault
+// @Tags fault-injection
+// @Accept json
+// @Produce json
+// @Param request body pkgfaultinjector.Request true "Fault injection request"
+// @Success 200 {object} map[string]string "Fault injected successfully"
+// @Failure 400 {object} map[string]interface{} "Bad request - invalid request body or validation error"
+// @Failure 404 {object} map[string]interface{} "Fault injector not set up"
+// @Failure 500 {object} map[string]interface{} "Internal server error"
+// @Router /inject-fault [post]
+func (s *Server) injectFault(c *gin.Context) {
+	if s.faultInjector == nil {
+		c.JSON(http.StatusNotFound, gin.H{"code": errdefs.ErrNotFound, "message": "fault injector not set up"})
+		return
+	}
+
+	// read the request body
+	request := new(pkgfaultinjector.Request)
+	if err := json.NewDecoder(c.Request.Body).Decode(request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "failed to decode request body: " + err.Error()})
+		return
+	}
+	if err := request.Validate(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "invalid request: " + err.Error()})
+		return
+	}
+
+	switch {
+	case request.KernelMessage != nil:
+		if err := s.faultInjector.KmsgWriter().Write(request.KernelMessage); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject kernel message: " + err.Error()})
+			return
+		}
+
+	case request.ComponentError != nil:
+		if injector, ok := s.faultInjector.(pkgfaultinjector.ComponentErrorInjector); ok {
+			if err := injector.InjectComponentError(c.Request.Context(), s.componentsRegistry, request.ComponentError); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject component error: " + err.Error()})
+				return
+			}
+		} else {
+			c.JSON(http.StatusNotImplemented, gin.H{"code": errdefs.ErrNotImplemented, "message": "component error injection not supported"})
+			return
+		}
+
+	case request.Event != nil:
+		if injector, ok := s.faultInjector.(pkgfaultinjector.EventInjector); ok {
+			if err := injector.InjectEvent(c.Request.Context(), s.componentsRegistry, request.Event); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject event: " + err.Error()})
+				return
+			}
+		} else {
+			c.JSON(http.StatusNotImplemented, gin.H{"code": errdefs.ErrNotImplemented, "message": "event injection not supported"})
+			return
+		}
+
+	case request.ComponentClear != nil:
+		if injector, ok := s.faultInjector.(pkgfaultinjector.ComponentClearInjector); ok {
+			if err := injector.ClearComponentFault(c.Request.Context(), s.componentsRegistry, request.ComponentClear); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to clear component fault: " + err.Error()})
+				return
+			}
+		} else {
+			c.JSON(http.StatusNotImplemented, gin.H{"code": errdefs.ErrNotImplemented, "message": "component fault clearing not supported"})
+			return
+		}
+
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "one of kernel_message, component_error, component_clear, or event is required"})
+		return
+	}
+
+	successMessage := "fault injected"
+	if request.ComponentClear != nil {
+		successMessage = "component fault cleared"
+	}
+	c.JSON(http.StatusOK, gin.H{"message": successMessage})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,7 +35,9 @@ import (
 	"github.com/leptonai/gpud/components"
 	"github.com/leptonai/gpud/components/all"
 	"github.com/leptonai/gpud/pkg/eventstore"
+	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
 	pkghost "github.com/leptonai/gpud/pkg/host"
+	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
 	"github.com/leptonai/gpud/pkg/log"
 	pkgmetadata "github.com/leptonai/gpud/pkg/metadata"
 	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
@@ -63,6 +65,9 @@ type Server struct {
 
 	// healthExporter is the health exporter instance
 	healthExporter exporter.Exporter
+
+	// faultInjector is the fault injector for testing
+	faultInjector pkgfaultinjector.Injector
 
 	machineID string
 }
@@ -124,6 +129,10 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 
 	s.machineID = machineID
 
+	// Initialize fault injector for testing
+	kmsgWriter := pkgkmsgwriter.NewWriter(pkgkmsgwriter.DefaultDevKmsg)
+	s.faultInjector = pkgfaultinjector.NewInjector(kmsgWriter)
+
 	nvmlInstance, err := nvidianvml.NewWithExitOnSuccessfulLoad(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create NVML instance: %w", err)
@@ -146,16 +155,23 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 		log.Logger.Errorw("failed to record reboot", "error", err)
 	}
 
+	// Determine health check interval from config, with fallback to default
+	healthCheckInterval := time.Minute // default
+	if config.HealthExporter != nil && config.HealthExporter.HealthCheckInterval.Duration > 0 {
+		healthCheckInterval = config.HealthExporter.HealthCheckInterval.Duration
+	}
+
 	s.gpudInstance = &components.GPUdInstance{
-		RootCtx:          ctx,
-		MachineID:        machineID,
-		NVMLInstance:     nvmlInstance,
-		DBRW:             dbRW,
-		DBRO:             dbRO,
-		EventStore:       eventStore,
-		RebootEventStore: rebootEventStore,
-		MountPoints:      []string{"/"},
-		MountTargets:     []string{"/var/lib/kubelet"},
+		RootCtx:             ctx,
+		MachineID:           machineID,
+		NVMLInstance:        nvmlInstance,
+		DBRW:                dbRW,
+		DBRO:                dbRO,
+		EventStore:          eventStore,
+		RebootEventStore:    rebootEventStore,
+		MountPoints:         []string{"/"},
+		MountTargets:        []string{"/var/lib/kubelet"},
+		HealthCheckInterval: healthCheckInterval,
 	}
 
 	// Register only enabled components for health monitoring
@@ -313,6 +329,7 @@ func (s *Server) startServer(ctx context.Context, nvmlInstance nvidianvml.Instan
 	})
 	router.GET("/healthz", s.healthz())
 	router.GET("/machine-info", globalHandler.machineInfo)
+	router.POST(URLPathInjectFault, s.injectFault)
 
 	log.Logger.Infow("gpuhealth started serving with HTTP", "address", s.config.Address)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a gpuhealth CLI “inject” subcommand to simulate faults and clear them, with flags for component, fault type, message, event type, and clear.
  - Enabled server-side fault injection via a new HTTP API, supporting component errors, events, kernel messages, and clearing injected faults with clear error responses.
  - Made health-check interval configurable via settings.
- Chores
  - Updated gpud dependency to a newer snapshot version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->