### PR TITLE
[GPUHEALTH-758] Simplify extra info field to avoid parsing during ingestion

### DIFF
--- a/internal/exporter/collector/collector.go
+++ b/internal/exporter/collector/collector.go
@@ -259,6 +259,12 @@ func (c *collector) collectComponentData(data *HealthData) error {
 			reason = firstState.Reason
 			timeValue = firstState.Time
 			extraInfo = firstState.ExtraInfo
+
+			if extraInfoMap, ok := extraInfo.(map[string]interface{}); ok {
+				if dataValue, exists := extraInfoMap["data"]; exists {
+					extraInfo = dataValue
+				}
+			}
 		}
 
 		componentData[componentName] = map[string]interface{}{


### PR DESCRIPTION
Modifying the extra_info field from

"extra_info": "map[data:{\"gsp_firmware_modes\":[{\"uuid\":\"GPU-b1631f34-4ee6-b7a8-5afc-00c88d0fcae1\",\"bus_id\":\"0000:01:00.0\",\"enabled\":false,\"supported\":false}]}]",


to

"extra_info": "{\"gsp_firmware_modes\":[{\"uuid\":\"GPU-b1631f34-4ee6-b7a8-5afc-00c88d0fcae1\",\"bus_id\":\"0000:01:00.0\",\"enabled\":false,\"supported\":false}]}"