### PR TITLE
feat: add enrollment precheck command

### DIFF
--- a/cmd/fleetint/enroll.go
+++ b/cmd/fleetint/enroll.go
@@ -28,9 +28,30 @@ import (
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/enrollment"
 )
 
+var (
+	performEnrollment = func(enrollEndpoint, sakToken string) (string, error) {
+		return enrollment.PerformEnrollment(context.Background(), enrollEndpoint, sakToken)
+	}
+	storeEnrollmentConfig = storeConfigInMetadata
+)
+
 func enrollCommand(cliContext *cli.Context) error {
 	baseEndpoint := cliContext.String("endpoint")
 	sakToken := cliContext.String("token")
+	force := cliContext.Bool("force")
+
+	result, err := runPrecheck()
+	if err != nil {
+		return fmt.Errorf("failed to run precheck: %w", err)
+	}
+	printPrecheckResult(writerFromContext(cliContext), result)
+	if !result.Passed() {
+		if !force {
+			fmt.Fprintln(writerFromContext(cliContext), "Enrollment skipped: precheck failed")
+			return fmt.Errorf("precheck failed")
+		}
+		fmt.Fprintln(writerFromContext(cliContext), "Proceeding with enrollment because --force was provided")
+	}
 
 	// Validate base endpoint
 	baseURL, err := url.Parse(baseEndpoint)
@@ -56,7 +77,7 @@ func enrollCommand(cliContext *cli.Context) error {
 	}
 
 	// Make enrollment request to get JWT token
-	jwtToken, err := enrollment.PerformEnrollment(context.Background(), enrollEndpoint, sakToken)
+	jwtToken, err := performEnrollment(enrollEndpoint, sakToken)
 	if err != nil {
 		// Error already printed to stderr by PerformEnrollment
 		return err
@@ -77,7 +98,7 @@ func enrollCommand(cliContext *cli.Context) error {
 	}
 
 	// Store endpoints and JWT token in metadata table
-	if err := storeConfigInMetadata(enrollEndpoint, metricsEndpoint, logsEndpoint, nonceEndpoint, jwtToken, sakToken); err != nil {
+	if err := storeEnrollmentConfig(enrollEndpoint, metricsEndpoint, logsEndpoint, nonceEndpoint, jwtToken, sakToken); err != nil {
 		return fmt.Errorf("failed to store configuration: %w", err)
 	}
 

--- a/cmd/fleetint/enroll_test.go
+++ b/cmd/fleetint/enroll_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/precheck"
+)
+
+func TestEnrollCommandPrecheckError(t *testing.T) {
+	originalRunPrecheck := runPrecheck
+	t.Cleanup(func() {
+		runPrecheck = originalRunPrecheck
+	})
+
+	runPrecheck = func() (precheck.Result, error) {
+		return precheck.Result{}, fmt.Errorf("nvml init failed")
+	}
+
+	app := App()
+	app.Writer = &bytes.Buffer{}
+
+	err := app.Run([]string{"fleetint", "enroll", "--endpoint", "https://example.com", "--token", "token"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to run precheck")
+	assert.Contains(t, err.Error(), "nvml init failed")
+}
+
+func TestEnrollCommandBlocksOnFailedPrecheck(t *testing.T) {
+	originalRunPrecheck := runPrecheck
+	originalPerformEnrollment := performEnrollment
+	originalStoreConfig := storeEnrollmentConfig
+	t.Cleanup(func() {
+		runPrecheck = originalRunPrecheck
+		performEnrollment = originalPerformEnrollment
+		storeEnrollmentConfig = originalStoreConfig
+	})
+
+	enrollmentCalled := false
+	runPrecheck = func() (precheck.Result, error) {
+		return precheck.Result{
+			Checks: []precheck.Check{
+				{Name: "gpu-present", Message: "no NVIDIA GPU detected"},
+			},
+		}, nil
+	}
+	performEnrollment = func(enrollEndpoint, sakToken string) (string, error) {
+		enrollmentCalled = true
+		return "jwt-token", nil
+	}
+	storeEnrollmentConfig = func(enrollEndpoint, metricsEndpoint, logsEndpoint, nonceEndpoint, jwtToken, sakToken string) error {
+		return nil
+	}
+
+	out := &bytes.Buffer{}
+	app := App()
+	app.Writer = out
+
+	err := app.Run([]string{"fleetint", "enroll", "--endpoint", "https://example.com", "--token", "token"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "precheck failed")
+	assert.Contains(t, out.String(), "Enrollment skipped: precheck failed")
+	assert.False(t, enrollmentCalled)
+}
+
+func TestEnrollCommandForceBypassesFailedPrecheck(t *testing.T) {
+	originalRunPrecheck := runPrecheck
+	originalPerformEnrollment := performEnrollment
+	originalStoreConfig := storeEnrollmentConfig
+	t.Cleanup(func() {
+		runPrecheck = originalRunPrecheck
+		performEnrollment = originalPerformEnrollment
+		storeEnrollmentConfig = originalStoreConfig
+	})
+
+	enrollmentCalled := false
+	runPrecheck = func() (precheck.Result, error) {
+		return precheck.Result{
+			Checks: []precheck.Check{
+				{Name: "gpu-present", Message: "no NVIDIA GPU detected"},
+			},
+		}, nil
+	}
+	performEnrollment = func(enrollEndpoint, sakToken string) (string, error) {
+		enrollmentCalled = true
+		return "jwt-token", nil
+	}
+	storeEnrollmentConfig = func(enrollEndpoint, metricsEndpoint, logsEndpoint, nonceEndpoint, jwtToken, sakToken string) error {
+		return nil
+	}
+
+	app := App()
+	app.Writer = &bytes.Buffer{}
+
+	err := app.Run([]string{"fleetint", "enroll", "--endpoint", "https://example.com", "--token", "token", "--force"})
+
+	require.NoError(t, err)
+	assert.True(t, enrollmentCalled)
+}

--- a/cmd/fleetint/precheck.go
+++ b/cmd/fleetint/precheck.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/urfave/cli"
+
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/cmdutil"
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/precheck"
+)
+
+var runPrecheck = precheck.Run
+
+func precheckCommand(cliContext *cli.Context) error {
+	result, err := runPrecheck()
+	if err != nil {
+		return fmt.Errorf("failed to run precheck: %w", err)
+	}
+
+	printPrecheckResult(writerFromContext(cliContext), result)
+	if !result.Passed() {
+		return fmt.Errorf("precheck failed")
+	}
+
+	return nil
+}
+
+func printPrecheckResult(w io.Writer, result precheck.Result) {
+	for _, check := range result.Checks {
+		symbol := cmdutil.WarningSign
+		if check.Passed {
+			symbol = cmdutil.CheckMark
+		}
+		fmt.Fprintf(w, "%s %s\n", symbol, check.Message)
+	}
+}
+
+func writerFromContext(cliContext *cli.Context) io.Writer {
+	if cliContext != nil && cliContext.App != nil && cliContext.App.Writer != nil {
+		return cliContext.App.Writer
+	}
+
+	return os.Stdout
+}

--- a/cmd/fleetint/precheck_test.go
+++ b/cmd/fleetint/precheck_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/precheck"
+)
+
+func TestAppIncludesPrecheckCommand(t *testing.T) {
+	t.Parallel()
+
+	app := App()
+
+	commandNames := make([]string, 0, len(app.Commands))
+	for _, command := range app.Commands {
+		commandNames = append(commandNames, command.Name)
+	}
+
+	assert.Contains(t, commandNames, "precheck")
+}
+
+func TestPrecheckCommand(t *testing.T) {
+	originalRunPrecheck := runPrecheck
+	t.Cleanup(func() {
+		runPrecheck = originalRunPrecheck
+	})
+
+	tests := []struct {
+		name      string
+		result    precheck.Result
+		wantError string
+	}{
+		{
+			name: "returns success when checks pass",
+			result: precheck.Result{
+				Checks: []precheck.Check{
+					{Name: "gpu-present", Passed: true, Message: "NVIDIA GPU detected"},
+				},
+			},
+		},
+		{
+			name: "returns error when checks fail",
+			result: precheck.Result{
+				Checks: []precheck.Check{
+					{Name: "gpu-present", Message: "no NVIDIA GPU detected"},
+				},
+			},
+			wantError: "precheck failed",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			runPrecheck = func() (precheck.Result, error) {
+				return tt.result, nil
+			}
+
+			app := App()
+			app.Writer = &bytes.Buffer{}
+
+			err := app.Run([]string{"fleetint", "precheck"})
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+		})
+	}
+}

--- a/cmd/fleetint/root.go
+++ b/cmd/fleetint/root.go
@@ -202,6 +202,11 @@ func App() *cli.App {
 			},
 		},
 		{
+			Name:   "precheck",
+			Usage:  "validate host prerequisites required for installation and enrollment",
+			Action: precheckCommand,
+		},
+		{
 			Name:   "enroll",
 			Usage:  "enroll the agent with Fleet Intelligence backend endpoints and credentials",
 			Action: enrollCommand,
@@ -215,6 +220,10 @@ func App() *cli.App {
 					Name:     "token",
 					Usage:    "authentication token (required)",
 					Required: true,
+				},
+				&cli.BoolFlag{
+					Name:  "force",
+					Usage: "continue enrollment even when precheck fails",
 				},
 			},
 		},

