### PR TITLE
chore: Add SPDX Apache 2.0 license headers to missing file

### DIFF
--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/metrics.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/metrics.go
@@ -1,3 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package inforom
 
 import (


### PR DESCRIPTION
- Add full header to missing file third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/metrics.go