### PR TITLE
[GPUHEALTH-37] Fix Agent Un-enroll after Enroll

### DIFF
--- a/cmd/gpuhealth/unenroll.go
+++ b/cmd/gpuhealth/unenroll.go
@@ -55,8 +55,8 @@ func unenrollCommand(c *cli.Context) error {
 
 // removeEnrollmentMetadata removes all enrollment-related metadata from the database
 func removeEnrollmentMetadata(ctx context.Context, dbRW *sql.DB) error {
-	// List of metadata keys to clear (set to empty string)
-	keysToClear := []string{
+	// List of metadata keys to delete
+	keysToDelete := []string{
 		pkgmetadata.MetadataKeyToken,
 		"sak_token",
 		"enroll_endpoint",
@@ -65,15 +65,24 @@ func removeEnrollmentMetadata(ctx context.Context, dbRW *sql.DB) error {
 		"nonce_endpoint",
 	}
 
-	// Clear each metadata entry by setting it to empty string
-	for _, key := range keysToClear {
-		if err := pkgmetadata.SetMetadata(ctx, dbRW, key, ""); err != nil {
-			log.Logger.Errorw("Failed to clear metadata key", "key", key, "error", err)
-			return fmt.Errorf("failed to clear metadata key %s: %w", key, err)
-		} else {
-			log.Logger.Infow("Cleared metadata key", "key", key)
-		}
+	// Build batch delete query
+	query := "DELETE FROM gpud_metadata WHERE key IN (?, ?, ?, ?, ?, ?)"
+
+	// Convert string slice to []interface{} for ExecContext
+	args := make([]interface{}, len(keysToDelete))
+	for i, key := range keysToDelete {
+		args[i] = key
 	}
+
+	// Execute batch delete
+	result, err := dbRW.ExecContext(ctx, query, args...)
+	if err != nil {
+		log.Logger.Errorw("Failed to delete enrollment metadata", "error", err)
+		return fmt.Errorf("failed to delete enrollment metadata: %w", err)
+	}
+
+	rowsAffected, _ := result.RowsAffected()
+	log.Logger.Infow("Deleted enrollment metadata", "rows_deleted", rowsAffected)
 
 	return nil
 }

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -143,7 +143,6 @@ func (e *healthExporter) Start() error {
 				if err := e.export(); err != nil {
 					log.Logger.Errorw("Export failed", "error", err)
 				} else {
-					log.Logger.Infow("Successfully exported health data", "timestamp", time.Now().UTC())
 					e.lastExport = time.Now().UTC()
 				}
 			}
@@ -213,6 +212,8 @@ func (e *healthExporter) exportToFile(data *collector.HealthData) error {
 		return fmt.Errorf("unsupported output format: %s", outputFormat)
 	}
 
+	// Log the timestamp of the export on successful export
+	log.Logger.Infow("Successfully exported health data to file", "timestamp", time.Now().UTC())
 	return nil
 }
 
@@ -233,6 +234,9 @@ func (e *healthExporter) exportToHTTP(ctx context.Context, data *collector.Healt
 	if err != nil {
 		return fmt.Errorf("failed to send data: %w", err)
 	}
+
+	// Log the timestamp of the export on successful export - this won't be logged if not enrolled
+	log.Logger.Infow("Successfully exported health data to", "timestamp", time.Now().UTC())
 
 	// If we received a new JWT token, update it in metadata and config
 	if newToken != "" && newToken != e.options.config.AuthToken {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -532,7 +532,7 @@ func TestExportToHTTP(t *testing.T) {
 		}
 
 		err = he.exportToHTTP(ctx, healthData)
-		require.NoError(t, err) // Should not error, just skip
+		require.NoError(t, err) // Should not error, just skip gracefully
 
 		// Cleanup
 		err = exporter.Stop()
@@ -561,7 +561,7 @@ func TestExportToHTTP(t *testing.T) {
 		}
 
 		err = he.exportToHTTP(ctx, healthData)
-		require.NoError(t, err) // Should not error, just skip
+		require.NoError(t, err) // Should not error, just skip gracefully
 
 		// Cleanup
 		err = exporter.Stop()


### PR DESCRIPTION
SetMetadata function does not UPSERT, so it cannot handle updating the database when the keys exist already. 

In addition, when gpuhealth agent is running but not enrolled, we currently still get: 

`{"level":"info","ts":"2025-11-17T20:40:54.911+0100","caller":"exporter/exporter.go:146","msg":"Successfully exported health data","timestamp":"2025-11-17T19:40:54.911Z"}`

Changed this to be a more descriptive message about missing endpoint/auth token. 

Now we have: 

```
mukils@mukil-testing:~/gpuhealth-fix$ sudo ./bin/gpuhealth enroll --endpoint https://data.us-east-1.dev.gpuhealth.nvidia.com --token 
Enrollment succeeded

mukils@mukil-testing:~/gpuhealth-fix$ sudo ./bin/gpuhealth unenroll
{"level":"info","ts":"2025-11-17T20:26:35.881+0100","caller":"gpuhealth/unenroll.go:32","msg":"Starting un-enrollment process"}
{"level":"info","ts":"2025-11-17T20:26:35.884+0100","caller":"gpuhealth/unenroll.go:85","msg":"Deleted enrollment metadata","rows_deleted":6}
{"level":"info","ts":"2025-11-17T20:26:35.884+0100","caller":"gpuhealth/unenroll.go:52","msg":"Successfully un-enrolled from GPU Health backend"}

mukils@mukil-testing:~/gpuhealth-fix$ sudo ./bin/gpuhealth enroll --endpoint https://data.us-east-1.dev.gpuhealth.nvidia.com --token 
Enrollment succeeded

mukils@mukil-testing:~/gpuhealth-fix$ sudo ./bin/gpuhealth unenroll
{"level":"info","ts":"2025-11-17T20:31:10.221+0100","caller":"gpuhealth/unenroll.go:32","msg":"Starting un-enrollment process"}
{"level":"info","ts":"2025-11-17T20:31:10.222+0100","caller":"gpuhealth/unenroll.go:85","msg":"Deleted enrollment metadata","rows_deleted":6}
{"level":"info","ts":"2025-11-17T20:31:10.222+0100","caller":"gpuhealth/unenroll.go:52","msg":"Successfully un-enrolled from GPU Health backend"}

mukils@mukil-testing:~/gpuhealth-fix$ sudo ./bin/gpuhealth enroll --endpoint https://data.us-east-1.dev.gpuhealth.nvidia.com --token 
Enrollment succeeded
```