### PR TITLE
exclude third_party/* from sonar coverage check

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.exclusions=**/*_test.go,**/mock_*.go,Dockerfile.citests,third_party/fleet-
 # Test sources
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
-sonar.test.exclusions=**/vendor/**
+sonar.test.exclusions=**/vendor/**,**/third_party/**
 
 # Go specific settings
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Sonar check is failing on the coverage check after vendoring the gpud packages, this excludes this directory from the check for now.