### PR TITLE
Change log timestamp for failed attestaion

### DIFF
--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -547,7 +547,7 @@ func (c *otlpConverter) convertAttestationToOTLPLogs(data *collector.HealthData)
 	}
 
 	summaryLogRecord := &logsv1.LogRecord{
-		TimeUnixNano:   uint64(attestation.NonceRefreshTimestamp.UnixNano()),
+		TimeUnixNano:   uint64(data.Timestamp.UnixNano()),
 		SeverityNumber: severity,
 		SeverityText:   severityText,
 		Body: &commonv1.AnyValue{
@@ -617,7 +617,7 @@ func (c *otlpConverter) convertAttestationToOTLPLogs(data *collector.HealthData)
 		}
 
 		evidenceLogRecord := &logsv1.LogRecord{
-			TimeUnixNano:   uint64(attestation.NonceRefreshTimestamp.UnixNano()),
+			TimeUnixNano:   uint64(data.Timestamp.UnixNano()),
 			SeverityNumber: logsv1.SeverityNumber_SEVERITY_NUMBER_INFO,
 			SeverityText:   "INFO",
 			Body: &commonv1.AnyValue{


### PR DESCRIPTION
- When there is no GPU or getNonce fails for any reason, the nonce refresh timestamp is not set
- Then, when the corresponding event logs are created, the nonce refresh timestamp was used as the log timestamp, but since it was never set, we get an odd timestamp:

`{"key":"nonce_refresh_timestamp","value":{"stringValue":"0001-01-01T00:00:00Z"}}],"body":{"stringValue":"Attestation Failed: no GPU information available"},"severityNumber":17,"severityText":"ERROR","timeUnixNano":"11651379494838206464"}],"scope":{"name":"gpuhealth-exporter","version":"1.0.0"}}]}],"year":"2025"}`

Thie timeUnixNano corresponds to some time in 1754, because agent is converting 0001-01-01T00:00:00Z to unix nano. 

- Otel uses this as the timestamp, so all event logs will have the exact same 1754 timestamp, and we get duplicate key errors for events table. 