### PR TITLE
[GPUHEALTH-1331] fix: export structured event extra_info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: '1.24.13'
+  GO_VERSION: '1.26.1'
   GOFLAGS: '-trimpath'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'  # Triggers on version tags like v1.0.0, v2.1.3, etc.
 
 env:
-  GO_VERSION: '1.24.13'
+  GO_VERSION: '1.26.1'
 
 permissions:
   contents: write  # Needed for creating GitHub releases

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ CLAUDE.md
 AGENTS.md
 
 .worktrees/
+docs/plans/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG DCGM_VERSION="4.4.2-1-ubuntu22.04"
 
-FROM golang:1.24.13 AS build
+FROM golang:1.26.1 AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/Dockerfile.citests
+++ b/Dockerfile.citests
@@ -16,7 +16,7 @@
 # Run specific package tests:
 #   docker run --rm fleet-intelligence-agent:test go test -v ./internal/...
 #
-FROM golang:1.24.13
+FROM golang:1.26.1
 
 ARG TARGETARCH
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,7 +11,7 @@ cd fleet-intelligence-agent
 
 ### Prerequisites
 
-- **Go**: 1.24.13
+- **Go**: 1.26.1
 - **GoReleaser**: For building packages (install from [goreleaser.com](https://goreleaser.com/install/))
 - **For ARM64 cross-compilation** (optional): `gcc-aarch64-linux-gnu` and `g++-aarch64-linux-gnu`
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/fleet-intelligence-agent
 
-go 1.24.13
+go 1.26.1
 
 require (
 	github.com/NVIDIA/fleet-intelligence-sdk v0.0.0-00010101000000-000000000000

--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -276,15 +276,10 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 			if extraInfo == nil {
 				extraInfo = map[string]string{}
 			}
-			extraInfoJSON, err := json.Marshal(extraInfo)
-			if err == nil {
-				attributes = append(attributes, &commonv1.KeyValue{
-					Key: "extra_info",
-					Value: &commonv1.AnyValue{
-						Value: &commonv1.AnyValue_StringValue{StringValue: string(extraInfoJSON)},
-					},
-				})
-			}
+			attributes = append(attributes, &commonv1.KeyValue{
+				Key:   "extra_info",
+				Value: extraInfoToAnyValue(extraInfo),
+			})
 
 			logRecord := &logsv1.LogRecord{
 				TimeUnixNano:   uint64(event.Time.UnixNano()),
@@ -379,6 +374,81 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 	}
 
 	return logRecords
+}
+
+func extraInfoToAnyValue(extraInfo map[string]string) *commonv1.AnyValue {
+	values := make([]*commonv1.KeyValue, 0, len(extraInfo))
+	for key, raw := range extraInfo {
+		values = append(values, &commonv1.KeyValue{
+			Key:   key,
+			Value: stringToStructuredAnyValue(raw),
+		})
+	}
+
+	return &commonv1.AnyValue{
+		Value: &commonv1.AnyValue_KvlistValue{
+			KvlistValue: &commonv1.KeyValueList{Values: values},
+		},
+	}
+}
+
+func stringToStructuredAnyValue(raw string) *commonv1.AnyValue {
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil || decoded == nil {
+		return &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_StringValue{StringValue: raw},
+		}
+	}
+
+	return jsonValueToAnyValue(decoded)
+}
+
+func jsonValueToAnyValue(v any) *commonv1.AnyValue {
+	switch value := v.(type) {
+	case map[string]any:
+		values := make([]*commonv1.KeyValue, 0, len(value))
+		for key, nested := range value {
+			values = append(values, &commonv1.KeyValue{
+				Key:   key,
+				Value: jsonValueToAnyValue(nested),
+			})
+		}
+		return &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_KvlistValue{
+				KvlistValue: &commonv1.KeyValueList{Values: values},
+			},
+		}
+	case []any:
+		values := make([]*commonv1.AnyValue, 0, len(value))
+		for _, nested := range value {
+			values = append(values, jsonValueToAnyValue(nested))
+		}
+		return &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_ArrayValue{
+				ArrayValue: &commonv1.ArrayValue{Values: values},
+			},
+		}
+	case bool:
+		return &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_BoolValue{BoolValue: value},
+		}
+	case float64:
+		return &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_DoubleValue{DoubleValue: value},
+		}
+	case string:
+		return &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_StringValue{StringValue: value},
+		}
+	case nil:
+		return &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_StringValue{StringValue: "null"},
+		}
+	default:
+		return &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_StringValue{StringValue: fmt.Sprintf("%v", value)},
+		}
+	}
 }
 
 // convertStructToOTLPAttributes converts a struct to OTLP attributes using reflection