--- a/deployments/helm/fleet-intelligence-agent/README.md
+++ b/deployments/helm/fleet-intelligence-agent/README.md
@@ -42,6 +42,7 @@ Common values (defaults from `values.yaml`):
 | `components` | `all` | Enabled components. |
 | `enroll.enabled` | `false` | Enable enrollment init container. |
 | `enroll.unenroll` | `false` | Run explicit unenroll init container (cleanup persisted enrollment metadata). |
+| `enroll.force` | `false` | Append `--force` to the enrollment command. |
 | `enroll.endpoint` | `""` | Enrollment endpoint. |
 | `enroll.tokenSecretName` | `""` | Secret name for enrollment token. |
 | `enroll.tokenSecretKey` | `token` | Secret key for enrollment token. |
@@ -64,6 +65,7 @@ Common values (defaults from `values.yaml`):
 ### Enrollment (per node via init container)
 
 `enroll.enabled` and `enroll.unenroll` are mutually exclusive; do not set both to `true`.
+Set `enroll.force=true` to append `--force` to `fleetint enroll`.
 
 See `docs/install-helm.md` for the enrollment flow and secret creation steps.
 

--- a/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
+++ b/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
@@ -71,6 +71,9 @@ spec:
               /usr/bin/fleetint enroll
               --endpoint {{ required "enroll.endpoint is required when enroll.enabled=true" .Values.enroll.endpoint | quote }}
               --token "${FLEETINT_TOKEN}"
