### PR TITLE
[GPUHEALTH-1491] docs: update install prerequisites and supported GPU platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ Built on top of [leptonai/gpud](https://github.com/leptonai/gpud)
 
 ## Overview
 
-**Prerequisites:**
-- NVIDIA DCGM (Data Center GPU Manager) - automatically installed from NVIDIA CUDA repositories
-- See [DEB Installation](docs/install-deb.md) or [RPM Installation](docs/install-rpm.md) for CUDA repository setup instructions
+For installation prerequisites and setup details, see:
+[Helm Installation](docs/install-helm.md), [DEB Installation](docs/install-deb.md), and [RPM Installation](docs/install-rpm.md).
 
 **What It Monitors:**
 - GPU Metrics: Power, temperature, clocks, utilization, memory, Xid events
@@ -27,13 +26,13 @@ Built on top of [leptonai/gpud](https://github.com/leptonai/gpud)
 
 ## Supported Platforms
 
-| OS Family | Supported Versions | Architecture |
-|-----------|--------------------|--------------|
-| Ubuntu | 22.04, 24.04 | x86_64, ARM64 |
-| RHEL | 8, 9, 10 | x86_64, ARM64 |
-| Rocky Linux | 8, 9, 10 | x86_64, ARM64 |
-| AlmaLinux | 8, 9, 10 | x86_64, ARM64 |
-| Amazon Linux | 2023 | x86_64, ARM64 |
+| OS Family | Supported Versions | Architecture | GPU |
+|-----------|--------------------|--------------|-----|
+| Ubuntu | 22.04, 24.04 | x86_64, ARM64 | Hopper, Blackwell, Rubin |
+| RHEL | 8, 9, 10 | x86_64, ARM64 | Hopper, Blackwell, Rubin |
+| Rocky Linux | 8, 9, 10 | x86_64, ARM64 | Hopper, Blackwell, Rubin |
+| AlmaLinux | 8, 9, 10 | x86_64, ARM64 | Hopper, Blackwell, Rubin |
+| Amazon Linux | 2023 | x86_64, ARM64 | Hopper, Blackwell, Rubin |
 
 ## Documentation
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,7 @@
 
 ```bash
 git clone https://github.com/NVIDIA/fleet-intelligence-agent.git
-cd fleetint
+cd fleet-intelligence-agent
 ```
 
 ### Prerequisites
@@ -144,7 +144,7 @@ make fleetint
 ./bin/fleetint scan
 
 # Test with different configurations
-./bin/fleetint run --log-level=debug --port=8080
+./bin/fleetint run --log-level=debug --listen-address=127.0.0.1:8080
 
 # Test offline mode
 ./bin/fleetint run --offline-mode --path=/tmp/test --duration=00:01:00 --format=csv

--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -1,10 +1,29 @@
 # DEB Installation
 
-## Prerequisites: NVIDIA CUDA Repository
+## Prerequisites
 
-The Fleet Intelligence Agent requires NVIDIA DCGM (Data Center GPU Manager) for GPU monitoring. DCGM is available through NVIDIA's CUDA repository and will be automatically installed when you install the Fleet Intelligence Agent package.
+The Fleet Intelligence Agent DEB package has the following runtime dependencies:
 
-Before installing the Fleet Intelligence Agent, add the appropriate NVIDIA CUDA repository for your system:
+- `datacenter-gpu-manager-4-proprietary` (DCGM)
+- `nvattest` (NVIDIA Attestation SDK CLI, NVAT)
+- `corelib` (NVAT GPU evidence source dependency)
+
+Before installing Fleet Intelligence Agent, ensure the following prerequisites are met:
+
+- NVIDIA package repository is configured (network or local CUDA repository) so `datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib` can be installed
+- A supported NVIDIA Datacenter Driver is installed
+- Install/upgrade commands are run as `root` or with `sudo`
+- Attestation for the fleetint use case only supports Blackwell and newer GPUs, and applies to non-CC mode systems
+- For NVSwitch systems (driver branch must match installed datacenter driver):
+  - Hopper (pre-4th gen NVSwitch): install `cuda-drivers-fabricmanager-<driver-branch>`
+  - Blackwell (4th gen NVSwitch): install `nvidia-open-<driver-branch>` and `nvlink5-<driver-branch>`
+
+References:
+- DCGM: <https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#installation>
+- Fabric Manager: <https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#installing-fabric-manager>
+- NVAT (`nvattest`/`corelib`): <https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/overview.html>
+
+Fleet Intelligence Agent package dependencies (`datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib`) are available through NVIDIA's CUDA repository. Before installing Fleet Intelligence Agent, add the appropriate NVIDIA CUDA repository for your system:
 
 ```bash
 # Ubuntu 22.04 (x86_64)
@@ -28,11 +47,11 @@ sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
 ```
 
-After adding the CUDA repository, DCGM (`datacenter-gpu-manager-4-core`) will be automatically installed as a recommended dependency when you install the Fleet Intelligence Agent package.
+After adding the CUDA repository, package dependencies (`datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib`) are resolved automatically by `apt` during Fleet Intelligence Agent installation.
 
 ## Install package
 
-Download the package from [Releases](https://github.com/NVIDIA/fleet-intelligence-agent/releases), then install:
+Download the package from [Latest stable release](https://github.com/NVIDIA/fleet-intelligence-agent/releases/latest), then install:
 
 ```bash
 # Ubuntu (x86_64)
@@ -69,4 +88,3 @@ The service will automatically restart with the new version.
 sudo apt remove fleetint
 sudo apt purge fleetint  # Also removes configuration files
 ```
-

--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -1,10 +1,36 @@
 # RPM Installation
 
-## Prerequisites: NVIDIA CUDA Repository
+## Prerequisites
 
-The Fleet Intelligence Agent requires NVIDIA DCGM (Data Center GPU Manager) for GPU monitoring. DCGM is available through NVIDIA's CUDA repository and will be automatically installed when you install the Fleet Intelligence Agent package.
+The Fleet Intelligence Agent RPM package has the following runtime dependencies:
 
-Before installing the Fleet Intelligence Agent, add the appropriate NVIDIA CUDA repository for your system.
+- `datacenter-gpu-manager-4-proprietary` (DCGM)
+- `nvattest` (NVIDIA Attestation SDK CLI, NVAT)
+- `corelib` (NVAT GPU evidence source dependency)
+
+Before installing Fleet Intelligence Agent, ensure the following prerequisites are met:
+
+- NVIDIA package repository is configured (network or local CUDA repository) so `datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib` can be installed
+- A supported NVIDIA Datacenter Driver is installed
+- Install/upgrade commands are run as `root` or with `sudo`
+- `dnf-plugins-core` is installed (required for `dnf config-manager`)
+- Attestation for the fleetint use case only supports Blackwell and newer GPUs, and applies to non-CC mode systems
+- For NVSwitch systems (driver branch must match installed datacenter driver):
+  - Hopper (pre-4th gen NVSwitch): install `nvidia-driver:<driver-branch>/fm`
+  - Blackwell (4th gen NVSwitch): install `nvidia-driver-<driver-branch>-open` and `nvlink-<driver-branch>`
+
+References:
+- DCGM: <https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#installation>
+- Fabric Manager: <https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#installing-fabric-manager>
+- NVAT (`nvattest`/`corelib`): <https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/overview.html>
+
+Fleet Intelligence Agent package dependencies (`datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib`) are available through NVIDIA's CUDA repository. Before installing Fleet Intelligence Agent, add the appropriate NVIDIA CUDA repository for your system.
+
+Install `dnf-plugins-core` first if `dnf config-manager` is not available:
+
+```bash
+sudo dnf install -y dnf-plugins-core
+```
 
 ### RHEL/Rocky/AlmaLinux Systems
 
@@ -46,11 +72,11 @@ sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute
 sudo dnf clean all
 ```
 
-After adding the CUDA repository, DCGM (`datacenter-gpu-manager-4-core`) will be automatically installed as a recommended dependency when you install the Fleet Intelligence Agent package.
+After adding the CUDA repository, package dependencies (`datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib`) are resolved automatically by `dnf` during Fleet Intelligence Agent installation.
 
 ## Install package
 
-Download the package from [Releases](https://github.com/NVIDIA/fleet-intelligence-agent/releases), then install:
+Download the package from [Latest stable release](https://github.com/NVIDIA/fleet-intelligence-agent/releases/latest), then install:
 
 ```bash
 # RHEL/Rocky/AlmaLinux/Amazon Linux (x86_64)
@@ -86,4 +112,3 @@ The service will automatically restart with the new version.
 ```bash
 sudo dnf remove fleetint
 ```
-

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,6 @@ Starts the HTTP API server on port 15133. The server provides REST endpoints and
 **Options:**
 - `--log-level`: Set logging level (debug, info, warn, error)
 - `--listen-address`: Change listen address (default: `127.0.0.1:15133` for localhost only; see [Exposing the Agent for External Monitoring](#exposing-the-agent-for-external-monitoring) for details on exposing to Prometheus and other tools)
-- `--pprof`: Enable pprof profiling endpoint (note: pprof routes are not yet exposed)
 - `--components`: Enable/disable specific components
 
 ### Check Status
@@ -258,7 +257,7 @@ scrape_configs:
     metrics_path: /metrics
 ```
 
-**For production deployments** with persistent configuration and security considerations, see the [Configuration Guide](configuration.md#change-api-server-listen-address).
+**For production deployments** with persistent configuration and security considerations, see the [Configuration Guide](configuration.md#where-to-configure).
 
 ## Troubleshooting
 
@@ -308,4 +307,3 @@ The agent should use <100MB RAM and <1% CPU. Higher usage might indicate:
 - Large lookback windows (check `FLEETINT_METRICS_LOOKBACK` and `FLEETINT_EVENTS_LOOKBACK`)
 - Many GPUs in the system (resource usage scales with GPU count)
 - Debug logging enabled (use `--log-level=warn` or `error`)
-


### PR DESCRIPTION
## Summary
- update README/install docs with runtime package dependencies: datacenter-gpu-manager-4-proprietary, nvattest, corelib
- add DCGM/Fabric Manager prerequisite guidance and official reference links
- fix docs issues (invalid flags/link/path) and add Supported Platforms GPU column: Hopper, Blackwell, Rubin

## Test Plan
- make test

## Jira
- https://jirasw.nvidia.com/browse/GPUHEALTH-1491