### PR TITLE
[gpuhealth-1197] Restrict access to /inject-fault endpoint and add option to explicit enable it

### DIFF
--- a/cmd/gpuhealth/root.go
+++ b/cmd/gpuhealth/root.go
@@ -136,6 +136,10 @@ func App() *cli.App {
 					Name:  "enable-dcgm-policy",
 					Usage: "enable DCGM policy violation monitoring for non-XID policies (PCIe, DBE, NVLink, Power, Thermal, Page Retirement) -- XID policy is always enabled (default: false)",
 				},
+				&cli.BoolFlag{
+					Name:  "enable-fault-injection",
+					Usage: "enable fault injection endpoint for testing (only accessible from localhost, default: false)",
+				},
 			},
 		},
 		{

--- a/cmd/gpuhealth/run.go
+++ b/cmd/gpuhealth/run.go
@@ -254,11 +254,6 @@ func runCommand(cliContext *cli.Context) error {
 	}
 	log.Logger.Infow("health exporter configuration", "cfg", cfg.HealthExporter)
 
-	// Apply environment variable overrides for feature flags
-	if err := setBoolFromEnv("GPUHEALTH_ENABLE_FAULT_INJECTION", &cfg.EnableFaultInjection, "set fault injection enabled from env", "enable_fault_injection"); err != nil {
-		return err
-	}
-
 	if listenAddress != "" {
 		cfg.Address = listenAddress
 	}

--- a/cmd/gpuhealth/run.go
+++ b/cmd/gpuhealth/run.go
@@ -194,6 +194,7 @@ func runCommand(cliContext *cli.Context) error {
 	gpuCount := cliContext.Int("gpu-count")
 	infinibandExpectedPortStates := cliContext.String("infiniband-expected-port-states")
 	enableDCGMPolicy := cliContext.Bool("enable-dcgm-policy")
+	enableFaultInjection := cliContext.Bool("enable-fault-injection")
 
 	// GPU Health Exporter configuration
 	offlineMode := cliContext.Bool("offline-mode")
@@ -253,6 +254,11 @@ func runCommand(cliContext *cli.Context) error {
 	}
 	log.Logger.Infow("health exporter configuration", "cfg", cfg.HealthExporter)
 
+	// Apply environment variable overrides for feature flags
+	if err := setBoolFromEnv("GPUHEALTH_ENABLE_FAULT_INJECTION", &cfg.EnableFaultInjection, "set fault injection enabled from env", "enable_fault_injection"); err != nil {
+		return err
+	}
+
 	if listenAddress != "" {
 		cfg.Address = listenAddress
 	}
@@ -270,6 +276,18 @@ func runCommand(cliContext *cli.Context) error {
 		log.Logger.Infow("DCGM policy violation monitoring enabled for all policies (PCIe, DBE, NVLink, Power, Thermal, Page Retirement)")
 	} else {
 		log.Logger.Infow("DCGM policy violation monitoring disabled by default (only XID policy will be enabled)")
+	}
+
+	// Only apply CLI flag if true, to avoid overwriting env var setting
+	// (since we can't distinguish between explicit --enable-fault-injection=false and default false)
+	if enableFaultInjection {
+		cfg.EnableFaultInjection = true
+	}
+
+	if cfg.EnableFaultInjection {
+		log.Logger.Infow("fault injection endpoint enabled for testing")
+	} else {
+		log.Logger.Infow("fault injection endpoint disabled")
 	}
 
 	// Configure offline mode if enabled

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,7 @@ GPUHEALTH_RETRY_MAX_ATTEMPTS="3"
 | `GPUHEALTH_EVENTS_LOOKBACK` | How far back to look for events | `1m` |
 | `GPUHEALTH_CHECK_INTERVAL` | Component health check frequency (1s to 24h) | `1m` |
 | `GPUHEALTH_RETRY_MAX_ATTEMPTS` | Max retry attempts for failed exports | `3` |
+| `GPUHEALTH_ENABLE_FAULT_INJECTION` | Enable fault injection endpoint for testing (localhost only) | `false` |
 | `HTTP_PROXY` | HTTP proxy server URL | - |
 | `HTTPS_PROXY` | HTTPS proxy server URL | - |
 
@@ -194,6 +195,48 @@ GPUHEALTH_FLAGS="--log-level=warn --components=accelerator-nvidia-dcgm-thermal,a
 - `kernel-module` - Kernel module status
 - `library` - System library information
 - `pci` - PCI device information
+
+## Fault Injection for Testing
+
+** TESTING ONLY - DO NOT ENABLE IN PRODUCTION**
+
+The fault injection endpoint allows testing error handling and recovery by artificially injecting faults into the system. This is disabled by default for security reasons.
+
+### Enabling Fault Injection
+
+Via command line flag:
+```bash
+gpuhealth run --enable-fault-injection
+```
+
+Via environment variable:
+```bash
+export GPUHEALTH_ENABLE_FAULT_INJECTION=true
+gpuhealth run
+```
+
+Via systemd service (`/etc/default/gpuhealth`):
+```bash
+GPUHEALTH_FLAGS="--log-level=warn --enable-fault-injection"
+```
+
+### Security Notes
+
+- **Localhost only**: The endpoint is only accessible from `127.0.0.1` or `::1` (IPv4/IPv6 loopback)
+- **Not bypassable**: Even if the server binds to `0.0.0.0`, remote requests are rejected
+- **Use in testing environments only**: Never enable in production systems
+
+### Example Usage
+
+Once enabled, you can inject faults via the `gpuhealth inject` command:
+
+```bash
+# Inject a component error
+gpuhealth inject --component nvidia-gpu --fault-type component-error --fault-message "Test error"
+
+# Clear injected faults
+gpuhealth inject --component nvidia-gpu --clear
+```
 
 ## Troubleshooting Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,6 @@ GPUHEALTH_RETRY_MAX_ATTEMPTS="3"
 | `GPUHEALTH_EVENTS_LOOKBACK` | How far back to look for events | `1m` |
 | `GPUHEALTH_CHECK_INTERVAL` | Component health check frequency (1s to 24h) | `1m` |
 | `GPUHEALTH_RETRY_MAX_ATTEMPTS` | Max retry attempts for failed exports | `3` |
-| `GPUHEALTH_ENABLE_FAULT_INJECTION` | Enable fault injection endpoint for testing (localhost only) | `false` |
 | `HTTP_PROXY` | HTTP proxy server URL | - |
 | `HTTPS_PROXY` | HTTPS proxy server URL | - |
 
@@ -207,12 +206,6 @@ The fault injection endpoint allows testing error handling and recovery by artif
 Via command line flag:
 ```bash
 gpuhealth run --enable-fault-injection
-```
-
-Via environment variable:
-```bash
-export GPUHEALTH_ENABLE_FAULT_INJECTION=true
-gpuhealth run
 ```
 
 Via systemd service (`/etc/default/gpuhealth`):

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,11 @@ type Config struct {
 	// PCIe, DBE, and NVLink have false-positive issues with monotonic counter checks.
 	EnableDCGMPolicy bool `json:"enable_dcgm_policy"`
 
+	// EnableFaultInjection enables the /inject-fault endpoint for testing.
+	// This endpoint allows injecting faults (kernel messages, component errors, events) into the system.
+	// SECURITY: Only accessible from localhost (127.0.0.0/8 or ::1). Disabled by default.
+	EnableFaultInjection bool `json:"enable_fault_injection"`
+
 	// Health Exporter Configuration
 	HealthExporter *HealthExporterConfig `json:"health_exporter,omitempty"`
 }

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -58,9 +58,10 @@ func Default(ctx context.Context, opts ...OpOption) (*Config, error) {
 	}
 
 	cfg := &Config{
-		APIVersion:      DefaultAPIVersion,
-		Address:         DefaultListenAddress,
-		RetentionPeriod: DefaultRetentionPeriod,
+		APIVersion:           DefaultAPIVersion,
+		Address:              DefaultListenAddress,
+		RetentionPeriod:      DefaultRetentionPeriod,
+		EnableFaultInjection: false, // Disabled by default for security
 		NvidiaToolOverwrites: nvidiacommon.ToolOverwrites{
 			InfinibandClassRootDir: options.InfinibandClassRootDir,
 		},

--- a/internal/server/handlers_inject_fault.go
+++ b/internal/server/handlers_inject_fault.go
@@ -17,6 +17,7 @@ package server
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -41,8 +42,22 @@ const URLPathInjectFault = "/inject-fault"
 // @Failure 500 {object} map[string]interface{} "Internal server error"
 // @Router /inject-fault [post]
 func (s *Server) injectFault(c *gin.Context) {
+	// Security check: verify request is from localhost
+	remoteHost, _, err := net.SplitHostPort(c.Request.RemoteAddr)
+	if err != nil {
+		c.JSON(http.StatusForbidden, gin.H{"code": errdefs.ErrFailedPrecondition, "message": "access denied"})
+		return
+	}
+
+	ip := net.ParseIP(remoteHost)
+	if ip == nil || !ip.IsLoopback() {
+		c.JSON(http.StatusForbidden, gin.H{"code": errdefs.ErrFailedPrecondition, "message": "access denied"})
+		return
+	}
+
+	// Defense in depth: verify fault injector is enabled
 	if s.faultInjector == nil {
-		c.JSON(http.StatusNotFound, gin.H{"code": errdefs.ErrNotFound, "message": "fault injector not set up"})
+		c.JSON(http.StatusNotFound, gin.H{"code": errdefs.ErrNotFound, "message": "fault injector not enabled"})
 		return
 	}
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -661,26 +661,43 @@ func TestInjectFault(t *testing.T) {
 		name           string
 		faultInjector  pkgfaultinjector.Injector
 		requestBody    interface{}
+		remoteAddr     string // Set to test security check
 		expectedStatus int
 		checkResponse  func(t *testing.T, body []byte)
 	}{
 		{
+			name:           "non_localhost_rejected",
+			faultInjector:  pkgfaultinjector.NewInjector(pkgkmsgwriter.NewWriter("/dev/null")),
+			requestBody:    map[string]interface{}{},
+			remoteAddr:     "192.168.1.100:12345", // Non-localhost address
+			expectedStatus: http.StatusForbidden,
+			checkResponse: func(t *testing.T, body []byte) {
+				var response map[string]interface{}
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				assert.Contains(t, response, "message")
+				assert.Contains(t, response["message"], "access denied")
+			},
+		},
+		{
 			name:           "nil_fault_injector",
 			faultInjector:  nil,
 			requestBody:    map[string]interface{}{},
+			remoteAddr:     "127.0.0.1:54321", // Localhost address
 			expectedStatus: http.StatusNotFound,
 			checkResponse: func(t *testing.T, body []byte) {
 				var response map[string]interface{}
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
 				assert.Contains(t, response, "message")
-				assert.Contains(t, response["message"], "fault injector not set up")
+				assert.Contains(t, response["message"], "fault injector not enabled")
 			},
 		},
 		{
 			name:           "invalid_json",
 			faultInjector:  pkgfaultinjector.NewInjector(pkgkmsgwriter.NewWriter("/dev/null")),
 			requestBody:    "invalid json",
+			remoteAddr:     "127.0.0.1:54321",
 			expectedStatus: http.StatusBadRequest,
 			checkResponse: func(t *testing.T, body []byte) {
 				var response map[string]interface{}
@@ -696,6 +713,7 @@ func TestInjectFault(t *testing.T) {
 			requestBody:   &pkgfaultinjector.Request{
 				// Empty request - should fail validation
 			},
+			remoteAddr:     "127.0.0.1:54321",
 			expectedStatus: http.StatusBadRequest,
 			checkResponse: func(t *testing.T, body []byte) {
 				var response map[string]interface{}
@@ -703,6 +721,20 @@ func TestInjectFault(t *testing.T) {
 				require.NoError(t, err)
 				assert.Contains(t, response, "message")
 				assert.Contains(t, response["message"], "invalid request")
+			},
+		},
+		{
+			name:           "ipv6_localhost",
+			faultInjector:  nil,
+			requestBody:    map[string]interface{}{},
+			remoteAddr:     "[::1]:54321", // IPv6 localhost
+			expectedStatus: http.StatusNotFound,
+			checkResponse: func(t *testing.T, body []byte) {
+				var response map[string]interface{}
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				assert.Contains(t, response, "message")
+				assert.Contains(t, response["message"], "fault injector not enabled")
 			},
 		},
 	}
@@ -727,6 +759,12 @@ func TestInjectFault(t *testing.T) {
 
 			req := httptest.NewRequest("POST", "/inject-fault", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
+
+			// Set RemoteAddr for security check testing
+			if tt.remoteAddr != "" {
+				req.RemoteAddr = tt.remoteAddr
+			}
+
 			w := httptest.NewRecorder()
 
 			router.ServeHTTP(w, req)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -187,9 +187,15 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 	}
 	s.machineID = machineID
 
-	// Initialize fault injector for testing
-	kmsgWriter := pkgkmsgwriter.NewWriter(pkgkmsgwriter.DefaultDevKmsg)
-	s.faultInjector = pkgfaultinjector.NewInjector(kmsgWriter)
+	// Initialize fault injector for testing (only if enabled)
+	if config.EnableFaultInjection {
+		log.Logger.Infow("fault injection enabled for testing")
+		kmsgWriter := pkgkmsgwriter.NewWriter(pkgkmsgwriter.DefaultDevKmsg)
+		s.faultInjector = pkgfaultinjector.NewInjector(kmsgWriter)
+	} else {
+		log.Logger.Infow("fault injection disabled")
+		s.faultInjector = nil
+	}
 
 	nvmlInstance, err := nvidianvml.NewWithExitOnSuccessfulLoad(ctx)
 	if err != nil {
@@ -444,7 +450,14 @@ func (s *Server) startServer(ctx context.Context, nvmlInstance nvidianvml.Instan
 	})
 	router.GET("/healthz", s.healthz())
 	router.GET("/machine-info", globalHandler.machineInfo)
-	router.POST(URLPathInjectFault, s.injectFault)
+
+	// Only register fault injection endpoint if explicitly enabled
+	if s.config.EnableFaultInjection {
+		log.Logger.Infow("registering fault injection endpoint", "path", URLPathInjectFault)
+		router.POST(URLPathInjectFault, s.injectFault)
+	} else {
+		log.Logger.Debugw("fault injection endpoint disabled")
+	}
 
 	log.Logger.Infow("gpuhealth started serving with HTTP", "address", s.config.Address)
 


### PR DESCRIPTION
A security analysis pointed out a possible security risk with a writable endpoint that injects faults (including a kernel message) using the agent's API

This change restrict the endpoint to localhost using `ClientIP()` and add an option to explicit enable this endpoint for testing. The endpoint will be disabled by default and documentation is updated to reflect the change and explain how this endpoint is used 