### PR TITLE
[GPUHEALTH-1417] fix: use default GPU group for profiling watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ dev/
 
 CLAUDE.md
 AGENTS.md
+
+.worktrees/

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/prof/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/prof/component.go
@@ -119,7 +119,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		maxKeepSamples := int32(3)
 
 		err = dcgm.WatchFieldsWithGroupEx(fieldGroupID,
-			c.dcgmInstance.GetGroupHandle(),
+			dcgm.GroupAllGPUs(),
 			updateFreqMicroseconds, maxKeepAge, maxKeepSamples)
 		if err != nil {
 			log.Logger.Warnw("failed to set up DCGM field watching", "error", err)


### PR DESCRIPTION
## Summary
- switch DCGM profiling field watching from the custom instance group to the default all-GPU group
- keep profiling field-group creation and sampling behavior unchanged
- align behavior with root cause from GPUHEALTH-1417 (profiling unsupported on the separate group)

## Test Plan
- [x] go test ./components/accelerator/nvidia/dcgm/prof (from third_party/fleet-intelligence-sdk)
