### PR TITLE
[GPUHEALTH-630] fix: component health check enable/disable fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,3 +137,7 @@ clean: ## clean up binaries and build artifacts
 	@rm -rf dist/
 	@rm -rf coverage/
 	@rm -f /tmp/gofmt.out
+
+package-snapshot: ## package snapshot
+	@echo "Packaging snapshot..."
+	@goreleaser release --snapshot --clean --config .goreleaser.yaml

--- a/deployments/packages/systemd/gpuhealth.env
+++ b/deployments/packages/systemd/gpuhealth.env
@@ -1,5 +1,5 @@
 # GPU Health Agent environment configuration
-GPUHEALTH_FLAGS="--log-level=warn"
+GPUHEALTH_FLAGS="--log-level=warn --components=all,-docker,-kubelet,-tailscale,-containerd,-fuse,-nfs"
 GPUHEALTH_COLLECT_INTERVAL="1m"
 GPUHEALTH_INCLUDE_METRICS="true"
 GPUHEALTH_INCLUDE_EVENTS="true"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,7 +197,7 @@ func (config *Config) ShouldEnable(componentName string) bool {
 // If no disable components are specified, all components are enabled by default.
 func (config *Config) ShouldDisable(componentName string) bool {
 	// Not specified, enable all components (don't disable any)
-	if len(config.Components) == 0 || config.Components[0] == "*" || config.Components[0] == "all" {
+	if len(config.Components) == 0 {
 		return false
 	}
 
@@ -205,16 +205,16 @@ func (config *Config) ShouldDisable(componentName string) bool {
 		config.disabledComponents = make(map[string]any)
 
 		for _, c := range config.Components {
+			// Skip "all" and "*" markers
 			if c == "*" || c == "all" {
-				// Enable all components
-				return false
+				continue
 			}
 
 			// Prefix "-" is used to disable a component
-			if !strings.HasPrefix(c, "-") {
-				continue
+			if strings.HasPrefix(c, "-") {
+				// Store without the "-" prefix for matching
+				config.disabledComponents[strings.TrimPrefix(c, "-")] = struct{}{}
 			}
-			config.disabledComponents[c] = struct{}{}
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -112,8 +112,8 @@ func TestComponentSelection(t *testing.T) {
 			Components: []string{"-disk", "-network"},
 		}
 
-		assert.True(t, cfg.ShouldDisable("-disk"))
-		assert.True(t, cfg.ShouldDisable("-network"))
+		assert.True(t, cfg.ShouldDisable("disk"))
+		assert.True(t, cfg.ShouldDisable("network"))
 		assert.False(t, cfg.ShouldDisable("gpu-memory"))
 		assert.False(t, cfg.ShouldEnable("disk"))
 	})
@@ -136,6 +136,27 @@ func TestComponentSelection(t *testing.T) {
 		assert.True(t, cfg.ShouldEnable("gpu-memory"))
 		assert.True(t, cfg.ShouldEnable("any-component"))
 		assert.False(t, cfg.ShouldDisable("gpu-memory"))
+	})
+
+	t.Run("all with exclusions", func(t *testing.T) {
+		cfg := &Config{
+			Components: []string{"all", "-kubelet", "-docker", "-tailscale"},
+		}
+
+		// Should enable all components
+		assert.True(t, cfg.ShouldEnable("gpu-memory"))
+		assert.True(t, cfg.ShouldEnable("cpu"))
+		assert.True(t, cfg.ShouldEnable("kubelet"))
+		assert.True(t, cfg.ShouldEnable("docker"))
+
+		// Should disable the excluded components
+		assert.True(t, cfg.ShouldDisable("kubelet"))
+		assert.True(t, cfg.ShouldDisable("docker"))
+		assert.True(t, cfg.ShouldDisable("tailscale"))
+
+		// Should not disable non-excluded components
+		assert.False(t, cfg.ShouldDisable("gpu-memory"))
+		assert.False(t, cfg.ShouldDisable("cpu"))
 	})
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded component selection: “all” is now supported with explicit exclusions (e.g., -docker, -kubelet), and wildcards no longer disable everything by default.
  * Updated GPU health configuration to monitor all components by default while excluding specific services, improving coverage and control.

* **Chores**
  * Added a package-snapshot build target to create snapshot releases.

* **Tests**
  * Updated and added tests to validate the new component selection and exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->