### PR TITLE
[GPUHEALTH-549] fix: Change gpud version to gpuhealth version for health agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,7 @@ RELEASE=gpuhealth-$(VERSION:v%=%)-${GOOS}-${GOARCH}
 
 COMMANDS=gpuhealth
 
-# Discover gpud version from go.mod
-GPUd_VERSION ?= $(shell $(GO) list -m -f '{{.Version}}' github.com/leptonai/gpud 2>/dev/null)
-
-GO_BUILD_FLAGS=-ldflags '-s -X $(PACKAGE)/internal/version.BuildTimestamp=$(BUILD_TIMESTAMP) -X $(PACKAGE)/internal/version.Version=$(VERSION) -X $(PACKAGE)/internal/version.Revision=$(REVISION) -X $(PACKAGE)/internal/version.Package=$(PACKAGE) -X $(PACKAGE)/internal/version.GPUdModuleVersion=$(GPUd_VERSION)'
+GO_BUILD_FLAGS=-ldflags '-s -X $(PACKAGE)/internal/version.BuildTimestamp=$(BUILD_TIMESTAMP) -X $(PACKAGE)/internal/version.Version=$(VERSION) -X $(PACKAGE)/internal/version.Revision=$(REVISION) -X $(PACKAGE)/internal/version.Package=$(PACKAGE)'
 
 ifdef BUILDTAGS
     GO_BUILDTAGS = ${BUILDTAGS}

--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ Register for remote export:
 
 ```bash
 sudo gpuhealth register --endpoint "https://telemetry.company.com/v1" --token "your-token"
-sudo systemctl restart gpuhealthd
 ```
 
 HTTP proxy configuration:

--- a/cmd/gpuhealth/machine_info.go
+++ b/cmd/gpuhealth/machine_info.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/leptonai/gpud/pkg/log"
-	pkgmachineinfo "github.com/leptonai/gpud/pkg/machine-info"
 	pkgmetadata "github.com/leptonai/gpud/pkg/metadata"
 	"github.com/leptonai/gpud/pkg/netutil"
 	nvidianvml "github.com/leptonai/gpud/pkg/nvidia-query/nvml"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/NVIDIA/gpuhealth/internal/cmdutil"
 	"github.com/NVIDIA/gpuhealth/internal/config"
