### PR TITLE
Exclude third_party from codecoverage check by sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,5 +20,4 @@ sonar.sourceEncoding=UTF-8
 sonar.go.coverage.reportPaths=coverage/coverage.out
 
 # Coverage exclusions
-sonar.coverage.exclusions=**/cmd/fleetint/**,**/docs/**,**/routes/**,**/testutil/**,**/*_test.go,**/mock_*.go,**/internal/server/**
-
+sonar.coverage.exclusions=**/cmd/fleetint/**,**/docs/**,**/routes/**,**/testutil/**,**/*_test.go,**/mock_*.go,**/internal/server/**,**/third_party/**


### PR DESCRIPTION
Coverage report still not happy with third_party directory, this will remove from that report as well.