### PR TITLE
Update Helm repo URL for gpuhealth chart

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -135,7 +135,7 @@ ENROLL_TOKEN_SECRET_NAME='gpuhealth-enroll-token'  # Recommended secret name
 ### Add the Helm repo
 
 ```bash
-helm repo add gpuhealth https://helm.ngc.nvidia.com/nvidian/gpu-health \
+helm repo add gpuhealth https://helm.ngc.nvidia.com/nvidia/charts/gpu-health \
   --username='$oauthtoken' \
   --password="$NGC_API_KEY"
 helm repo update


### PR DESCRIPTION
The original helm chart URI was incorrect. Verified this new URI works