### PR TITLE
[GPUHEALTH-439] docs: Change the release docs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -154,7 +154,6 @@ release:
   github:
     owner: NVIDIA
     name: gpuhealth
-  name_template: "NVIDIA GPU Health Agent v{{.Version}}"
   header: |
     ## NVIDIA GPU Health Agent v{{.Version}}
     

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### Prerequisites
 
-- Linux (Ubuntu 22.04+, RHEL 8+)
+- Linux (Ubuntu 22.04+, RHEL 9+, Amazon Linux 2023+)
 - Go 1.24+ (for building from source)
 - NVIDIA drivers (recommended)
 - Root/sudo access


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Documentation
  - Updated OS prerequisites: RHEL now 9+ (was 8+), Amazon Linux now 2023+ (was 8+).

- Chores
  - GitHub releases now use default naming, improving consistency across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->