--- a/internal/exporter/converter/otlp_test.go
+++ b/internal/exporter/converter/otlp_test.go
@@ -16,7 +16,6 @@
 package converter
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -138,20 +138,9 @@ func TestOTLPConverter_Convert_WithEvents(t *testing.T) {
 	assert.True(t, contains(body, "temperature_warning") || contains(body, "GPU temperature high"),
 		"Log should contain event name or message")
 
-	attributes := logs[0].Attributes
-	var extraInfoRaw string
-	for _, attr := range attributes {
-		if attr.Key == "extra_info" {
-			extraInfoRaw = attr.Value.GetStringValue()
-			break
-		}
-	}
-	require.NotEmpty(t, extraInfoRaw, "event log should include extra_info attribute")
-
-	var extraInfo map[string]string
-	err := json.Unmarshal([]byte(extraInfoRaw), &extraInfo)
-	require.NoError(t, err)
-	assert.Equal(t, "79", extraInfo["xid"])
+	extraInfo := findAttribute(t, logs[0].Attributes, "extra_info").GetKvlistValue()
+	require.NotNil(t, extraInfo, "event log should include structured extra_info attribute")
+	assert.Equal(t, float64(79), findMapValue(t, extraInfo.Values, "xid").GetDoubleValue())
 }
 
 func TestOTLPConverter_Convert_WithEvents_EmptyExtraInfo(t *testing.T) {
@@ -179,17 +168,12 @@ func TestOTLPConverter_Convert_WithEvents_EmptyExtraInfo(t *testing.T) {
 	logs := otlpData.Logs.ResourceLogs[0].ScopeLogs[0].LogRecords
 	require.GreaterOrEqual(t, len(logs), 1)
 
-	var extraInfoRaw string
-	for _, attr := range logs[0].Attributes {
-		if attr.Key == "extra_info" {
-			extraInfoRaw = attr.Value.GetStringValue()
-			break
-		}
-	}
-	require.Equal(t, "{}", extraInfoRaw, "event log should always include extra_info as empty JSON object")
+	extraInfo := findAttribute(t, logs[0].Attributes, "extra_info").GetKvlistValue()
+	require.NotNil(t, extraInfo, "event log should always include extra_info")
+	assert.Empty(t, extraInfo.Values, "event log should export empty extra_info as an empty OTLP map")
 }
 
-func TestOTLPConverter_Convert_WithEvents_ExtraInfoDataPayload(t *testing.T) {
+func TestOTLPConverter_Convert_WithEvents_StructuredExtraInfo(t *testing.T) {
 	rawData := `{"time":"2026-02-20T23:22:44Z","data_source":"kmsg","xid":149}`
 	data := &collector.HealthData{
 		Timestamp: time.Now(),
@@ -219,22 +203,48 @@ func TestOTLPConverter_Convert_WithEvents_ExtraInfoDataPayload(t *testing.T) {
 	logs := otlpData.Logs.ResourceLogs[0].ScopeLogs[0].LogRecords
 	require.GreaterOrEqual(t, len(logs), 1)
 
-	var extraInfoRaw string
-	for _, attr := range logs[0].Attributes {
-		if attr.Key == "extra_info" {
-			extraInfoRaw = attr.Value.GetStringValue()
-			break
-		}
-	}
-	require.NotEmpty(t, extraInfoRaw)
+	extraInfo := findAttribute(t, logs[0].Attributes, "extra_info").GetKvlistValue()
+	require.NotNil(t, extraInfo)
+	assert.Equal(t, "PCI:0000:04:00", findMapValue(t, extraInfo.Values, "device_uuid").GetStringValue())
 
-	var extraInfo map[string]string
-	require.NoError(t, json.Unmarshal([]byte(extraInfoRaw), &extraInfo))
-	assert.Equal(t, rawData, extraInfo["data"])
-	assert.Equal(t, "PCI:0000:04:00", extraInfo["device_uuid"])
+	dataValue := findMapValue(t, extraInfo.Values, "data").GetKvlistValue()
+	require.NotNil(t, dataValue)
+	assert.Equal(t, "2026-02-20T23:22:44Z", findMapValue(t, dataValue.Values, "time").GetStringValue())
+	assert.Equal(t, "kmsg", findMapValue(t, dataValue.Values, "data_source").GetStringValue())
+	assert.Equal(t, float64(149), findMapValue(t, dataValue.Values, "xid").GetDoubleValue())
+}
+
+func TestOTLPConverter_Convert_WithEvents_InvalidExtraInfoRemainsString(t *testing.T) {
+	data := &collector.HealthData{
+		Timestamp: time.Now(),
+		MachineID: "test-machine",
+		Events: eventstore.Events{
+			{
+				Time:      time.Date(2025, 11, 5, 12, 0, 0, 0, time.UTC),
+				Component: "gpu",
+				Name:      "temperature_warning",
+				Type:      "warning",
+				Message:   "GPU temperature high",
+				ExtraInfo: map[string]string{
+					"data": "{invalid",
+				},
+			},
+		},
+	}
+
+	converter := NewOTLPConverter()
+	otlpData := converter.Convert(data)
+
+	logs := otlpData.Logs.ResourceLogs[0].ScopeLogs[0].LogRecords
+	require.GreaterOrEqual(t, len(logs), 1)
+
+	extraInfo := findAttribute(t, logs[0].Attributes, "extra_info").GetKvlistValue()
+	require.NotNil(t, extraInfo)
+	assert.Equal(t, "{invalid", findMapValue(t, extraInfo.Values, "data").GetStringValue())
 }
 
 func TestOTLPConverter_Convert_WithComponentData(t *testing.T) {
+	rawData := `{"time":"2026-02-20T23:22:44Z","data_source":"kmsg","xid":149}`
 	data := &collector.HealthData{
 		Timestamp: time.Now(),
 		MachineID: "test-machine",
@@ -244,7 +254,10 @@ func TestOTLPConverter_Convert_WithComponentData(t *testing.T) {
 				"component_name": "gpu",
 				"health":         "healthy",
 				"reason":         "All checks passed",
-				"extra_info":     "Additional details",
+				"extra_info": map[string]any{
+					"device_uuid": "PCI:0000:04:00",
+					"data":        rawData,
+				},
 			},
 		},
 	}
@@ -265,6 +278,10 @@ func TestOTLPConverter_Convert_WithComponentData(t *testing.T) {
 	found := false
 	for _, log := range logs {
 		if contains(log.Body.GetStringValue(), "gpu") && contains(log.Body.GetStringValue(), "healthy") {
+			extraInfo := findAttribute(t, log.Attributes, "extra_info").GetStringValue()
+			require.NotEmpty(t, extraInfo)
+			assert.Contains(t, extraInfo, `"device_uuid":"PCI:0000:04:00"`)
+			assert.Contains(t, extraInfo, `"data":"{\"time\":\"2026-02-20T23:22:44Z\",\"data_source\":\"kmsg\",\"xid\":149}"`)
 			found = true
 			break
 		}
@@ -786,4 +803,23 @@ func findSubstring(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func findAttribute(t *testing.T, attrs []*commonv1.KeyValue, key string) *commonv1.AnyValue {
+	t.Helper()
+
+	for _, attr := range attrs {
+		if attr.Key == key {
+			return attr.Value
+		}
+	}
+
+	t.Fatalf("attribute %q not found", key)
+	return nil
+}
+
+func findMapValue(t *testing.T, attrs []*commonv1.KeyValue, key string) *commonv1.AnyValue {
+	t.Helper()
+
+	return findAttribute(t, attrs, key)
 }


### PR DESCRIPTION
## Summary
- export OTLP event extra_info as structured values instead of a JSON string
- keep component-data extra_info on the existing stringified path
- bump the repo toolchain pins to Go 1.26.1 across go.mod, CI, Docker, and development docs
- ignore local docs/plans/ files in git

## Verification
- go test ./internal/exporter/converter -run 'TestOTLPConverter_Convert_WithEvents|TestOTLPConverter_Convert_WithComponentData' -count=1
- make vuln