### PR TITLE
[GPUHEALTH-1393] fix: switch nvlink telemetry to dcgm counters

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -32,7 +32,6 @@ import (
 	componentsdcgmutilization "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/utilization"
 	componentsinfiniband "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/infiniband"
 	componentsnccl "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/nccl"
-	componentsnvlink "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/nvlink"
 	componentspeermem "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/peermem"
 	componentspersistencemode "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/persistence-mode"
 	componentsprocesses "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/processes"
@@ -66,11 +65,6 @@ func All() []Component {
 		{
 			Name:             componentsnccl.Name,
 			InitFunc:         componentsnccl.New,
-			EnabledByDefault: true,
-		},
-		{
-			Name:             componentsnvlink.Name,
-			InitFunc:         componentsnvlink.New,
 			EnabledByDefault: true,
 		},
 		{

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -97,6 +97,7 @@ func TestComponentNames(t *testing.T) {
 	expectedNames := []string{
 		"accelerator-nvidia-infiniband",
 		"accelerator-nvidia-nccl",
+		"accelerator-nvidia-dcgm-nvlink",
 		"cpu",
 		"disk",
 		"memory",
@@ -139,6 +140,7 @@ func TestRemovedComponentsAbsent(t *testing.T) {
 	removed := []string{
 		"accelerator-nvidia-fabric-manager",
 		"accelerator-nvidia-gpu-counts",
+		"accelerator-nvidia-nvlink",
 		"accelerator-nvidia-dcgm-xid",
 		"kernel-module",
 		"network-latency",

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
@@ -311,14 +311,56 @@ func (c *component) Check() components.CheckResult {
 			for _, fieldValue := range deviceData.Values {
 				// Use valid value
 				switch fieldValue.FieldID {
-			case dcgm.DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL:
-				bandwidthValue := fieldValue.Int64()
-				metricDCGMFIDevNvlinkBandwidthTotal.With(prometheus.Labels{
-					"uuid":      deviceData.UUID,
-					"gpu": fmt.Sprintf("%d", deviceData.DeviceID),
-				}).Set(float64(bandwidthValue))
+				case dcgm.DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL:
+					bandwidthValue := fieldValue.Int64()
+					metricDCGMFIDevNvlinkBandwidthTotal.With(prometheus.Labels{
+						"uuid": deviceData.UUID,
+						"gpu":  fmt.Sprintf("%d", deviceData.DeviceID),
+					}).Set(float64(bandwidthValue))
 					log.Logger.Debugw("recorded NVLink bandwidth total metric",
 						"deviceID", deviceData.DeviceID, "uuid", deviceData.UUID, "value", bandwidthValue)
+
+				case dcgm.DCGM_FI_DEV_NVLINK_ERROR_DL_CRC:
+					crcValue := fieldValue.Int64()
+					metricDCGMFIDevNvlinkErrorDLCrc.With(prometheus.Labels{
+						"uuid": deviceData.UUID,
+						"gpu":  fmt.Sprintf("%d", deviceData.DeviceID),
+					}).Set(float64(crcValue))
+
+				case dcgm.DCGM_FI_DEV_NVLINK_ERROR_DL_RECOVERY:
+					recoveryValue := fieldValue.Int64()
+					metricDCGMFIDevNvlinkErrorDLRecovery.With(prometheus.Labels{
+						"uuid": deviceData.UUID,
+						"gpu":  fmt.Sprintf("%d", deviceData.DeviceID),
+					}).Set(float64(recoveryValue))
+
+				case dcgm.DCGM_FI_DEV_NVLINK_ERROR_DL_REPLAY:
+					replayValue := fieldValue.Int64()
+					metricDCGMFIDevNvlinkErrorDLReplay.With(prometheus.Labels{
+						"uuid": deviceData.UUID,
+						"gpu":  fmt.Sprintf("%d", deviceData.DeviceID),
+					}).Set(float64(replayValue))
+
+				case dcgm.DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS:
+					recoverySuccessfulValue := fieldValue.Int64()
+					metricDCGMFIDevNvlinkCountLinkRecoverySuccessfulEvents.With(prometheus.Labels{
+						"uuid": deviceData.UUID,
+						"gpu":  fmt.Sprintf("%d", deviceData.DeviceID),
+					}).Set(float64(recoverySuccessfulValue))
+
+				case dcgm.DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS:
+					recoveryFailedValue := fieldValue.Int64()
+					metricDCGMFIDevNvlinkCountLinkRecoveryFailedEvents.With(prometheus.Labels{
+						"uuid": deviceData.UUID,
+						"gpu":  fmt.Sprintf("%d", deviceData.DeviceID),
+					}).Set(float64(recoveryFailedValue))
+
+				case dcgm.DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS:
+					recoveryEventsValue := fieldValue.Int64()
+					metricDCGMFIDevNvlinkCountLinkRecoveryEvents.With(prometheus.Labels{
+						"uuid": deviceData.UUID,
+						"gpu":  fmt.Sprintf("%d", deviceData.DeviceID),
+					}).Set(float64(recoveryEventsValue))
 				}
 			}
 		}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component_test.go
@@ -129,7 +129,13 @@ func TestCheck(t *testing.T) {
 
 	// Look for our NVLink metrics
 	nvlinkMetricsFound := map[string]int{
-		"dcgm_fi_dev_nvlink_bandwidth_total": 0,
+		"dcgm_fi_dev_nvlink_bandwidth_total":                       0,
+		"dcgm_fi_dev_nvlink_error_dl_crc":                          0,
+		"dcgm_fi_dev_nvlink_error_dl_recovery":                     0,
+		"dcgm_fi_dev_nvlink_error_dl_replay":                       0,
+		"dcgm_fi_dev_nvlink_count_link_recovery_successful_events": 0,
+		"dcgm_fi_dev_nvlink_count_link_recovery_failed_events":     0,
+		"dcgm_fi_dev_nvlink_count_link_recovery_events":            0,
 	}
 
 	for _, metric := range metrics {
@@ -147,7 +153,7 @@ func TestCheck(t *testing.T) {
 	// Verify we found metrics for all expected fields
 	for metricName, count := range nvlinkMetricsFound {
 		if count == 0 {
-			t.Logf("  [WARN] Metric %s was not found in Prometheus registry", metricName)
+			t.Logf("  [WARN] Metric %s was not found in Prometheus registry (possibly unsupported on this platform)", metricName)
 		} else {
 			t.Logf("Found %d instance(s) of metric %s", count, metricName)
 		}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/metrics.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/metrics.go
@@ -10,7 +10,13 @@ import (
 
 // nvlinkFields defines the DCGM fields to monitor for NVLink metrics
 var nvlinkFields = []dcgm.Short{
-	dcgm.DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL, // Total NVLink bandwidth
+	dcgm.DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,                       // Total NVLink bandwidth
+	dcgm.DCGM_FI_DEV_NVLINK_ERROR_DL_CRC,                          // NVLink DL CRC errors
+	dcgm.DCGM_FI_DEV_NVLINK_ERROR_DL_RECOVERY,                     // NVLink DL recovery errors
+	dcgm.DCGM_FI_DEV_NVLINK_ERROR_DL_REPLAY,                       // NVLink DL replay errors
+	dcgm.DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS, // Successful link recovery events
+	dcgm.DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS,     // Failed link recovery events
+	dcgm.DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS,            // Total link recovery events
 }
 
 var (
@@ -27,10 +33,76 @@ var (
 		},
 		[]string{pkgmetrics.MetricComponentLabelKey, "uuid", "gpu"},
 	).MustCurryWith(componentLabel)
+
+	metricDCGMFIDevNvlinkErrorDLCrc = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: "",
+			Name:      "dcgm_fi_dev_nvlink_error_dl_crc",
+			Help:      "NVLink CRC Error Counter",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey, "uuid", "gpu"},
+	).MustCurryWith(componentLabel)
+
+	metricDCGMFIDevNvlinkErrorDLRecovery = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: "",
+			Name:      "dcgm_fi_dev_nvlink_error_dl_recovery",
+			Help:      "NVLink Recovery Error Counter",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey, "uuid", "gpu"},
+	).MustCurryWith(componentLabel)
+
+	metricDCGMFIDevNvlinkErrorDLReplay = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: "",
+			Name:      "dcgm_fi_dev_nvlink_error_dl_replay",
+			Help:      "NVLink Replay Error Counter",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey, "uuid", "gpu"},
+	).MustCurryWith(componentLabel)
+
+	metricDCGMFIDevNvlinkCountLinkRecoverySuccessfulEvents = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: "",
+			Name:      "dcgm_fi_dev_nvlink_count_link_recovery_successful_events",
+			Help:      "Number of times link went from Up to recovery, succeeded and link came back up.",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey, "uuid", "gpu"},
+	).MustCurryWith(componentLabel)
+
+	metricDCGMFIDevNvlinkCountLinkRecoveryFailedEvents = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: "",
+			Name:      "dcgm_fi_dev_nvlink_count_link_recovery_failed_events",
+			Help:      "Number of times link went from Up to recovery, failed and link was declared down.",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey, "uuid", "gpu"},
+	).MustCurryWith(componentLabel)
+
+	metricDCGMFIDevNvlinkCountLinkRecoveryEvents = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: "",
+			Name:      "dcgm_fi_dev_nvlink_count_link_recovery_events",
+			Help:      "Number of times link went from Up to recovery, irrespective of the result.",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey, "uuid", "gpu"},
+	).MustCurryWith(componentLabel)
 )
 
 func init() {
 	pkgmetrics.MustRegister(
 		metricDCGMFIDevNvlinkBandwidthTotal,
+		metricDCGMFIDevNvlinkErrorDLCrc,
+		metricDCGMFIDevNvlinkErrorDLRecovery,
+		metricDCGMFIDevNvlinkErrorDLReplay,
+		metricDCGMFIDevNvlinkCountLinkRecoverySuccessfulEvents,
+		metricDCGMFIDevNvlinkCountLinkRecoveryFailedEvents,
+		metricDCGMFIDevNvlinkCountLinkRecoveryEvents,
 	)
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/metrics_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/metrics_test.go
@@ -1,0 +1,30 @@
+package nvlink
+
+import (
+	"testing"
+
+	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+)
+
+func TestNVLinkFieldsIncludeExpectedCounters(t *testing.T) {
+	fieldSet := make(map[dcgm.Short]struct{}, len(nvlinkFields))
+	for _, field := range nvlinkFields {
+		fieldSet[field] = struct{}{}
+	}
+
+	required := []dcgm.Short{
+		dcgm.DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,
+		dcgm.DCGM_FI_DEV_NVLINK_ERROR_DL_CRC,
+		dcgm.DCGM_FI_DEV_NVLINK_ERROR_DL_RECOVERY,
+		dcgm.DCGM_FI_DEV_NVLINK_ERROR_DL_REPLAY,
+		dcgm.DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS,
+		dcgm.DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS,
+		dcgm.DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS,
+	}
+
+	for _, field := range required {
+		if _, ok := fieldSet[field]; !ok {
+			t.Errorf("missing expected nvlink field: %d", field)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- remove raw NVML NVLink component registration from fleetint registry
- keep NVLink telemetry in DCGM NVLink component and add recovery-event counters (1211/1212/1213)
- add DCGM NVLink DL error counters (497/498/499) and export them as Prometheus metrics
- add deterministic field-list unit test and update existing NVLink scrape test expectations

## Validation
- go test ./internal/registry -count=1
- go test ./components/accelerator/nvidia/dcgm/nvlink -count=1

## Jira
- GPUHEALTH-1393