+	"github.com/NVIDIA/gpuhealth/internal/machineinfo"
 )
 
 func machineInfoCommand(cliContext *cli.Context) error {
@@ -70,14 +70,14 @@ func machineInfoCommand(cliContext *cli.Context) error {
 		return err
 	}
 
-	machineInfo, err := pkgmachineinfo.GetMachineInfo(nvmlInstance)
+	machineInfo, err := machineinfo.GetMachineInfo(nvmlInstance)
 	if err != nil {
 		return err
 	}
 	machineInfo.RenderTable(os.Stdout)
 
 	pubIP, _ := netutil.PublicIP()
-	providerInfo := pkgmachineinfo.GetProvider(pubIP)
+	providerInfo := machineinfo.GetProvider(pubIP)
 	if providerInfo == nil {
 		fmt.Printf("%s failed to find provider (%v)\n", cmdutil.WarningSign, err)
 	} else {

--- a/cmd/gpuhealth/root.go
+++ b/cmd/gpuhealth/root.go
@@ -33,12 +33,10 @@ func App() *cli.App {
 	app.Description = "Use this tool to monitor the health of your NVIDIA GPUs and export metrics for analysis"
 
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Printf("%s v%s (gpud %s, go %s, rev %s, built %s)\n",
+		fmt.Printf("%s v%s (go %s, built %s)\n",
 			c.App.Name,
 			version.Version,
-			version.GPUdModuleVersion,
 			version.GoVersion,
-			version.Revision,
 			version.BuildTimestamp,
 		)
 	}

--- a/cmd/gpuhealth/run.go
+++ b/cmd/gpuhealth/run.go
@@ -344,7 +344,7 @@ func runCommand(cliContext *cli.Context) error {
 	signals := make(chan os.Signal, 1)
 	done := make(chan struct{})
 
-	log.Logger.Infof("starting gpuhealth %v (gpud %s, go %s, rev %s, built %s)", version.Version, version.GPUdModuleVersion, version.GoVersion, version.Revision, version.BuildTimestamp)
+	log.Logger.Infof("starting gpuhealth %v", version.Version)
 
 	// Setup signal handling for graceful shutdown
 	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)

--- a/internal/exporter/collector/collector.go
+++ b/internal/exporter/collector/collector.go
@@ -23,16 +23,15 @@ import (
 	"fmt"
 	"time"
 
-	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/components"
 	"github.com/leptonai/gpud/pkg/eventstore"
 	pkghost "github.com/leptonai/gpud/pkg/host"
 	"github.com/leptonai/gpud/pkg/log"
-	machineinfo "github.com/leptonai/gpud/pkg/machine-info"
 	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
 	nvidianvml "github.com/leptonai/gpud/pkg/nvidia-query/nvml"
 
 	"github.com/NVIDIA/gpuhealth/internal/config"
+	"github.com/NVIDIA/gpuhealth/internal/machineinfo"
 )
 
 // GetMachineID gets machine ID from system (no database dependencies)
@@ -57,7 +56,7 @@ type HealthData struct {
 	CollectionID  string
 	MachineID     string
 	Timestamp     time.Time
-	MachineInfo   *apiv1.MachineInfo
+	MachineInfo   *machineinfo.MachineInfo
 	Metrics       pkgmetrics.Metrics
 	Events        eventstore.Events
 	ComponentData map[string]interface{}

--- a/internal/exporter/converter/csv.go
+++ b/internal/exporter/converter/csv.go
@@ -282,7 +282,7 @@ func (c *csvConverter) writeMachineInfoCSV(outputDir, filename string, data *col
 	// Header and basic system info
 	records = append(records,
 		[]string{"attribute_name", "attribute_value"},
-		[]string{"GPU Health Version", i.GPUdVersion},
+		[]string{"GPU Health Version", i.GPUHealthVersion},
 		[]string{"Container Runtime Version", i.ContainerRuntimeVersion},
 		[]string{"OS Image", i.OSImage},
 		[]string{"Kernel Version", i.KernelVersion},

--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -156,8 +156,8 @@ func (c *otlpConverter) convertMetricsToOTLP(data *collector.HealthData) []*metr
 
 	// Add a summary metric with collection info
 	summaryMetric := &metricsv1.Metric{
-		Name:        "gpud_health_agent_collection_info",
-		Description: "Summary information about health data collection",
+		Name:        "gpuhealth_agent_collection_summary",
+		Description: "Summary of GPU health data collection including counts of metrics, events, and components",
 		Unit:        "1",
 		Data: &metricsv1.Metric_Gauge{
 			Gauge: &metricsv1.Gauge{

--- a/internal/exporter/mock_endpoint.go
+++ b/internal/exporter/mock_endpoint.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 	"time"
 
-	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/pkg/eventstore"
 	"github.com/leptonai/gpud/pkg/log"
 	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
@@ -42,6 +41,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/NVIDIA/gpuhealth/internal/exporter/collector"
+	"github.com/NVIDIA/gpuhealth/internal/machineinfo"
 )
 
 // MockEndpoint represents a mock global health endpoint for testing
@@ -488,7 +488,7 @@ func (m *MockEndpoint) parseOTLPLogs(logsData *logsv1.LogsData, healthData *coll
 
 		// Extract machine info from resource attributes using reflection
 		if rl.Resource != nil {
-			healthData.MachineInfo = &apiv1.MachineInfo{}
+			healthData.MachineInfo = &machineinfo.MachineInfo{}
 
 			// Parse machine.id separately since it's not part of MachineInfo struct
 			for _, attr := range rl.Resource.Attributes {
@@ -584,7 +584,7 @@ func (m *MockEndpoint) parseOTLPMetrics(metricsData *metricsv1.MetricsData, heal
 
 		// Extract machine info from resource attributes using reflection
 		if rm.Resource != nil {
-			healthData.MachineInfo = &apiv1.MachineInfo{}
+			healthData.MachineInfo = &machineinfo.MachineInfo{}
 
 			// Parse machine.id separately since it's not part of MachineInfo struct
 			for _, attr := range rm.Resource.Attributes {

--- a/internal/machineinfo/machineinfo.go
+++ b/internal/machineinfo/machineinfo.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package machineinfo provides a shim layer over gpud's machine-info package
+// to customize version information for GPU Health.
+package machineinfo
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/dustin/go-humanize"
+	apiv1 "github.com/leptonai/gpud/api/v1"
+	pkgmachineinfo "github.com/leptonai/gpud/pkg/machine-info"
+	nvidianvml "github.com/leptonai/gpud/pkg/nvidia-query/nvml"
+	"github.com/leptonai/gpud/pkg/providers"
+	"github.com/olekukonko/tablewriter"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/NVIDIA/gpuhealth/internal/version"
+)
+
+// MachineInfo is a custom struct that replaces GPUdVersion with GPUHealthVersion
+type MachineInfo struct {
+	// GPUHealthVersion represents the current version of GPU Health agent
+	GPUHealthVersion string `json:"gpuHealthVersion,omitempty"`
+	// GPUDriverVersion represents the current version of GPU driver installed
+	GPUDriverVersion string `json:"gpuDriverVersion,omitempty"`
+	// CUDAVersion represents the current version of cuda library.
+	CUDAVersion string `json:"cudaVersion,omitempty"`
+	// ContainerRuntime Version reported by the node through runtime remote API (e.g. containerd://1.4.2).
+	ContainerRuntimeVersion string `json:"containerRuntimeVersion,omitempty"`
+	// Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
+	KernelVersion string `json:"kernelVersion,omitempty"`
+	// OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
+	OSImage string `json:"osImage,omitempty"`
+	// The Operating System reported by the node
+	OperatingSystem string `json:"operatingSystem,omitempty"`
+	// SystemUUID comes from https://github.com/google/cadvisor/blob/master/utils/sysfs/sysfs.go#L442
+	SystemUUID string `json:"systemUUID,omitempty"`
+	// MachineID is collected by GPUd. It comes from /etc/machine-id or /var/lib/dbus/machine-id
+	MachineID string `json:"machineID,omitempty"`
+	// BootID is collected by GPUd.
+	BootID string `json:"bootID,omitempty"`
+	// Hostname is the current host of machine
+	Hostname string `json:"hostname,omitempty"`
+	// Uptime represents when the machine up
+	Uptime metav1.Time `json:"uptime,omitempty"`
+
+	// CPUInfo is the CPU info of the machine.
+	CPUInfo *apiv1.MachineCPUInfo `json:"cpuInfo,omitempty"`
+	// MemoryInfo is the memory info of the machine.
+	MemoryInfo *apiv1.MachineMemoryInfo `json:"memoryInfo,omitempty"`
+	// GPUInfo is the GPU info of the machine.
+	GPUInfo *apiv1.MachineGPUInfo `json:"gpuInfo,omitempty"`
+	// DiskInfo is the Disk info of the machine.
+	DiskInfo *apiv1.MachineDiskInfo `json:"diskInfo,omitempty"`
+	// NICInfo is the network info of the machine.
+	NICInfo *apiv1.MachineNICInfo `json:"nicInfo,omitempty"`
+}
+
+// GetMachineInfo retrieves machine info and customizes it for GPU Health
+func GetMachineInfo(nvmlInstance nvidianvml.Instance) (*MachineInfo, error) {
+	// Get the original machine info from gpud
+	gpudInfo, err := pkgmachineinfo.GetMachineInfo(nvmlInstance)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to our custom MachineInfo struct with GPU Health version
+	return &MachineInfo{
+		GPUHealthVersion:        version.Version,
+		GPUDriverVersion:        gpudInfo.GPUDriverVersion,
+		CUDAVersion:             gpudInfo.CUDAVersion,
+		ContainerRuntimeVersion: gpudInfo.ContainerRuntimeVersion,
+		KernelVersion:           gpudInfo.KernelVersion,
+		OSImage:                 gpudInfo.OSImage,
+		OperatingSystem:         gpudInfo.OperatingSystem,
+		SystemUUID:              gpudInfo.SystemUUID,
+		MachineID:               gpudInfo.MachineID,
+		BootID:                  gpudInfo.BootID,
+		Hostname:                gpudInfo.Hostname,
+		Uptime:                  gpudInfo.Uptime,
+		CPUInfo:                 gpudInfo.CPUInfo,
+		MemoryInfo:              gpudInfo.MemoryInfo,
+		GPUInfo:                 gpudInfo.GPUInfo,
+		DiskInfo:                gpudInfo.DiskInfo,
+		NICInfo:                 gpudInfo.NICInfo,
+	}, nil
+}
+
+// RenderTable renders the machine info table with GPU Health branding
+func (i *MachineInfo) RenderTable(wr io.Writer) {
+	if i == nil {
+		return
+	}
+
+	table := tablewriter.NewWriter(wr)
+	table.SetAlignment(tablewriter.ALIGN_CENTER)
+
+	// Show GPU Health Version instead of GPUd Version
+	table.Append([]string{"GPUHealth Version", i.GPUHealthVersion})
+	table.Append([]string{"Container Runtime Version", i.ContainerRuntimeVersion})
+	table.Append([]string{"OS Image", i.OSImage})
+	table.Append([]string{"Kernel Version", i.KernelVersion})
+
+	if i.CPUInfo != nil {
+		table.Append([]string{"CPU Type", i.CPUInfo.Type})
+		table.Append([]string{"CPU Manufacturer", i.CPUInfo.Manufacturer})
+		table.Append([]string{"CPU Architecture", i.CPUInfo.Architecture})
+		table.Append([]string{"CPU Logical Cores", fmt.Sprintf("%d", i.CPUInfo.LogicalCores)})
+	}
+	if i.MemoryInfo != nil {
+		table.Append([]string{"Memory Total", humanize.IBytes(i.MemoryInfo.TotalBytes)})
+	}
+
+	table.Append([]string{"CUDA Version", i.CUDAVersion})
+	if i.GPUInfo != nil {
+		table.Append([]string{"GPU Driver Version", i.GPUDriverVersion})
+		table.Append([]string{"GPU Product", i.GPUInfo.Product})
+		table.Append([]string{"GPU Manufacturer", i.GPUInfo.Manufacturer})
+		table.Append([]string{"GPU Architecture", i.GPUInfo.Architecture})
+		table.Append([]string{"GPU Memory", i.GPUInfo.Memory})
+	}
+
+	if i.NICInfo != nil {
+		for idx, nic := range i.NICInfo.PrivateIPInterfaces {
+			table.Append([]string{fmt.Sprintf("Private IP Interface %d", idx+1), fmt.Sprintf("%s (%s, %s)", nic.Interface, nic.MAC, nic.IP)})
+		}
+	}
+
+	if i.DiskInfo != nil {
+		table.Append([]string{"Container Root Disk", i.DiskInfo.ContainerRootDisk})
+	}
+
+	table.Render()
+	fmt.Fprintf(wr, "\n")
+
+	if i.DiskInfo != nil {
+		i.DiskInfo.RenderTable(wr)
+		fmt.Fprintf(wr, "\n")
+	}
+
+	if i.GPUInfo != nil {
+		i.GPUInfo.RenderTable(wr)
+		fmt.Fprintf(wr, "\n")
+	}
+}
+
+// GetProvider is a passthrough to gpud's GetProvider function
+func GetProvider(publicIP string) *providers.Info {
+	return pkgmachineinfo.GetProvider(publicIP)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -33,7 +33,4 @@ var (
 
 	// GoVersion is Go tree's version.
 	GoVersion = runtime.Version()
-
-	// GPUdModuleVersion is injected at build time via ldflags.
-	GPUdModuleVersion = "unknown"
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - GPU Health-specific machine info with improved table output and a visible "GPU Health Version".
  - CSV export now reports "GPU Health Version".

- Refactor
  - CLI version output and startup logs simplified; extra module-version details removed.

- Chores
  - OTLP metric renamed to gpuhealth_agent_collection_summary with clearer description.
  - Internal machine info representation consolidated; consumers may observe renamed fields.

- Documentation
  - Removed the step to restart the gpuhealthd service after remote export registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->