### PR TITLE
chore: remove stale gitlab ssh and gowork config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ on:
 env:
   GO_VERSION: '1.24.13'
   GOFLAGS: '-trimpath'
-  GOPRIVATE: gitlab-master.nvidia.com/*
-  GONOPROXY: gitlab-master.nvidia.com/*
-  GONOSUMDB: gitlab-master.nvidia.com/*
-  GOWORK: off
 
 jobs:
   secret-detection:
@@ -67,10 +63,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Configure Git for private repositories
-        run: |
-          git config --global url."https://git:${{ secrets.GITLAB_TOKEN }}@gitlab-master.nvidia.com/".insteadOf "https://gitlab-master.nvidia.com/"
-
       - name: Download dependencies
         run: go mod download
 
@@ -81,8 +73,6 @@ jobs:
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
-        env:
-          GOWORK: off
         with:
           version: latest
           args: --timeout=5m
@@ -101,10 +91,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Configure Git for private repositories
-        run: |
-          git config --global url."https://git:${{ secrets.GITLAB_TOKEN }}@gitlab-master.nvidia.com/".insteadOf "https://gitlab-master.nvidia.com/"
 
       - name: Download dependencies
         run: go mod download
@@ -140,10 +126,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Configure Git for private repositories
-        run: |
-          git config --global url."https://git:${{ secrets.GITLAB_TOKEN }}@gitlab-master.nvidia.com/".insteadOf "https://gitlab-master.nvidia.com/"
 
       - name: Download dependencies
         run: go mod download
@@ -192,10 +174,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Configure Git for private repositories
-        run: |
-          git config --global url."https://git:${{ secrets.GITLAB_TOKEN }}@gitlab-master.nvidia.com/".insteadOf "https://gitlab-master.nvidia.com/"
-
       - name: Download dependencies
         run: go mod download
 
@@ -230,10 +208,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Configure Git for private repositories
-        run: |
-          git config --global url."https://git:${{ secrets.GITLAB_TOKEN }}@gitlab-master.nvidia.com/".insteadOf "https://gitlab-master.nvidia.com/"
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   GO_VERSION: '1.24.13'
-  GOWORK: off
 
 permissions:
   contents: write  # Needed for creating GitHub releases
@@ -139,7 +138,6 @@ jobs:
           tags: |
             ${{ steps.agent_image.outputs.tags }}
             ${{ steps.agent_image_ghcr.outputs.tags }}
-          ssh: default
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
             REVISION=${{ steps.version.outputs.commit }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,25 +6,10 @@
 #   goreleaser release --snapshot --clean    # Create packages without releasing
 #   goreleaser release --clean               # Full release (requires git tag)
 #
-# Prerequisites for private GitLab dependencies:
-#   - SSH key configured for gitlab-master.nvidia.com:12051
-#   - Access to gpu-health/gpud repository
-#
 # Prerequisites for ARM64 cross-compilation:
 #   - sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
 version: 2
-
-# Global environment variables for private GitLab access
-env:
-  - GOPRIVATE=gitlab-master.nvidia.com/*
-  - GONOPROXY=gitlab-master.nvidia.com/*
-  - GONOSUMDB=gitlab-master.nvidia.com/*
-
-# Git configuration for private repository access
-before:
-  hooks:
-    - git config --global url."ssh://git@gitlab-master.nvidia.com:12051/".insteadOf "https://gitlab-master.nvidia.com/"
 
 # Build configuration
 builds:
@@ -75,10 +60,9 @@ nfpms:
     file_name_template: "fleetint_{{ .Version }}_{{ if eq .Arch \"amd64\" }}amd64{{ else if eq .Arch \"arm64\" }}arm64{{ else }}{{ .Arch }}{{ end }}"
     vendor: NVIDIA Corporation
     homepage: https://github.com/NVIDIA/fleet-intelligence-agent
-    maintainer: NVIDIA GPU Health Team
+    maintainer: NVIDIA Fleet Intelligence Team
     description: |
-      NVIDIA Fleet Intelligence Agent - Lightweight GPU health monitoring and reporting agent
-      for NVIDIA GPU infrastructure.
+      NVIDIA Fleet Intelligence Agent - Host agent for GPU telemetry collection and attestation.
     section: utils
     priority: optional
     formats:
@@ -116,10 +100,9 @@ nfpms:
     file_name_template: "fleetint-{{ .Version }}-1.{{ if eq .Arch \"amd64\" }}x86_64{{ else if eq .Arch \"arm64\" }}aarch64{{ else }}{{ .Arch }}{{ end }}"
     vendor: NVIDIA Corporation
     homepage: https://github.com/NVIDIA/fleet-intelligence-agent
-    maintainer: NVIDIA GPU Health Team
+    maintainer: NVIDIA Fleet Intelligence Team
     description: |
-      NVIDIA Fleet Intelligence Agent - Lightweight GPU health monitoring and reporting agent
-      for NVIDIA GPU infrastructure.
+      NVIDIA Fleet Intelligence Agent - Host agent for GPU telemetry collection and attestation.
     section: Applications/System
     formats:
       - rpm
@@ -169,7 +152,7 @@ release:
   header: |
     ## NVIDIA Fleet Intelligence Agent v{{.Version}}
     
-    This release includes GPU health monitoring and reporting capabilities for NVIDIA GPU infrastructure.
+    This release includes a host agent for GPU telemetry collection and attestation.
     
     ### Available Packages
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-# This repo depends on a private module on gitlab-master.nvidia.com (see go.mod replace),
-# so you must provide credentials at build time via SSH agent forwarding:
-#     eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_ed25519
-#     DOCKER_BUILDKIT=1 docker build --ssh default -t fleet-intelligence-agent:dev .
 ARG DCGM_VERSION="4.4.2-1-ubuntu22.04"
 
 FROM golang:1.24.13 AS build
@@ -9,27 +5,16 @@ FROM golang:1.24.13 AS build
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
-    openssh-client \
     build-essential \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
 
-RUN git config --global url."ssh://git@gitlab-master.nvidia.com:12051/".insteadOf "https://gitlab-master.nvidia.com/"
-RUN mkdir -p /root/.ssh && ssh-keyscan -p 12051 gitlab-master.nvidia.com >> /root/.ssh/known_hosts
-
-ARG GOPRIVATE=gitlab-master.nvidia.com
-ENV GOPRIVATE=${GOPRIVATE}
-ENV GONOSUMDB=${GOPRIVATE}
-# Ignore local go.work during container builds (no ../gpud in context)
-ENV GOWORK=off
-
 COPY go.mod go.sum ./
 # Local replace target must exist before go mod download (replace => ./third_party/fleet-intelligence-sdk).
 COPY third_party/fleet-intelligence-sdk ./third_party/fleet-intelligence-sdk
 
-# Download modules with ephemeral credentials (not persisted in image layers).
-RUN --mount=type=ssh /bin/sh -ceu 'go mod download'
+RUN go mod download
 
 COPY . .
 

--- a/Dockerfile.citests
+++ b/Dockerfile.citests
@@ -52,7 +52,6 @@ RUN go install golang.org/x/vuln/cmd/govulncheck@latest && mv /go/bin/govulnchec
 
 WORKDIR /src
 
-ENV GOWORK=off
 ENV CGO_ENABLED=1
 ENV GOFLAGS=-trimpath
 

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,6 @@ DOCKER ?= docker
 IMAGE ?= fleet-intelligence-agent:dev
 DOCKER_BUILDKIT ?= 1
 DOCKER_BUILD_PROGRESS ?= auto
-# By default, use ssh-agent forwarding for private module access during `docker build`.
-# Set DOCKER_SSH= to disable (e.g. when using --secret/netrc in CI).
-DOCKER_SSH ?= default
 DOCKER_BUILD_EXTRA_FLAGS ?=
 
 # Root directory of the project (absolute path).
@@ -104,22 +101,20 @@ bin/%: cmd/% FORCE
 binaries: $(BINARIES) ## build binaries
 	@echo "Built binaries: $(BINARIES)"
 
-# Build container image (requires BuildKit for --ssh/--secret mounts used in Dockerfile)
+# Build container image (BuildKit enabled by default)
 docker-build: ## build container image (IMAGE=fleet-intelligence-agent:dev)
 	@echo "Building container image: $(IMAGE)"
 	@DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) $(DOCKER) build \
-		$(if $(DOCKER_SSH),--ssh $(DOCKER_SSH),) \
 		--progress=$(DOCKER_BUILD_PROGRESS) \
 		-t $(IMAGE) \
 		$(DOCKER_BUILD_EXTRA_FLAGS) \
 		.
 
-# Build test image and run tests in container (requires SSH for private modules)
+# Build test image and run tests in container
 TEST_IMAGE ?= fleet-intelligence-agent:test
 docker-test: ## build test image and run tests in container
 	@echo "Building test image: $(TEST_IMAGE)"
 	@DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) $(DOCKER) build -f Dockerfile.citests \
-		$(if $(DOCKER_SSH),--ssh $(DOCKER_SSH),) \
 		-t $(TEST_IMAGE) \
 		.
 	@echo "Running tests..."
@@ -132,7 +127,7 @@ fleetint: bin/fleetint ## build fleetint binary
 lint: ## run linting tools
 	@echo "Running linting..."
 	@if command -v $(GOLANGCI_LINT) >/dev/null 2>&1; then \
-		GOWORK=off $(GOLANGCI_LINT) run ./...; \
+		$(GOLANGCI_LINT) run ./...; \
 	else \
 		echo "golangci-lint not found, running basic checks..."; \
 		$(GOFMT) -l -s . | tee /tmp/gofmt.out; \
@@ -140,7 +135,7 @@ lint: ## run linting tools
 			echo "Code formatting issues found. Run 'make fmt' to fix."; \
 			exit 1; \
 		fi; \
-		GOWORK=off go vet ./...; \
+		go vet ./...; \
 	fi
 
 fmt: ## format Go code

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # NVIDIA Fleet Intelligence Agent
 
-Lightweight Fleet Intelligence monitoring and reporting agent for NVIDIA GPU infrastructure building on top of [leptonai/gpud](https://github.com/leptonai/gpud)
+NVIDIA Fleet Intelligence Agent - Host agent for GPU telemetry collection and attestation.
+
+Built on top of [leptonai/gpud](https://github.com/leptonai/gpud)
 
 ## Overview
 

--- a/deployments/helm/fleet-intelligence-agent/Chart.yaml
+++ b/deployments/helm/fleet-intelligence-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fleet-intelligence-agent
-description: GPU health agent daemonset
+description: Fleet Intelligence Agent daemonset
 type: application
 version: 0.0.1
 appVersion: "0.0.1"

--- a/deployments/packages/scripts/preinst
+++ b/deployments/packages/scripts/preinst
@@ -3,16 +3,16 @@ set -e
 
 case "$1" in
     install|1)
-        echo "Preparing to install GPU Health Agent..."
+        echo "Preparing to install Fleet Intelligence Agent..."
         # Warn if systemd not available
         if [ ! -d /run/systemd/system ]; then
             echo "[WARNING] Systemd not detected - service management will be limited"
         fi
         ;;
     upgrade|2)
-        echo "Preparing to upgrade GPU Health Agent${2:+ from version $2}..."
+        echo "Preparing to upgrade Fleet Intelligence Agent${2:+ from version $2}..."
         ;;
     abort-upgrade)
-        echo "Aborting GPU Health Agent upgrade..."
+        echo "Aborting Fleet Intelligence Agent upgrade..."
         ;;
 esac

--- a/deployments/packages/systemd/fleetint.env
+++ b/deployments/packages/systemd/fleetint.env
@@ -1,4 +1,4 @@
-# GPU Health Agent environment configuration
+# Fleet Intelligence Agent environment configuration
 FLEETINT_FLAGS="--log-level=warn"
 FLEETINT_COLLECT_INTERVAL="1m"
 FLEETINT_INCLUDE_METRICS="true"

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,14 +15,6 @@ cd fleetint
 - **GoReleaser**: For building packages (install from [goreleaser.com](https://goreleaser.com/install/))
 - **For ARM64 cross-compilation** (optional): `gcc-aarch64-linux-gnu` and `g++-aarch64-linux-gnu`
 
-### Configure Go Environment
-
-For NVIDIA internal development, configure Go for private repository access:
-
-```bash
-go env -w GOPRIVATE=gitlab-master.nvidia.com/*
-```
-
 ### Build
 
 ```bash
@@ -200,4 +192,3 @@ make package-snapshot  # Build packages (no git tag required)
 ## Contributing
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed contribution guidelines.
-


### PR DESCRIPTION
## Summary
- remove stale GitLab/SSH configuration from Dockerfiles and CI/release workflows
- remove stale GOWORK settings from Dockerfiles, workflows, and Makefile
- simplify Makefile docker targets by removing SSH forwarding hooks

## Test Plan
- [x] make test