+              {{- if .Values.enroll.force }}
+              --force
+              {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           env:

--- a/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
+++ b/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
@@ -77,6 +77,12 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           env:
+            {{- range $name, $value := .Values.env }}
+            {{- if ne (toString $value) "" }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
             - name: FLEETINT_TOKEN
               {{- if .Values.enroll.tokenSecretName }}
               valueFrom:

--- a/deployments/helm/fleet-intelligence-agent/values.yaml
+++ b/deployments/helm/fleet-intelligence-agent/values.yaml
@@ -52,6 +52,7 @@ components: all
 enroll:
   enabled: false
   unenroll: false
+  force: false
   endpoint: ""
   tokenSecretName: ""
   tokenSecretKey: "token"

--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -12,7 +12,7 @@ Before installing Fleet Intelligence Agent, ensure the following prerequisites a
 
 - NVIDIA package repository is configured (network or local CUDA repository) so `datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib` can be installed
 - DCGM HostEngine `4.2.3` or newer
-- A supported NVIDIA Datacenter Driver is installed
+- NVIDIA Datacenter Driver major version `510` or newer is installed
 - Install/upgrade commands are run as `root` or with `sudo`
 - Attestation for the fleetint use case only supports Blackwell and newer GPUs, and applies to non-CC mode systems
 - For NVSwitch systems (driver branch must match installed datacenter driver):

--- a/docs/install-helm.md
+++ b/docs/install-helm.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 
 - NVIDIA GPU Operator installed with DCGM HostEngine enabled.
+- NVIDIA Datacenter Driver major version `510` or newer on the cluster nodes.
 - DCGM HostEngine `4.2.3` or newer.
 - A DCGM service endpoint reachable from the cluster (defaults to `nvidia-dcgm.gpu-operator.svc:5555`).
 - Access to GitHub Container Registry (`ghcr.io`) from your cluster/network.

--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -12,7 +12,7 @@ Before installing Fleet Intelligence Agent, ensure the following prerequisites a
 
 - NVIDIA package repository is configured (network or local CUDA repository) so `datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib` can be installed
 - DCGM HostEngine `4.2.3` or newer
-- A supported NVIDIA Datacenter Driver is installed
+- NVIDIA Datacenter Driver major version `510` or newer is installed
 - Install/upgrade commands are run as `root` or with `sudo`
 - `dnf-plugins-core` is installed (required for `dnf config-manager`)
 - Attestation for the fleetint use case only supports Blackwell and newer GPUs, and applies to non-CC mode systems

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,6 +61,28 @@ sudo fleetint metadata --set-key="key" --set-value="value"
 
 Used to view or update the agent's metadata store, including remote export configuration.
 
+### Validate Prerequisites
+
+```bash
+sudo fleetint precheck
+```
+
+Validates the local prerequisites required for installation and enrollment.
+
+**What it checks:**
+- NVIDIA GPU presence
+- supported GPU architecture (`Hopper`, `Blackwell`, `Rubin`)
+- NVIDIA driver detection
+- DCGM HostEngine reachability
+- DCGM HostEngine minimum version (`4.2.3`)
+- `nvattest` availability
+
+The command prints each check result and exits non-zero if any hard requirement fails.
+
+**Environment Variables (DCGM connection):**
+- `DCGM_URL`: Address of the DCGM HostEngine (default: `localhost`)
+- `DCGM_URL_IS_UNIX_SOCKET`: Set to `true` if `DCGM_URL` is a Unix socket path (default: `false`)
+
 ### Enroll Agent
 
 ```bash
@@ -73,11 +95,15 @@ Enrolls the agent with the Fleet Intelligence backend by exchanging a Service Ac
 - `--endpoint`: Base endpoint URL for the Fleet Intelligence backend (must use HTTPS)
 - `--token`: Service Account Key (SAK) token for authentication
 
+**Optional Flags:**
+- `--force`: Continue enrollment even if `fleetint precheck` fails
+
 **What it does:**
-1. Validates the endpoint URL (must be HTTPS)
-2. Makes an enrollment request to exchange the SAK token for a JWT token
-3. Stores the JWT token and backend endpoints (metrics, logs, nonce) in the local metadata database
-4. The stored credentials are used automatically by the agent for data export
+1. Runs the same prerequisite validation as `fleetint precheck`
+2. Validates the endpoint URL (must be HTTPS)
+3. Makes an enrollment request to exchange the SAK token for a JWT token
+4. Stores the JWT token and backend endpoints (metrics, logs, nonce) in the local metadata database
+5. The stored credentials are used automatically by the agent for data export
 
 **Example output:**
 ```
@@ -85,6 +111,7 @@ Enrollment succeeded
 ```
 
 **Error handling:**
+- precheck failure: Enrollment is blocked unless `--force` is set
 - 400: Token format is incorrect
 - 401: Token is invalid
 - 403: Token is expired or revoked

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,7 +72,7 @@ Validates the local prerequisites required for installation and enrollment.
 **What it checks:**
 - NVIDIA GPU presence
 - supported GPU architecture (`Hopper`, `Blackwell`, `Rubin`)
-- NVIDIA driver detection
+- NVIDIA driver major version (`510` or newer)
 - DCGM HostEngine reachability
 - DCGM HostEngine minimum version (`4.2.3`)
 - `nvattest` availability

--- a/internal/precheck/precheck.go
+++ b/internal/precheck/precheck.go
@@ -33,6 +33,7 @@ import (
 var supportedArchitectures = []string{"Hopper", "Blackwell", "Rubin"}
 
 const minimumDCGMVersion = "4.2.3"
+const minimumDriverMajorVersion = 510
 
 var (
 	newNVML              = nvidianvml.New
@@ -191,6 +192,21 @@ func evaluateDriver(info *machineinfo.MachineInfo) Check {
 		return Check{
 			Name:    "gpu-driver",
 			Message: "NVIDIA driver not detected",
+		}
+	}
+
+	driverMajor, _, _, err := nvidianvml.ParseDriverVersion(info.GPUDriverVersion)
+	if err != nil {
+		return Check{
+			Name:    "gpu-driver",
+			Message: "failed to parse NVIDIA driver version: " + err.Error(),
+		}
+	}
+
+	if driverMajor < minimumDriverMajorVersion {
+		return Check{
+			Name:    "gpu-driver",
+			Message: fmt.Sprintf("NVIDIA driver major version %d is below required minimum %d", driverMajor, minimumDriverMajorVersion),
 		}
 	}
 

--- a/internal/precheck/precheck.go
+++ b/internal/precheck/precheck.go
@@ -1,0 +1,381 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package precheck evaluates prerequisite checks for enrollment and installation flows.
+package precheck
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+
+	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
+	godcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
+)
+
+var supportedArchitectures = []string{"Hopper", "Blackwell", "Rubin"}
+
+const minimumDCGMVersion = "4.2.3"
+
+var (
+	newNVML              = nvidianvml.New
+	getMachineInfo       = machineinfo.GetMachineInfo
+	lookPath             = exec.LookPath
+	dcgmInit             = initDCGMStandalone
+	getHostengineVersion = getDCGMHostengineVersion
+	getenv               = os.Getenv
+)
+
+type nvmlInstance = nvidianvml.Instance
+
+type Input struct {
+	MachineInfo     *machineinfo.MachineInfo
+	NVAttestPresent *bool
+	DCGMReachable   *bool
+	DCGMVersion     string
+}
+
+type Check struct {
+	Name    string
+	Passed  bool
+	Message string
+}
+
+type Result struct {
+	Checks []Check
+}
+
+func (r Result) Passed() bool {
+	for _, check := range r.Checks {
+		if !check.Passed {
+			return false
+		}
+	}
+
+	return true
+}
+
+func SupportedArchitectures() []string {
+	return slices.Clone(supportedArchitectures)
+}
+
+func (r Result) FailedChecks() []Check {
+	failed := make([]Check, 0, len(r.Checks))
+	for _, check := range r.Checks {
+		if !check.Passed {
+			failed = append(failed, check)
+		}
+	}
+
+	return failed
+}
+
+func Run() (Result, error) {
+	input, err := CollectInput()
+	if err != nil {
+		return Result{}, err
+	}
+
+	return Evaluate(input), nil
+}
+
+func CollectInput() (Input, error) {
+	input := Input{}
+
+	nvmlInstance, err := newNVML()
+	if err == nil {
+		defer func() { _ = nvmlInstance.Shutdown() }()
+
+		info, machineInfoErr := getMachineInfo(nvmlInstance)
+		if machineInfoErr == nil {
+			input.MachineInfo = info
+		}
+	}
+
+	nvattestPresent := detectNVAttest()
+	input.NVAttestPresent = &nvattestPresent
+
+	dcgmReachable, dcgmVersion := detectDCGM()
+	input.DCGMReachable = &dcgmReachable
+	input.DCGMVersion = dcgmVersion
+
+	return input, nil
+}
+
+func Evaluate(input Input) Result {
+	checks := []Check{
+		evaluateGPUPresence(input.MachineInfo),
+		evaluateArchitecture(input.MachineInfo),
+		evaluateDriver(input.MachineInfo),
+		evaluateNVAttest(input.NVAttestPresent),
+		evaluateDCGM(input),
+	}
+
+	return Result{Checks: checks}
+}
+
+func evaluateGPUPresence(info *machineinfo.MachineInfo) Check {
+	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
+		return Check{
+			Name:    "gpu-present",
+			Message: "no NVIDIA GPU detected",
+		}
+	}
+
+	return Check{
+		Name:    "gpu-present",
+		Passed:  true,
+		Message: "NVIDIA GPU detected",
+	}
+}
+
+func evaluateArchitecture(info *machineinfo.MachineInfo) Check {
+	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
+		return Check{
+			Name:    "gpu-architecture",
+			Passed:  true,
+			Message: "GPU architecture check skipped because no GPU was detected",
+		}
+	}
+
+	if info.GPUInfo.Architecture == "" {
+		return Check{
+			Name:    "gpu-architecture",
+			Message: "GPU architecture is unknown",
+		}
+	}
+
+	if !slices.ContainsFunc(supportedArchitectures, func(s string) bool {
+		return strings.EqualFold(s, info.GPUInfo.Architecture)
+	}) {
+		return Check{
+			Name:    "gpu-architecture",
+			Message: "unsupported GPU architecture: " + info.GPUInfo.Architecture,
+		}
+	}
+
+	return Check{
+		Name:    "gpu-architecture",
+		Passed:  true,
+		Message: "supported GPU architecture detected: " + info.GPUInfo.Architecture,
+	}
+}
+
+func evaluateDriver(info *machineinfo.MachineInfo) Check {
+	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
+		return Check{
+			Name:    "gpu-driver",
+			Passed:  true,
+			Message: "driver check skipped because no GPU was detected",
+		}
+	}
+
+	if info.GPUDriverVersion == "" {
+		return Check{
+			Name:    "gpu-driver",
+			Message: "NVIDIA driver not detected",
+		}
+	}
+
+	return Check{
+		Name:    "gpu-driver",
+		Passed:  true,
+		Message: "NVIDIA driver detected: " + info.GPUDriverVersion,
+	}
+}
+
+// evaluateNVAttest checks whether nvattest is present in PATH.
+// present may be nil when constructing a partial Input (e.g. in targeted tests
+// that focus on other checks); in that case the check is skipped.
+func evaluateNVAttest(present *bool) Check {
+	if present == nil {
+		return Check{
+			Name:    "nvattest",
+			Passed:  true,
+			Message: "nvattest check skipped",
+		}
+	}
+
+	if !*present {
+		return Check{
+			Name:    "nvattest",
+			Message: "nvattest not found in PATH",
+		}
+	}
+
+	return Check{
+		Name:    "nvattest",
+		Passed:  true,
+		Message: "nvattest detected",
+	}
+}
+
+func evaluateDCGM(input Input) Check {
+	if input.DCGMReachable == nil {
+		return Check{
+			Name:    "dcgm",
+			Passed:  true,
+			Message: "DCGM checks skipped",
+		}
+	}
+
+	if !*input.DCGMReachable {
+		return Check{
+			Name:    "dcgm",
+			Message: "DCGM HostEngine is not reachable",
+		}
+	}
+
+	if input.DCGMVersion == "" {
+		return Check{
+			Name:    "dcgm",
+			Message: "DCGM HostEngine version could not be determined",
+		}
+	}
+
+	versionOK, err := isVersionAtLeast(input.DCGMVersion, minimumDCGMVersion)
+	if err != nil {
+		return Check{
+			Name:    "dcgm",
+			Message: "failed to parse DCGM HostEngine version: " + err.Error(),
+		}
+	}
+
+	if !versionOK {
+		return Check{
+			Name:    "dcgm",
+			Message: "DCGM HostEngine version " + input.DCGMVersion + " is below required minimum " + minimumDCGMVersion,
+		}
+	}
+
+	return Check{
+		Name:    "dcgm",
+		Passed:  true,
+		Message: "DCGM HostEngine version is supported: " + input.DCGMVersion,
+	}
+}
+
+func isVersionAtLeast(version, minimum string) (bool, error) {
+	versionParts, err := parseVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	minimumParts, err := parseVersion(minimum)
+	if err != nil {
+		return false, err
+	}
+
+	for i := range min(len(versionParts), len(minimumParts)) {
+		if versionParts[i] > minimumParts[i] {
+			return true, nil
+		}
+		if versionParts[i] < minimumParts[i] {
+			return false, nil
+		}
+	}
+
+	return len(versionParts) >= len(minimumParts), nil
+}
+
+func parseVersion(version string) ([]int, error) {
+	parts := strings.Split(version, ".")
+	parsed := make([]int, 0, len(parts))
+	for _, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid version %q", version)
+		}
+		parsed = append(parsed, value)
+	}
+
+	return parsed, nil
+}
+
+func detectNVAttest() bool {
+	_, err := lookPath("nvattest")
+	return err == nil
+}
+
+func detectDCGM() (bool, string) {
+	cleanup, err := dcgmInit()
+	if err != nil {
+		return false, ""
+	}
+	defer cleanup()
+
+	version, err := getHostengineVersion()
+	if err != nil {
+		return true, ""
+	}
+
+	return true, version
+}
+
+func extractVersion(raw string) string {
+	for _, pair := range strings.Split(raw, ";") {
+		key, value, ok := strings.Cut(pair, ":")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) == "version" {
+			return strings.TrimSpace(value)
+		}
+	}
+
+	return ""
+}
+
+func initDCGMStandalone() (func(), error) {
+	initParams := resolveDCGMInitFromEnv()
+	return godcgm.Init(godcgm.Standalone, initParams.address, initParams.isUnixSocket)
+}
+
+func getDCGMHostengineVersion() (string, error) {
+	versionInfo, err := godcgm.GetHostengineVersionInfo()
+	if err != nil {
+		return "", err
+	}
+
+	return extractVersion(versionInfo.RawBuildInfoString), nil
+}
+
+type dcgmInitParams struct {
+	address      string
+	isUnixSocket string
+}
+
+func resolveDCGMInitFromEnv() dcgmInitParams {
+	address := strings.TrimSpace(getenv("DCGM_URL"))
+	isUnixSocket := "0"
+
+	if truthy, err := strconv.ParseBool(strings.TrimSpace(getenv("DCGM_URL_IS_UNIX_SOCKET"))); err == nil && truthy {
+		isUnixSocket = "1"
+	}
+
+	if address == "" {
+		address = "localhost"
+	}
+
+	return dcgmInitParams{
+		address:      address,
+		isUnixSocket: isUnixSocket,
+	}
+}

--- a/internal/precheck/precheck_test.go
+++ b/internal/precheck/precheck_test.go
@@ -137,6 +137,28 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 			},
 		},
 		{
+			name: "fails for malformed driver version",
+			input: Input{
+				MachineInfo:     machineInfoWithGPU("Hopper", "not-a-version"),
+				NVAttestPresent: boolPtr(true),
+			},
+			wantPassed: false,
+			wantMessages: []string{
+				"failed to parse NVIDIA driver version: failed to parse driver version (expected at least 2 parts): not-a-version",
+			},
+		},
+		{
+			name: "fails for driver below minimum major version",
+			input: Input{
+				MachineInfo:     machineInfoWithGPU("Hopper", "509.12.01"),
+				NVAttestPresent: boolPtr(true),
+			},
+			wantPassed: false,
+			wantMessages: []string{
+				"NVIDIA driver major version 509 is below required minimum 510",
+			},
+		},
+		{
 			name: "fails for missing nvattest",
 			input: Input{
 				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
@@ -148,7 +170,15 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 			},
 		},
 		{
-			name: "passes when driver and nvattest are present",
+			name: "passes when driver major is at minimum and nvattest is present",
+			input: Input{
+				MachineInfo:     machineInfoWithGPU("Hopper", "510.47.03"),
+				NVAttestPresent: boolPtr(true),
+			},
+			wantPassed: true,
+		},
+		{
+			name: "passes when newer driver and nvattest are present",
 			input: Input{
 				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
 				NVAttestPresent: boolPtr(true),

--- a/internal/precheck/precheck_test.go
+++ b/internal/precheck/precheck_test.go
@@ -1,0 +1,339 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package precheck
+
+import (
+	"fmt"
+	"testing"
+
+	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
+)
+
+func TestEvaluateArchitecture(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        Input
+		wantPassed   bool
+		wantMessages []string
+	}{
+		{
+			name: "passes for hopper",
+			input: Input{
+				MachineInfo: machineInfoWithGPU("Hopper", "575.57.08"),
+			},
+			wantPassed: true,
+		},
+		{
+			name: "passes for blackwell",
+			input: Input{
+				MachineInfo: machineInfoWithGPU("Blackwell", "575.57.08"),
+			},
+			wantPassed: true,
+		},
+		{
+			name: "passes for rubin",
+			input: Input{
+				MachineInfo: machineInfoWithGPU("Rubin", "575.57.08"),
+			},
+			wantPassed: true,
+		},
+		{
+			name: "fails for missing gpu",
+			input: Input{
+				MachineInfo: &machineinfo.MachineInfo{},
+			},
+			wantPassed: false,
+			wantMessages: []string{
+				"no NVIDIA GPU detected",
+			},
+		},
+		{
+			name: "passes for hopper lowercase",
+			input: Input{
+				MachineInfo: machineInfoWithGPU("hopper", "575.57.08"),
+			},
+			wantPassed: true,
+		},
+		{
+			name: "fails for unsupported architecture",
+			input: Input{
+				MachineInfo: machineInfoWithGPU("Ampere", "575.57.08"),
+			},
+			wantPassed: false,
+			wantMessages: []string{
+				"unsupported GPU architecture: Ampere",
+			},
+		},
+		{
+			name: "fails for empty architecture",
+			input: Input{
+				MachineInfo: machineInfoWithGPU("", "575.57.08"),
+			},
+			wantPassed: false,
+			wantMessages: []string{
+				"GPU architecture is unknown",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := Evaluate(tt.input)
+
+			assert.Equal(t, tt.wantPassed, result.Passed())
+			for _, wantMessage := range tt.wantMessages {
+				assert.Contains(t, checkMessages(result.Checks), wantMessage)
+			}
+		})
+	}
+}
+
+func TestSupportedArchitectures(t *testing.T) {
+	t.Parallel()
+
+	require.ElementsMatch(t, []string{"Hopper", "Blackwell", "Rubin"}, SupportedArchitectures())
+}
+
+func TestEvaluateDriverAndNVAT(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        Input
+		wantPassed   bool
+		wantMessages []string
+	}{
+		{
+			name: "fails for missing driver",
+			input: Input{
+				MachineInfo:     machineInfoWithGPU("Hopper", ""),
+				NVAttestPresent: boolPtr(true),
+			},
+			wantPassed: false,
+			wantMessages: []string{
+				"NVIDIA driver not detected",
+			},
+		},
+		{
+			name: "fails for missing nvattest",
+			input: Input{
+				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
+				NVAttestPresent: boolPtr(false),
+			},
+			wantPassed: false,
+			wantMessages: []string{
+				"nvattest not found in PATH",
+			},
+		},
+		{
+			name: "passes when driver and nvattest are present",
+			input: Input{
+				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
+				NVAttestPresent: boolPtr(true),
+			},
+			wantPassed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := Evaluate(tt.input)
+
+			assert.Equal(t, tt.wantPassed, result.Passed())
+			for _, wantMessage := range tt.wantMessages {
+				assert.Contains(t, checkMessages(result.Checks), wantMessage)
+			}
+		})
+	}
+}
+
+func TestEvaluateAggregatesFailures(t *testing.T) {
+	t.Parallel()
+
+	result := Evaluate(Input{
+		MachineInfo:     machineInfoWithGPU("Ampere", ""),
+		NVAttestPresent: boolPtr(false),
+	})
+
+	assert.False(t, result.Passed())
+	assert.Contains(t, checkMessages(result.Checks), "unsupported GPU architecture: Ampere")
+	assert.Contains(t, checkMessages(result.Checks), "NVIDIA driver not detected")
+	assert.Contains(t, checkMessages(result.Checks), "nvattest not found in PATH")
+}
+
+func TestEvaluateDCGM(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        Input
+		wantPassed   bool
+		wantMessages []string
+	}{
+		{
+			name: "fails when dcgm is unreachable",
+			input: Input{
+				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
+				NVAttestPresent: boolPtr(true),
+				DCGMReachable:   boolPtr(false),
+			},
+			wantPassed: false,
+			wantMessages: []string{
+				"DCGM HostEngine is not reachable",
+			},
+		},
+		{
+			name: "fails when dcgm version is too old",
+			input: Input{
+				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
+				NVAttestPresent: boolPtr(true),
+				DCGMReachable:   boolPtr(true),
+				DCGMVersion:     "4.2.2",
+			},
+			wantPassed: false,
+			wantMessages: []string{
+				"DCGM HostEngine version 4.2.2 is below required minimum 4.2.3",
+			},
+		},
+		{
+			name: "passes for minimum supported dcgm version",
+			input: Input{
+				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
+				NVAttestPresent: boolPtr(true),
+				DCGMReachable:   boolPtr(true),
+				DCGMVersion:     "4.2.3",
+			},
+			wantPassed: true,
+		},
+		{
+			name: "passes for newer dcgm version",
+			input: Input{
+				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
+				NVAttestPresent: boolPtr(true),
+				DCGMReachable:   boolPtr(true),
+				DCGMVersion:     "4.3.0",
+			},
+			wantPassed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := Evaluate(tt.input)
+
+			assert.Equal(t, tt.wantPassed, result.Passed())
+			for _, wantMessage := range tt.wantMessages {
+				assert.Contains(t, checkMessages(result.Checks), wantMessage)
+			}
+		})
+	}
+}
+
+func TestEvaluateDCGMSkipsWhenReachabilityUnset(t *testing.T) {
+	t.Parallel()
+
+	result := Evaluate(Input{
+		MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
+		NVAttestPresent: boolPtr(true),
+	})
+
+	assert.True(t, result.Passed())
+	assert.Contains(t, checkMessages(result.Checks), "DCGM checks skipped")
+}
+
+func TestCollectInputCallsDCGMInit(t *testing.T) {
+	t.Parallel()
+
+	originalNewNVML := newNVML
+	originalLookPath := lookPath
+	originalDCGMInit := dcgmInit
+	originalGetHostengineVersion := getHostengineVersion
+	originalGetenv := getenv
+	t.Cleanup(func() {
+		newNVML = originalNewNVML
+		lookPath = originalLookPath
+		dcgmInit = originalDCGMInit
+		getHostengineVersion = originalGetHostengineVersion
+		getenv = originalGetenv
+	})
+
+	newNVML = func() (nvmlInstance, error) {
+		return nil, fmt.Errorf("skip nvml in test")
+	}
+	lookPath = func(file string) (string, error) {
+		return "/usr/bin/" + file, nil
+	}
+	getenv = func(string) string {
+		return ""
+	}
+
+	dcgmInitCalled := false
+	dcgmInit = func() (func(), error) {
+		dcgmInitCalled = true
+		return func() {}, nil
+	}
+	getHostengineVersion = func() (string, error) {
+		return "4.2.3", nil
+	}
+
+	input, err := CollectInput()
+
+	require.NoError(t, err)
+	require.NotNil(t, input.DCGMReachable)
+	assert.True(t, *input.DCGMReachable)
+	assert.Equal(t, "4.2.3", input.DCGMVersion)
+	assert.True(t, dcgmInitCalled)
+}
+
+func machineInfoWithGPU(architecture, driverVersion string) *machineinfo.MachineInfo {
+	return &machineinfo.MachineInfo{
+		GPUDriverVersion: driverVersion,
+		GPUInfo: &apiv1.MachineGPUInfo{
+			Architecture: architecture,
+			Product:      "test-gpu",
+			GPUs: []apiv1.MachineGPUInstance{
+				{UUID: "GPU-1"},
+			},
+		},
+	}
+}
+
+func checkMessages(checks []Check) []string {
+	messages := make([]string, 0, len(checks))
+	for _, check := range checks {
+		messages = append(messages, check.Message)
+	}
+	return messages
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}


### PR DESCRIPTION
## Summary
- add a shared precheck validator for GPU architecture, driver, DCGM, and nvattest prerequisites
- add `fleetint precheck` and gate `fleetint enroll` behind the same checks with a `--force` override
- add unit and CLI tests plus usage documentation for the new precheck flow

## Test Plan
- [x] go test ./...

[#1271] [#1341]