### PR TITLE
feat: add typed health incidents

### DIFF
--- a/internal/exporter/collector/collector.go
+++ b/internal/exporter/collector/collector.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
@@ -269,12 +270,16 @@ func (c *collector) collectComponentData(data *HealthData) error {
 		reason := "No health data"
 		var timeValue interface{}
 		var extraInfo interface{} = map[string]interface{}{} // Default to empty map for JSON marshaling
+		var incidents interface{} = []apiv1.HealthStateIncident{}
 
 		if len(healthStates) > 0 {
 			firstState := healthStates[0]
 			health = string(firstState.Health)
 			reason = firstState.Reason
 			timeValue = firstState.Time
+			if len(firstState.Incidents) > 0 {
+				incidents = firstState.Incidents
+			}
 
 			// Handle ExtraInfo - ensure it's properly set for JSON marshaling downstream
 			// ExtraInfo can be map[string]string, map[string]interface{}, or nil
@@ -303,6 +308,7 @@ func (c *collector) collectComponentData(data *HealthData) error {
 			"reason":         reason,
 			"time":           timeValue,
 			"extra_info":     extraInfo,
+			"incidents":      incidents,
 		}
 	}
 

--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -647,6 +647,14 @@ func TestCollector_CollectComponentData_WithComponents(t *testing.T) {
 				Reason:    "All checks passed",
 				Time:      metav1.Time{Time: time.Now()},
 				ExtraInfo: map[string]string{"key": "value"},
+				Incidents: []apiv1.HealthStateIncident{
+					{
+						DeviceID: "GPU-1234",
+						Message:  "Clock throttled",
+						Severity: apiv1.HealthStateTypeDegraded,
+						Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
+					},
+				},
 			},
 		},
 	}
@@ -669,6 +677,10 @@ func TestCollector_CollectComponentData_WithComponents(t *testing.T) {
 	assert.Equal(t, "test-component", dataMap["component_name"])
 	assert.Equal(t, "Healthy", dataMap["health"])
 	assert.Equal(t, "All checks passed", dataMap["reason"])
+	incidents, ok := dataMap["incidents"].([]apiv1.HealthStateIncident)
+	require.True(t, ok, "incidents should preserve the typed health incidents slice")
+	require.Len(t, incidents, 1)
+	assert.Equal(t, "GPU-1234", incidents[0].DeviceID)
 }
 
 func TestCollector_CollectComponentData_NoHealthStates(t *testing.T) {

--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -649,7 +649,7 @@ func TestCollector_CollectComponentData_WithComponents(t *testing.T) {
 				ExtraInfo: map[string]string{"key": "value"},
 				Incidents: []apiv1.HealthStateIncident{
 					{
-						DeviceID: "GPU-1234",
+						EntityID: "GPU-1234",
 						Message:  "Clock throttled",
 						Severity: apiv1.HealthStateTypeDegraded,
 						Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
@@ -680,7 +680,7 @@ func TestCollector_CollectComponentData_WithComponents(t *testing.T) {
 	incidents, ok := dataMap["incidents"].([]apiv1.HealthStateIncident)
 	require.True(t, ok, "incidents should preserve the typed health incidents slice")
 	require.Len(t, incidents, 1)
-	assert.Equal(t, "GPU-1234", incidents[0].DeviceID)
+	assert.Equal(t, "GPU-1234", incidents[0].EntityID)
 }
 
 func TestCollector_CollectComponentData_NoHealthStates(t *testing.T) {

--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -438,7 +438,7 @@ func incidentsToOTLPArrayValue(incidents []apiv1.HealthStateIncident) *commonv1.
 	values := make([]*commonv1.AnyValue, 0, len(incidents))
 	for _, inc := range incidents {
 		kvs := []*commonv1.KeyValue{
-			{Key: "device_id", Value: stringAnyValue(inc.DeviceID)},
+			{Key: "entity_id", Value: stringAnyValue(inc.EntityID)},
 			{Key: "message", Value: stringAnyValue(inc.Message)},
 			{Key: "severity", Value: stringAnyValue(string(inc.Severity))},
 			{Key: "error", Value: stringAnyValue(inc.Error)},

--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
 	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
@@ -341,6 +342,7 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 			reason := componentInfo["reason"]
 			timeVal := componentInfo["time"]
 			extraInfo := componentInfo["extra_info"]
+			incidents := componentInfo["incidents"]
 
 			attributes := []*commonv1.KeyValue{
 				{
@@ -391,6 +393,13 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 				}
 			}
 
+			if typedIncidents, ok := toHealthStateIncidents(incidents); ok && len(typedIncidents) > 0 {
+				attributes = append(attributes, &commonv1.KeyValue{
+					Key:   "incidents",
+					Value: incidentsToOTLPArrayValue(typedIncidents),
+				})
+			}
+
 			logRecord := &logsv1.LogRecord{
 				TimeUnixNano:   uint64(data.Timestamp.UnixNano()),
 				SeverityNumber: logsv1.SeverityNumber_SEVERITY_NUMBER_INFO,
@@ -422,6 +431,46 @@ func extraInfoToAnyValue(extraInfo map[string]string) *commonv1.AnyValue {
 		Value: &commonv1.AnyValue_KvlistValue{
 			KvlistValue: &commonv1.KeyValueList{Values: values},
 		},
+	}
+}
+
+func incidentsToOTLPArrayValue(incidents []apiv1.HealthStateIncident) *commonv1.AnyValue {
+	values := make([]*commonv1.AnyValue, 0, len(incidents))
+	for _, inc := range incidents {
+		kvs := []*commonv1.KeyValue{
+			{Key: "device_id", Value: stringAnyValue(inc.DeviceID)},
+			{Key: "message", Value: stringAnyValue(inc.Message)},
+			{Key: "severity", Value: stringAnyValue(string(inc.Severity))},
+			{Key: "error", Value: stringAnyValue(inc.Error)},
+		}
+		values = append(values, &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_KvlistValue{
+				KvlistValue: &commonv1.KeyValueList{Values: kvs},
+			},
+		})
+	}
+
+	return &commonv1.AnyValue{
+		Value: &commonv1.AnyValue_ArrayValue{
+			ArrayValue: &commonv1.ArrayValue{Values: values},
+		},
+	}
+}
+
+func toHealthStateIncidents(v interface{}) ([]apiv1.HealthStateIncident, bool) {
+	switch typed := v.(type) {
+	case []apiv1.HealthStateIncident:
+		return typed, true
+	case apiv1.HealthStateIncident:
+		return []apiv1.HealthStateIncident{typed}, true
+	default:
+		return nil, false
+	}
+}
+
+func stringAnyValue(v string) *commonv1.AnyValue {
+	return &commonv1.AnyValue{
+		Value: &commonv1.AnyValue_StringValue{StringValue: v},
 	}
 }
 

--- a/internal/exporter/converter/otlp_test.go
+++ b/internal/exporter/converter/otlp_test.go
@@ -258,6 +258,14 @@ func TestOTLPConverter_Convert_WithComponentData(t *testing.T) {
 					"device_uuid": "PCI:0000:04:00",
 					"data":        rawData,
 				},
+				"incidents": []apiv1.HealthStateIncident{
+					{
+						DeviceID: "GPU-1234",
+						Message:  "Clock throttled",
+						Severity: apiv1.HealthStateTypeDegraded,
+						Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
+					},
+				},
 			},
 		},
 	}
@@ -282,6 +290,16 @@ func TestOTLPConverter_Convert_WithComponentData(t *testing.T) {
 			require.NotEmpty(t, extraInfo)
 			assert.Contains(t, extraInfo, `"device_uuid":"PCI:0000:04:00"`)
 			assert.Contains(t, extraInfo, `"data":"{\"time\":\"2026-02-20T23:22:44Z\",\"data_source\":\"kmsg\",\"xid\":149}"`)
+
+			incidents := findAttribute(t, log.Attributes, "incidents").GetArrayValue()
+			require.NotNil(t, incidents)
+			require.Len(t, incidents.Values, 1)
+			incident := incidents.Values[0].GetKvlistValue()
+			require.NotNil(t, incident)
+			assert.Equal(t, "GPU-1234", findMapValue(t, incident.Values, "device_id").GetStringValue())
+			assert.Equal(t, "Clock throttled", findMapValue(t, incident.Values, "message").GetStringValue())
+			assert.Equal(t, "Degraded", findMapValue(t, incident.Values, "severity").GetStringValue())
+			assert.Equal(t, "DCGM_FR_CLOCK_THROTTLE_POWER", findMapValue(t, incident.Values, "error").GetStringValue())
 			found = true
 			break
 		}

--- a/internal/exporter/converter/otlp_test.go
+++ b/internal/exporter/converter/otlp_test.go
@@ -260,7 +260,7 @@ func TestOTLPConverter_Convert_WithComponentData(t *testing.T) {
 				},
 				"incidents": []apiv1.HealthStateIncident{
 					{
-						DeviceID: "GPU-1234",
+						EntityID: "GPU-1234",
 						Message:  "Clock throttled",
 						Severity: apiv1.HealthStateTypeDegraded,
 						Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
@@ -296,7 +296,7 @@ func TestOTLPConverter_Convert_WithComponentData(t *testing.T) {
 			require.Len(t, incidents.Values, 1)
 			incident := incidents.Values[0].GetKvlistValue()
 			require.NotNil(t, incident)
-			assert.Equal(t, "GPU-1234", findMapValue(t, incident.Values, "device_id").GetStringValue())
+			assert.Equal(t, "GPU-1234", findMapValue(t, incident.Values, "entity_id").GetStringValue())
 			assert.Equal(t, "Clock throttled", findMapValue(t, incident.Values, "message").GetStringValue())
 			assert.Equal(t, "Degraded", findMapValue(t, incident.Values, "severity").GetStringValue())
 			assert.Equal(t, "DCGM_FR_CLOCK_THROTTLE_POWER", findMapValue(t, incident.Values, "error").GetStringValue())

--- a/third_party/fleet-intelligence-sdk/api/v1/types.go
+++ b/third_party/fleet-intelligence-sdk/api/v1/types.go
@@ -101,8 +101,8 @@ type HealthState struct {
 
 // HealthStateIncident represents a discrete fault detected during a component check.
 type HealthStateIncident struct {
-	// DeviceID identifies the affected entity, such as GPU UUID or device name.
-	DeviceID string `json:"device_id,omitempty"`
+	// EntityID identifies the affected entity.
+	EntityID string `json:"entity_id,omitempty"`
 	// Message is the human-readable description of the fault.
 	Message string `json:"message"`
 	// Severity mirrors HealthState health levels.

--- a/third_party/fleet-intelligence-sdk/api/v1/types.go
+++ b/third_party/fleet-intelligence-sdk/api/v1/types.go
@@ -89,11 +89,26 @@ type HealthState struct {
 	// ExtraInfo represents the extra information of the state.
 	ExtraInfo map[string]string `json:"extra_info,omitempty"`
 
+	// Incidents contains structured per-device faults detected during the check.
+	Incidents []HealthStateIncident `json:"incidents,omitempty"`
+
 	// RawOutput represents the raw output of the health checker.
 	// e.g., If a custom plugin runs a Python script, the raw output
 	// is the stdout/stderr of the script.
 	// The maximum length of the raw output is 4096 bytes.
 	RawOutput string `json:"raw_output,omitempty"`
+}
+
+// HealthStateIncident represents a discrete fault detected during a component check.
+type HealthStateIncident struct {
+	// DeviceID identifies the affected entity, such as GPU UUID or device name.
+	DeviceID string `json:"device_id,omitempty"`
+	// Message is the human-readable description of the fault.
+	Message string `json:"message"`
+	// Severity mirrors HealthState health levels.
+	Severity HealthStateType `json:"severity,omitempty"`
+	// Error is a symbolic error identifier when available.
+	Error string `json:"error,omitempty"`
 }
 
 type HealthStates []HealthState

--- a/third_party/fleet-intelligence-sdk/api/v1/types_test.go
+++ b/third_party/fleet-intelligence-sdk/api/v1/types_test.go
@@ -15,7 +15,7 @@ func TestHealthState_JSONIncludesIncidents(t *testing.T) {
 		Health:    HealthStateTypeDegraded,
 		Incidents: []HealthStateIncident{
 			{
-				DeviceID: "GPU-1234",
+				EntityID: "GPU-0",
 				Message:  "Clock throttled",
 				Severity: HealthStateTypeDegraded,
 				Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
@@ -31,7 +31,7 @@ func TestHealthState_JSONIncludesIncidents(t *testing.T) {
 	got := string(data)
 	for _, want := range []string{
 		`"incidents":[`,
-		`"device_id":"GPU-1234"`,
+		`"entity_id":"GPU-0"`,
 		`"message":"Clock throttled"`,
 		`"severity":"Degraded"`,
 		`"error":"DCGM_FR_CLOCK_THROTTLE_POWER"`,

--- a/third_party/fleet-intelligence-sdk/api/v1/types_test.go
+++ b/third_party/fleet-intelligence-sdk/api/v1/types_test.go
@@ -5,8 +5,42 @@ package v1
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 )
+
+func TestHealthState_JSONIncludesIncidents(t *testing.T) {
+	state := HealthState{
+		Component: "accelerator-nvidia-dcgm-power",
+		Health:    HealthStateTypeDegraded,
+		Incidents: []HealthStateIncident{
+			{
+				DeviceID: "GPU-1234",
+				Message:  "Clock throttled",
+				Severity: HealthStateTypeDegraded,
+				Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
+			},
+		},
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	got := string(data)
+	for _, want := range []string{
+		`"incidents":[`,
+		`"device_id":"GPU-1234"`,
+		`"message":"Clock throttled"`,
+		`"severity":"Degraded"`,
+		`"error":"DCGM_FR_CLOCK_THROTTLE_POWER"`,
+	} {
+		if !bytes.Contains(data, []byte(want)) {
+			t.Fatalf("Marshal() = %s, want substring %s", got, want)
+		}
+	}
+}
 
 func TestEventTypeFromString(t *testing.T) {
 	tests := []struct {
@@ -262,7 +296,7 @@ func TestMachineGPUInfo_RenderTable(t *testing.T) {
 					},
 				},
 			},
-			wantContains: []string{"UUID", "GPU INDEX", "SN", "MINOR ID", "GPU-abc123", "SN12345", "0"},		},
+			wantContains: []string{"UUID", "GPU INDEX", "SN", "MINOR ID", "GPU-abc123", "SN12345", "0"}},
 		{
 			name: "Multiple GPUs",
 			gpuInfo: MachineGPUInfo{
@@ -272,16 +306,16 @@ func TestMachineGPUInfo_RenderTable(t *testing.T) {
 				Memory:       "40GB",
 				GPUs: []MachineGPUInstance{
 					{
-						UUID:    "GPU-abc123",
+						UUID:     "GPU-abc123",
 						GPUIndex: "0",
-						SN:      "SN12345",
-						MinorID: "0",
+						SN:       "SN12345",
+						MinorID:  "0",
 					},
 					{
-						UUID:    "GPU-def456",
+						UUID:     "GPU-def456",
 						GPUIndex: "1",
-						SN:      "SN67890",
-						MinorID: "1",
+						SN:       "SN67890",
+						MinorID:  "1",
 					},
 				},
 			},

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
@@ -18,8 +18,6 @@ package common
 
 import (
 	"fmt"
-	"sort"
-	"strings"
 
 	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
 
@@ -253,27 +251,16 @@ func FormatIncidents(prefix string, incidents []EnrichedIncident) string {
 	}
 
 	devices := make(map[string]struct{})
-	codes := make(map[string]struct{})
 	for _, incident := range incidents {
 		if incident.UUID != "" {
 			devices[incident.UUID] = struct{}{}
 		}
-		if incident.ErrorCode != "" {
-			codes[incident.ErrorCode] = struct{}{}
-		}
 	}
 
-	codeList := make([]string, 0, len(codes))
-	for code := range codes {
-		codeList = append(codeList, code)
-	}
-	sort.Strings(codeList)
-
-	return fmt.Sprintf("%s: %d incident(s) across %d device(s) [%s]",
+	return fmt.Sprintf("%s: %d incident(s) across %d device(s)",
 		prefix,
 		len(incidents),
 		len(devices),
-		strings.Join(codeList, ", "),
 	)
 }
 

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
@@ -18,10 +18,150 @@ package common
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+
+	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 )
+
+var healthCheckErrorCodeNames = map[dcgm.HealthCheckErrorCode]string{
+	dcgm.DCGM_FR_OK:                              "DCGM_FR_OK",
+	dcgm.DCGM_FR_UNKNOWN:                         "DCGM_FR_UNKNOWN",
+	dcgm.DCGM_FR_UNRECOGNIZED:                    "DCGM_FR_UNRECOGNIZED",
+	dcgm.DCGM_FR_PCI_REPLAY_RATE:                 "DCGM_FR_PCI_REPLAY_RATE",
+	dcgm.DCGM_FR_VOLATILE_DBE_DETECTED:           "DCGM_FR_VOLATILE_DBE_DETECTED",
+	dcgm.DCGM_FR_VOLATILE_SBE_DETECTED:           "DCGM_FR_VOLATILE_SBE_DETECTED",
+	dcgm.DCGM_FR_VOLATILE_SBE_DETECTED_TS:        "DCGM_FR_VOLATILE_SBE_DETECTED_TS",
+	dcgm.DCGM_FR_RETIRED_PAGES_LIMIT:             "DCGM_FR_RETIRED_PAGES_LIMIT",
+	dcgm.DCGM_FR_RETIRED_PAGES_DBE_LIMIT:         "DCGM_FR_RETIRED_PAGES_DBE_LIMIT",
+	dcgm.DCGM_FR_CORRUPT_INFOROM:                 "DCGM_FR_CORRUPT_INFOROM",
+	dcgm.DCGM_FR_CLOCK_THROTTLE_THERMAL:          "DCGM_FR_CLOCK_THROTTLE_THERMAL",
+	dcgm.DCGM_FR_POWER_UNREADABLE:                "DCGM_FR_POWER_UNREADABLE",
+	dcgm.DCGM_FR_CLOCK_THROTTLE_POWER:            "DCGM_FR_CLOCK_THROTTLE_POWER",
+	dcgm.DCGM_FR_NVLINK_ERROR_THRESHOLD:          "DCGM_FR_NVLINK_ERROR_THRESHOLD",
+	dcgm.DCGM_FR_NVLINK_DOWN:                     "DCGM_FR_NVLINK_DOWN",
+	dcgm.DCGM_FR_NVSWITCH_FATAL_ERROR:            "DCGM_FR_NVSWITCH_FATAL_ERROR",
+	dcgm.DCGM_FR_NVSWITCH_NON_FATAL_ERROR:        "DCGM_FR_NVSWITCH_NON_FATAL_ERROR",
+	dcgm.DCGM_FR_NVSWITCH_DOWN:                   "DCGM_FR_NVSWITCH_DOWN",
+	dcgm.DCGM_FR_NO_ACCESS_TO_FILE:               "DCGM_FR_NO_ACCESS_TO_FILE",
+	dcgm.DCGM_FR_NVML_API:                        "DCGM_FR_NVML_API",
+	dcgm.DCGM_FR_DEVICE_COUNT_MISMATCH:           "DCGM_FR_DEVICE_COUNT_MISMATCH",
+	dcgm.DCGM_FR_BAD_PARAMETER:                   "DCGM_FR_BAD_PARAMETER",
+	dcgm.DCGM_FR_CANNOT_OPEN_LIB:                 "DCGM_FR_CANNOT_OPEN_LIB",
+	dcgm.DCGM_FR_DENYLISTED_DRIVER:               "DCGM_FR_DENYLISTED_DRIVER",
+	dcgm.DCGM_FR_NVML_LIB_BAD:                    "DCGM_FR_NVML_LIB_BAD",
+	dcgm.DCGM_FR_GRAPHICS_PROCESSES:              "DCGM_FR_GRAPHICS_PROCESSES",
+	dcgm.DCGM_FR_HOSTENGINE_CONN:                 "DCGM_FR_HOSTENGINE_CONN",
+	dcgm.DCGM_FR_FIELD_QUERY:                     "DCGM_FR_FIELD_QUERY",
+	dcgm.DCGM_FR_BAD_CUDA_ENV:                    "DCGM_FR_BAD_CUDA_ENV",
+	dcgm.DCGM_FR_PERSISTENCE_MODE:                "DCGM_FR_PERSISTENCE_MODE",
+	dcgm.DCGM_FR_LOW_BANDWIDTH:                   "DCGM_FR_LOW_BANDWIDTH",
+	dcgm.DCGM_FR_HIGH_LATENCY:                    "DCGM_FR_HIGH_LATENCY",
+	dcgm.DCGM_FR_CANNOT_GET_FIELD_TAG:            "DCGM_FR_CANNOT_GET_FIELD_TAG",
+	dcgm.DCGM_FR_FIELD_VIOLATION:                 "DCGM_FR_FIELD_VIOLATION",
+	dcgm.DCGM_FR_FIELD_THRESHOLD:                 "DCGM_FR_FIELD_THRESHOLD",
+	dcgm.DCGM_FR_FIELD_VIOLATION_DBL:             "DCGM_FR_FIELD_VIOLATION_DBL",
+	dcgm.DCGM_FR_FIELD_THRESHOLD_DBL:             "DCGM_FR_FIELD_THRESHOLD_DBL",
+	dcgm.DCGM_FR_UNSUPPORTED_FIELD_TYPE:          "DCGM_FR_UNSUPPORTED_FIELD_TYPE",
+	dcgm.DCGM_FR_FIELD_THRESHOLD_TS:              "DCGM_FR_FIELD_THRESHOLD_TS",
+	dcgm.DCGM_FR_FIELD_THRESHOLD_TS_DBL:          "DCGM_FR_FIELD_THRESHOLD_TS_DBL",
+	dcgm.DCGM_FR_THERMAL_VIOLATIONS:              "DCGM_FR_THERMAL_VIOLATIONS",
+	dcgm.DCGM_FR_THERMAL_VIOLATIONS_TS:           "DCGM_FR_THERMAL_VIOLATIONS_TS",
+	dcgm.DCGM_FR_TEMP_VIOLATION:                  "DCGM_FR_TEMP_VIOLATION",
+	dcgm.DCGM_FR_THROTTLING_VIOLATION:            "DCGM_FR_THROTTLING_VIOLATION",
+	dcgm.DCGM_FR_INTERNAL:                        "DCGM_FR_INTERNAL",
+	dcgm.DCGM_FR_PCIE_GENERATION:                 "DCGM_FR_PCIE_GENERATION",
+	dcgm.DCGM_FR_PCIE_WIDTH:                      "DCGM_FR_PCIE_WIDTH",
+	dcgm.DCGM_FR_ABORTED:                         "DCGM_FR_ABORTED",
+	dcgm.DCGM_FR_TEST_DISABLED:                   "DCGM_FR_TEST_DISABLED",
+	dcgm.DCGM_FR_CANNOT_GET_STAT:                 "DCGM_FR_CANNOT_GET_STAT",
+	dcgm.DCGM_FR_STRESS_LEVEL:                    "DCGM_FR_STRESS_LEVEL",
+	dcgm.DCGM_FR_CUDA_API:                        "DCGM_FR_CUDA_API",
+	dcgm.DCGM_FR_FAULTY_MEMORY:                   "DCGM_FR_FAULTY_MEMORY",
+	dcgm.DCGM_FR_CANNOT_SET_WATCHES:              "DCGM_FR_CANNOT_SET_WATCHES",
+	dcgm.DCGM_FR_CUDA_UNBOUND:                    "DCGM_FR_CUDA_UNBOUND",
+	dcgm.DCGM_FR_ECC_DISABLED:                    "DCGM_FR_ECC_DISABLED",
+	dcgm.DCGM_FR_MEMORY_ALLOC:                    "DCGM_FR_MEMORY_ALLOC",
+	dcgm.DCGM_FR_CUDA_DBE:                        "DCGM_FR_CUDA_DBE",
+	dcgm.DCGM_FR_MEMORY_MISMATCH:                 "DCGM_FR_MEMORY_MISMATCH",
+	dcgm.DCGM_FR_CUDA_DEVICE:                     "DCGM_FR_CUDA_DEVICE",
+	dcgm.DCGM_FR_ECC_UNSUPPORTED:                 "DCGM_FR_ECC_UNSUPPORTED",
+	dcgm.DCGM_FR_ECC_PENDING:                     "DCGM_FR_ECC_PENDING",
+	dcgm.DCGM_FR_MEMORY_BANDWIDTH:                "DCGM_FR_MEMORY_BANDWIDTH",
+	dcgm.DCGM_FR_TARGET_POWER:                    "DCGM_FR_TARGET_POWER",
+	dcgm.DCGM_FR_API_FAIL:                        "DCGM_FR_API_FAIL",
+	dcgm.DCGM_FR_API_FAIL_GPU:                    "DCGM_FR_API_FAIL_GPU",
+	dcgm.DCGM_FR_CUDA_CONTEXT:                    "DCGM_FR_CUDA_CONTEXT",
+	dcgm.DCGM_FR_DCGM_API:                        "DCGM_FR_DCGM_API",
+	dcgm.DCGM_FR_CONCURRENT_GPUS:                 "DCGM_FR_CONCURRENT_GPUS",
+	dcgm.DCGM_FR_TOO_MANY_ERRORS:                 "DCGM_FR_TOO_MANY_ERRORS",
+	dcgm.DCGM_FR_NVLINK_CRC_ERROR_THRESHOLD:      "DCGM_FR_NVLINK_CRC_ERROR_THRESHOLD",
+	dcgm.DCGM_FR_NVLINK_ERROR_CRITICAL:           "DCGM_FR_NVLINK_ERROR_CRITICAL",
+	dcgm.DCGM_FR_ENFORCED_POWER_LIMIT:            "DCGM_FR_ENFORCED_POWER_LIMIT",
+	dcgm.DCGM_FR_MEMORY_ALLOC_HOST:               "DCGM_FR_MEMORY_ALLOC_HOST",
+	dcgm.DCGM_FR_GPU_OP_MODE:                     "DCGM_FR_GPU_OP_MODE",
+	dcgm.DCGM_FR_NO_MEMORY_CLOCKS:                "DCGM_FR_NO_MEMORY_CLOCKS",
+	dcgm.DCGM_FR_NO_GRAPHICS_CLOCKS:              "DCGM_FR_NO_GRAPHICS_CLOCKS",
+	dcgm.DCGM_FR_HAD_TO_RESTORE_STATE:            "DCGM_FR_HAD_TO_RESTORE_STATE",
+	dcgm.DCGM_FR_L1TAG_UNSUPPORTED:               "DCGM_FR_L1TAG_UNSUPPORTED",
+	dcgm.DCGM_FR_L1TAG_MISCOMPARE:                "DCGM_FR_L1TAG_MISCOMPARE",
+	dcgm.DCGM_FR_ROW_REMAP_FAILURE:               "DCGM_FR_ROW_REMAP_FAILURE",
+	dcgm.DCGM_FR_UNCONTAINED_ERROR:               "DCGM_FR_UNCONTAINED_ERROR",
+	dcgm.DCGM_FR_EMPTY_GPU_LIST:                  "DCGM_FR_EMPTY_GPU_LIST",
+	dcgm.DCGM_FR_DBE_PENDING_PAGE_RETIREMENTS:    "DCGM_FR_DBE_PENDING_PAGE_RETIREMENTS",
+	dcgm.DCGM_FR_UNCORRECTABLE_ROW_REMAP:         "DCGM_FR_UNCORRECTABLE_ROW_REMAP",
+	dcgm.DCGM_FR_PENDING_ROW_REMAP:               "DCGM_FR_PENDING_ROW_REMAP",
+	dcgm.DCGM_FR_BROKEN_P2P_MEMORY_DEVICE:        "DCGM_FR_BROKEN_P2P_MEMORY_DEVICE",
+	dcgm.DCGM_FR_BROKEN_P2P_WRITER_DEVICE:        "DCGM_FR_BROKEN_P2P_WRITER_DEVICE",
+	dcgm.DCGM_FR_NVSWITCH_NVLINK_DOWN:            "DCGM_FR_NVSWITCH_NVLINK_DOWN",
+	dcgm.DCGM_FR_EUD_BINARY_PERMISSIONS:          "DCGM_FR_EUD_BINARY_PERMISSIONS",
+	dcgm.DCGM_FR_EUD_NON_ROOT_USER:               "DCGM_FR_EUD_NON_ROOT_USER",
+	dcgm.DCGM_FR_EUD_SPAWN_FAILURE:               "DCGM_FR_EUD_SPAWN_FAILURE",
+	dcgm.DCGM_FR_EUD_TIMEOUT:                     "DCGM_FR_EUD_TIMEOUT",
+	dcgm.DCGM_FR_EUD_ZOMBIE:                      "DCGM_FR_EUD_ZOMBIE",
+	dcgm.DCGM_FR_EUD_NON_ZERO_EXIT_CODE:          "DCGM_FR_EUD_NON_ZERO_EXIT_CODE",
+	dcgm.DCGM_FR_EUD_TEST_FAILED:                 "DCGM_FR_EUD_TEST_FAILED",
+	dcgm.DCGM_FR_FILE_CREATE_PERMISSIONS:         "DCGM_FR_FILE_CREATE_PERMISSIONS",
+	dcgm.DCGM_FR_PAUSE_RESUME_FAILED:             "DCGM_FR_PAUSE_RESUME_FAILED",
+	dcgm.DCGM_FR_PCIE_H_REPLAY_VIOLATION:         "DCGM_FR_PCIE_H_REPLAY_VIOLATION",
+	dcgm.DCGM_FR_GPU_EXPECTED_NVLINKS_UP:         "DCGM_FR_GPU_EXPECTED_NVLINKS_UP",
+	dcgm.DCGM_FR_NVSWITCH_EXPECTED_NVLINKS_UP:    "DCGM_FR_NVSWITCH_EXPECTED_NVLINKS_UP",
+	dcgm.DCGM_FR_XID_ERROR:                       "DCGM_FR_XID_ERROR",
+	dcgm.DCGM_FR_SBE_VIOLATION:                   "DCGM_FR_SBE_VIOLATION",
+	dcgm.DCGM_FR_DBE_VIOLATION:                   "DCGM_FR_DBE_VIOLATION",
+	dcgm.DCGM_FR_PCIE_REPLAY_VIOLATION:           "DCGM_FR_PCIE_REPLAY_VIOLATION",
+	dcgm.DCGM_FR_SBE_THRESHOLD_VIOLATION:         "DCGM_FR_SBE_THRESHOLD_VIOLATION",
+	dcgm.DCGM_FR_DBE_THRESHOLD_VIOLATION:         "DCGM_FR_DBE_THRESHOLD_VIOLATION",
+	dcgm.DCGM_FR_PCIE_REPLAY_THRESHOLD_VIOLATION: "DCGM_FR_PCIE_REPLAY_THRESHOLD_VIOLATION",
+	dcgm.DCGM_FR_CUDA_FM_NOT_INITIALIZED:         "DCGM_FR_CUDA_FM_NOT_INITIALIZED",
+	dcgm.DCGM_FR_SXID_ERROR:                      "DCGM_FR_SXID_ERROR",
+	dcgm.DCGM_FR_GFLOPS_THRESHOLD_VIOLATION:      "DCGM_FR_GFLOPS_THRESHOLD_VIOLATION",
+	dcgm.DCGM_FR_NAN_VALUE:                       "DCGM_FR_NAN_VALUE",
+	dcgm.DCGM_FR_FABRIC_MANAGER_TRAINING_ERROR:   "DCGM_FR_FABRIC_MANAGER_TRAINING_ERROR",
+	dcgm.DCGM_FR_BROKEN_P2P_PCIE_MEMORY_DEVICE:   "DCGM_FR_BROKEN_P2P_PCIE_MEMORY_DEVICE",
+	dcgm.DCGM_FR_BROKEN_P2P_PCIE_WRITER_DEVICE:   "DCGM_FR_BROKEN_P2P_PCIE_WRITER_DEVICE",
+	dcgm.DCGM_FR_BROKEN_P2P_NVLINK_MEMORY_DEVICE: "DCGM_FR_BROKEN_P2P_NVLINK_MEMORY_DEVICE",
+	dcgm.DCGM_FR_BROKEN_P2P_NVLINK_WRITER_DEVICE: "DCGM_FR_BROKEN_P2P_NVLINK_WRITER_DEVICE",
+	dcgm.DCGM_FR_ERROR_SENTINEL:                  "DCGM_FR_ERROR_SENTINEL",
+}
+
+var healthSystemNames = map[dcgm.HealthSystem]string{
+	dcgm.DCGM_HEALTH_WATCH_PCIE:              "DCGM_HEALTH_WATCH_PCIE",
+	dcgm.DCGM_HEALTH_WATCH_NVLINK:            "DCGM_HEALTH_WATCH_NVLINK",
+	dcgm.DCGM_HEALTH_WATCH_PMU:               "DCGM_HEALTH_WATCH_PMU",
+	dcgm.DCGM_HEALTH_WATCH_MCU:               "DCGM_HEALTH_WATCH_MCU",
+	dcgm.DCGM_HEALTH_WATCH_MEM:               "DCGM_HEALTH_WATCH_MEM",
+	dcgm.DCGM_HEALTH_WATCH_SM:                "DCGM_HEALTH_WATCH_SM",
+	dcgm.DCGM_HEALTH_WATCH_INFOROM:           "DCGM_HEALTH_WATCH_INFOROM",
+	dcgm.DCGM_HEALTH_WATCH_THERMAL:           "DCGM_HEALTH_WATCH_THERMAL",
+	dcgm.DCGM_HEALTH_WATCH_POWER:             "DCGM_HEALTH_WATCH_POWER",
+	dcgm.DCGM_HEALTH_WATCH_DRIVER:            "DCGM_HEALTH_WATCH_DRIVER",
+	dcgm.DCGM_HEALTH_WATCH_NVSWITCH_NONFATAL: "DCGM_HEALTH_WATCH_NVSWITCH_NONFATAL",
+	dcgm.DCGM_HEALTH_WATCH_NVSWITCH_FATAL:    "DCGM_HEALTH_WATCH_NVSWITCH_FATAL",
+	dcgm.DCGM_HEALTH_WATCH_ALL:               "DCGM_HEALTH_WATCH_ALL",
+}
 
 // EnrichedIncident represents a DCGM incident with entity ID mapped to UUID for better usability.
 type EnrichedIncident struct {
@@ -29,12 +169,12 @@ type EnrichedIncident struct {
 	UUID string `json:"uuid"`
 	// error message from the incident
 	Message string `json:"message"`
-	// error code from the incident
-	Code interface{} `json:"code"`
-	// health system that reported the incident
-	System dcgm.HealthSystem `json:"system"`
-	// health result level (PASS/WARN/FAIL)
-	Health dcgm.HealthResult `json:"health"`
+	// symbolic DCGM_FR_* error code
+	ErrorCode string `json:"code"`
+	// symbolic DCGM_HEALTH_WATCH_* system name
+	System string `json:"system"`
+	// health result level mapped to API severity
+	Severity apiv1.HealthStateType `json:"health"`
 }
 
 // EnrichIncidents transforms DCGM incidents by mapping entity IDs to UUIDs.
@@ -54,32 +194,112 @@ func EnrichIncidents(incidents []dcgm.Incident, deviceMapping map[uint]string) [
 		}
 
 		enriched = append(enriched, EnrichedIncident{
-			UUID:    uuid,
-			Message: incident.Error.Message,
-			Code:    incident.Error.Code,
-			System:  incident.System,
-			Health:  incident.Health,
+			UUID:      uuid,
+			Message:   incident.Error.Message,
+			ErrorCode: healthCheckErrorCodeString(incident.Error.Code),
+			System:    healthSystemString(incident.System),
+			Severity:  healthResultToSeverity(incident.Health),
 		})
 	}
 
 	return enriched
 }
 
+// EnrichSwitchIncidents transforms NVSwitch incidents using switch-specific identifiers.
+func EnrichSwitchIncidents(incidents []dcgm.Incident) []EnrichedIncident {
+	if len(incidents) == 0 {
+		return nil
+	}
+
+	enriched := make([]EnrichedIncident, 0, len(incidents))
+	for _, incident := range incidents {
+		enriched = append(enriched, EnrichedIncident{
+			UUID:      fmt.Sprintf("nvswitch-%d", incident.EntityInfo.EntityId),
+			Message:   incident.Error.Message,
+			ErrorCode: healthCheckErrorCodeString(incident.Error.Code),
+			System:    healthSystemString(incident.System),
+			Severity:  healthResultToSeverity(incident.Health),
+		})
+	}
+
+	return enriched
+}
+
+func (e EnrichedIncident) ToHealthStateIncident() apiv1.HealthStateIncident {
+	return apiv1.HealthStateIncident{
+		DeviceID: e.UUID,
+		Message:  e.Message,
+		Severity: e.Severity,
+		Error:    e.ErrorCode,
+	}
+}
+
+func ToHealthStateIncidents(incidents []EnrichedIncident) []apiv1.HealthStateIncident {
+	if len(incidents) == 0 {
+		return nil
+	}
+
+	result := make([]apiv1.HealthStateIncident, 0, len(incidents))
+	for _, incident := range incidents {
+		result = append(result, incident.ToHealthStateIncident())
+	}
+	return result
+}
+
 // FormatIncidents formats enriched DCGM incidents into a human-readable string.
-// Formats enriched DCGM incidents with UUIDs into a human-readable string.
 func FormatIncidents(prefix string, incidents []EnrichedIncident) string {
 	if len(incidents) == 0 {
 		return prefix
 	}
 
-	var parts []string
+	devices := make(map[string]struct{})
+	codes := make(map[string]struct{})
 	for _, incident := range incidents {
-		msg := fmt.Sprintf("GPU %s: %s (code: %v)",
-			incident.UUID,
-			incident.Message,
-			incident.Code)
-		parts = append(parts, msg)
+		if incident.UUID != "" {
+			devices[incident.UUID] = struct{}{}
+		}
+		if incident.ErrorCode != "" {
+			codes[incident.ErrorCode] = struct{}{}
+		}
 	}
 
-	return fmt.Sprintf("%s - %s", prefix, strings.Join(parts, "; "))
+	codeList := make([]string, 0, len(codes))
+	for code := range codes {
+		codeList = append(codeList, code)
+	}
+	sort.Strings(codeList)
+
+	return fmt.Sprintf("%s: %d incident(s) across %d device(s) [%s]",
+		prefix,
+		len(incidents),
+		len(devices),
+		strings.Join(codeList, ", "),
+	)
+}
+
+func healthCheckErrorCodeString(code dcgm.HealthCheckErrorCode) string {
+	// Some DCGM codes have multiple macro aliases for the same numeric value.
+	// We return the first canonical name defined in the pinned go-dcgm constants.
+	if name, ok := healthCheckErrorCodeNames[code]; ok {
+		return name
+	}
+	return fmt.Sprintf("DCGM_FR_UNKNOWN(%d)", code)
+}
+
+func healthSystemString(system dcgm.HealthSystem) string {
+	if name, ok := healthSystemNames[system]; ok {
+		return name
+	}
+	return fmt.Sprintf("DCGM_HEALTH_WATCH_UNKNOWN(0x%X)", uint(system))
+}
+
+func healthResultToSeverity(result dcgm.HealthResult) apiv1.HealthStateType {
+	switch result {
+	case dcgm.DCGM_HEALTH_RESULT_WARN:
+		return apiv1.HealthStateTypeDegraded
+	case dcgm.DCGM_HEALTH_RESULT_FAIL:
+		return apiv1.HealthStateTypeUnhealthy
+	default:
+		return ""
+	}
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
@@ -165,6 +165,8 @@ var healthSystemNames = map[dcgm.HealthSystem]string{
 type EnrichedIncident struct {
 	// GPU UUID mapped from entity ID
 	UUID string `json:"uuid"`
+	// entity identifier derived from DCGM entity type and entity ID
+	EntityID string `json:"-"`
 	// error message from the incident
 	Message string `json:"message"`
 	// symbolic DCGM_FR_* error code
@@ -193,6 +195,7 @@ func EnrichIncidents(incidents []dcgm.Incident, deviceMapping map[uint]string) [
 
 		enriched = append(enriched, EnrichedIncident{
 			UUID:      uuid,
+			EntityID:  dcgmEntityID(incident.EntityInfo),
 			Message:   incident.Error.Message,
 			ErrorCode: healthCheckErrorCodeString(incident.Error.Code),
 			System:    healthSystemString(incident.System),
@@ -213,6 +216,7 @@ func EnrichSwitchIncidents(incidents []dcgm.Incident) []EnrichedIncident {
 	for _, incident := range incidents {
 		enriched = append(enriched, EnrichedIncident{
 			UUID:      fmt.Sprintf("nvswitch-%d", incident.EntityInfo.EntityId),
+			EntityID:  dcgmEntityID(incident.EntityInfo),
 			Message:   incident.Error.Message,
 			ErrorCode: healthCheckErrorCodeString(incident.Error.Code),
 			System:    healthSystemString(incident.System),
@@ -225,11 +229,15 @@ func EnrichSwitchIncidents(incidents []dcgm.Incident) []EnrichedIncident {
 
 func (e EnrichedIncident) ToHealthStateIncident() apiv1.HealthStateIncident {
 	return apiv1.HealthStateIncident{
-		DeviceID: e.UUID,
+		EntityID: e.EntityID,
 		Message:  e.Message,
 		Severity: e.Severity,
 		Error:    e.ErrorCode,
 	}
+}
+
+func dcgmEntityID(entity dcgm.GroupEntityPair) string {
+	return fmt.Sprintf("%s-%d", entity.EntityGroupId.String(), entity.EntityId)
 }
 
 func ToHealthStateIncidents(incidents []EnrichedIncident) []apiv1.HealthStateIncident {

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
@@ -87,6 +87,7 @@ func TestToHealthStateIncidents(t *testing.T) {
 	got := ToHealthStateIncidents([]EnrichedIncident{
 		{
 			UUID:      "GPU-1234",
+			EntityID:  "GPU-0",
 			Message:   "Power violation",
 			ErrorCode: "DCGM_FR_POWER_VIOLATION",
 			Severity:  apiv1.HealthStateTypeUnhealthy,
@@ -98,7 +99,7 @@ func TestToHealthStateIncidents(t *testing.T) {
 	}
 
 	want := apiv1.HealthStateIncident{
-		DeviceID: "GPU-1234",
+		EntityID: "GPU-0",
 		Message:  "Power violation",
 		Severity: apiv1.HealthStateTypeUnhealthy,
 		Error:    "DCGM_FR_POWER_VIOLATION",

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+
+	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 )
 
 func TestFormatEnrichedIncidents(t *testing.T) {
@@ -45,29 +47,29 @@ func TestFormatEnrichedIncidents(t *testing.T) {
 			prefix: "thermal warning",
 			incidents: []EnrichedIncident{
 				{
-					UUID:    "GPU-46a3bbe2-3e87-3dde-b464-a03eba0c21d7",
-					Message: "Temperature above threshold",
-					Code:    dcgm.DCGM_FR_TEMP_VIOLATION,
+					UUID:      "GPU-46a3bbe2-3e87-3dde-b464-a03eba0c21d7",
+					Message:   "Temperature above threshold",
+					ErrorCode: "DCGM_FR_TEMP_VIOLATION",
 				},
 			},
-			want: "thermal warning - GPU GPU-46a3bbe2-3e87-3dde-b464-a03eba0c21d7: Temperature above threshold (code: 42)",
+			want: "thermal warning: 1 incident(s) across 1 device(s) [DCGM_FR_TEMP_VIOLATION]",
 		},
 		{
 			name:   "multiple incidents",
 			prefix: "memory failure",
 			incidents: []EnrichedIncident{
 				{
-					UUID:    "GPU-46a3bbe2-3e87-3dde-b464-a03eba0c21d7",
-					Message: "DBE detected",
-					Code:    dcgm.DCGM_FR_VOLATILE_DBE_DETECTED,
+					UUID:      "GPU-46a3bbe2-3e87-3dde-b464-a03eba0c21d7",
+					Message:   "DBE detected",
+					ErrorCode: "DCGM_FR_VOLATILE_DBE_DETECTED",
 				},
 				{
-					UUID:    "GPU-7b4f2c1a-8d6e-4c5b-9a1f-2e3d4c5a6b7c",
-					Message: "Row remap failure",
-					Code:    dcgm.DCGM_FR_ROW_REMAP_FAILURE,
+					UUID:      "GPU-7b4f2c1a-8d6e-4c5b-9a1f-2e3d4c5a6b7c",
+					Message:   "Row remap failure",
+					ErrorCode: "DCGM_FR_ROW_REMAP_FAILURE",
 				},
 			},
-			want: "memory failure - GPU GPU-46a3bbe2-3e87-3dde-b464-a03eba0c21d7: DBE detected (code: 4); GPU GPU-7b4f2c1a-8d6e-4c5b-9a1f-2e3d4c5a6b7c: Row remap failure (code: 80)",
+			want: "memory failure: 2 incident(s) across 2 device(s) [DCGM_FR_ROW_REMAP_FAILURE, DCGM_FR_VOLATILE_DBE_DETECTED]",
 		},
 	}
 
@@ -78,5 +80,100 @@ func TestFormatEnrichedIncidents(t *testing.T) {
 				t.Errorf("FormatIncidents() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestToHealthStateIncidents(t *testing.T) {
+	got := ToHealthStateIncidents([]EnrichedIncident{
+		{
+			UUID:      "GPU-1234",
+			Message:   "Power violation",
+			ErrorCode: "DCGM_FR_POWER_VIOLATION",
+			Severity:  apiv1.HealthStateTypeUnhealthy,
+		},
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("len(ToHealthStateIncidents()) = %d, want 1", len(got))
+	}
+
+	want := apiv1.HealthStateIncident{
+		DeviceID: "GPU-1234",
+		Message:  "Power violation",
+		Severity: apiv1.HealthStateTypeUnhealthy,
+		Error:    "DCGM_FR_POWER_VIOLATION",
+	}
+	if got[0] != want {
+		t.Fatalf("ToHealthStateIncidents()[0] = %#v, want %#v", got[0], want)
+	}
+}
+
+func TestHealthCheckErrorCodeString(t *testing.T) {
+	if got := healthCheckErrorCodeString(dcgm.DCGM_FR_VOLATILE_DBE_DETECTED); got != "DCGM_FR_VOLATILE_DBE_DETECTED" {
+		t.Fatalf("healthCheckErrorCodeString(known) = %q", got)
+	}
+	if got := healthCheckErrorCodeString(dcgm.DCGM_FR_XID_ERROR); got != "DCGM_FR_XID_ERROR" {
+		t.Fatalf("healthCheckErrorCodeString(late known) = %q", got)
+	}
+	if got := healthCheckErrorCodeString(dcgm.DCGM_FR_ERROR_SENTINEL); got != "DCGM_FR_ERROR_SENTINEL" {
+		t.Fatalf("healthCheckErrorCodeString(sentinel) = %q", got)
+	}
+	if got := healthCheckErrorCodeString(dcgm.HealthCheckErrorCode(9999)); got != "DCGM_FR_UNKNOWN(9999)" {
+		t.Fatalf("healthCheckErrorCodeString(unknown) = %q", got)
+	}
+}
+
+func TestHealthSystemString(t *testing.T) {
+	if got := healthSystemString(dcgm.DCGM_HEALTH_WATCH_MEM); got != "DCGM_HEALTH_WATCH_MEM" {
+		t.Fatalf("healthSystemString(single) = %q", got)
+	}
+	if got := healthSystemString(dcgm.DCGM_HEALTH_WATCH_DRIVER); got != "DCGM_HEALTH_WATCH_DRIVER" {
+		t.Fatalf("healthSystemString(driver) = %q", got)
+	}
+	if got := healthSystemString(dcgm.DCGM_HEALTH_WATCH_NVSWITCH_FATAL); got != "DCGM_HEALTH_WATCH_NVSWITCH_FATAL" {
+		t.Fatalf("healthSystemString(nvswitch fatal) = %q", got)
+	}
+	if got := healthSystemString(dcgm.DCGM_HEALTH_WATCH_ALL); got != "DCGM_HEALTH_WATCH_ALL" {
+		t.Fatalf("healthSystemString(all) = %q", got)
+	}
+	if got := healthSystemString(dcgm.DCGM_HEALTH_WATCH_POWER | dcgm.DCGM_HEALTH_WATCH_THERMAL); got != "DCGM_HEALTH_WATCH_UNKNOWN(0x180)" {
+		t.Fatalf("healthSystemString(mask) = %q", got)
+	}
+	if got := healthSystemString(dcgm.DCGM_HEALTH_WATCH_NVLINK | dcgm.DCGM_HEALTH_WATCH_DRIVER | dcgm.DCGM_HEALTH_WATCH_NVSWITCH_FATAL); got != "DCGM_HEALTH_WATCH_UNKNOWN(0xA02)" {
+		t.Fatalf("healthSystemString(composite mask) = %q", got)
+	}
+}
+
+func TestHealthResultToSeverity(t *testing.T) {
+	if got := healthResultToSeverity(dcgm.DCGM_HEALTH_RESULT_WARN); got != apiv1.HealthStateTypeDegraded {
+		t.Fatalf("healthResultToSeverity(WARN) = %q", got)
+	}
+	if got := healthResultToSeverity(dcgm.DCGM_HEALTH_RESULT_FAIL); got != apiv1.HealthStateTypeUnhealthy {
+		t.Fatalf("healthResultToSeverity(FAIL) = %q", got)
+	}
+}
+
+func TestEnrichSwitchIncidents_UsesSwitchIdentifiers(t *testing.T) {
+	incidents := []dcgm.Incident{
+		{
+			EntityInfo: dcgm.GroupEntityPair{
+				EntityGroupId: dcgm.FE_SWITCH,
+				EntityId:      7,
+			},
+			Error: dcgm.DiagErrorDetail{
+				Message: "switch failure",
+				Code:    dcgm.DCGM_FR_NVSWITCH_FATAL_ERROR,
+			},
+			System: dcgm.DCGM_HEALTH_WATCH_NVSWITCH_FATAL,
+			Health: dcgm.DCGM_HEALTH_RESULT_FAIL,
+		},
+	}
+
+	got := EnrichSwitchIncidents(incidents)
+	if len(got) != 1 {
+		t.Fatalf("len(EnrichSwitchIncidents()) = %d, want 1", len(got))
+	}
+	if got[0].UUID != "nvswitch-7" {
+		t.Fatalf("EnrichSwitchIncidents()[0].UUID = %q, want nvswitch-7", got[0].UUID)
 	}
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
@@ -52,7 +52,7 @@ func TestFormatEnrichedIncidents(t *testing.T) {
 					ErrorCode: "DCGM_FR_TEMP_VIOLATION",
 				},
 			},
-			want: "thermal warning: 1 incident(s) across 1 device(s) [DCGM_FR_TEMP_VIOLATION]",
+			want: "thermal warning: 1 incident(s) across 1 device(s)",
 		},
 		{
 			name:   "multiple incidents",
@@ -69,7 +69,7 @@ func TestFormatEnrichedIncidents(t *testing.T) {
 					ErrorCode: "DCGM_FR_ROW_REMAP_FAILURE",
 				},
 			},
-			want: "memory failure: 2 incident(s) across 2 device(s) [DCGM_FR_ROW_REMAP_FAILURE, DCGM_FR_VOLATILE_DBE_DETECTED]",
+			want: "memory failure: 2 incident(s) across 2 device(s)",
 		},
 	}
 

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component.go
@@ -219,10 +219,12 @@ func (c *component) Check() components.CheckResult {
 	case dcgm.DCGM_HEALTH_RESULT_WARN:
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("InfoROM health warning", cr.enrichedIncidents)
 	case dcgm.DCGM_HEALTH_RESULT_FAIL:
 		cr.health = apiv1.HealthStateTypeUnhealthy
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("InfoROM health failure", cr.enrichedIncidents)
 	default:
 		cr.health = apiv1.HealthStateTypeDegraded
@@ -239,6 +241,7 @@ type checkResult struct {
 	err               error
 	health            apiv1.HealthStateType
 	reason            string
+	incidents         []apiv1.HealthStateIncident
 	enrichedIncidents []dcgmcommon.EnrichedIncident
 }
 
@@ -292,6 +295,7 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 		Reason:    cr.reason,
 		Error:     cr.getError(),
 		Health:    cr.health,
+		Incidents: cr.incidents,
 	}
 
 	// Add enriched DCGM incidents to ExtraInfo if available

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component_test.go
@@ -168,7 +168,7 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 	cr := &checkResult{
 		ts:                time.Now().UTC(),
 		health:            apiv1.HealthStateTypeDegraded,
-		reason:            "InfoROM health warning: 1 incident(s) across 1 device(s) [DCGM_FR_CORRUPT_INFOROM]",
+		reason:            "InfoROM health warning: 1 incident(s) across 1 device(s)",
 		incidents:         dcgmcommon.ToHealthStateIncidents(enriched),
 		enrichedIncidents: enriched,
 	}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component_test.go
@@ -158,6 +158,7 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 	enriched := []dcgmcommon.EnrichedIncident{
 		{
 			UUID:      "GPU-1234",
+			EntityID:  "GPU-0",
 			Message:   "Inforom corruption detected",
 			ErrorCode: "DCGM_FR_CORRUPT_INFOROM",
 			System:    "DCGM_HEALTH_WATCH_INFOROM",
@@ -182,8 +183,8 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 	if len(state.Incidents) != 1 {
 		t.Fatalf("len(state.Incidents) = %d, want 1", len(state.Incidents))
 	}
-	if got := state.Incidents[0].DeviceID; got != "GPU-1234" {
-		t.Fatalf("state.Incidents[0].DeviceID = %q", got)
+	if got := state.Incidents[0].EntityID; got != "GPU-0" {
+		t.Fatalf("state.Incidents[0].EntityID = %q", got)
 	}
 
 	raw := state.ExtraInfo["dcgm_incidents"]

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component_test.go
@@ -17,11 +17,13 @@ package inforom
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
+	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
 	pkgmetrics "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics/scraper"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
@@ -149,5 +151,51 @@ func TestCheck(t *testing.T) {
 
 	if metricFound == 0 {
 		t.Errorf("Metric %s was not found in Prometheus registry", "dcgm_fi_dev_inforom_config_valid")
+	}
+}
+
+func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t *testing.T) {
+	enriched := []dcgmcommon.EnrichedIncident{
+		{
+			UUID:      "GPU-1234",
+			Message:   "Inforom corruption detected",
+			ErrorCode: "DCGM_FR_CORRUPT_INFOROM",
+			System:    "DCGM_HEALTH_WATCH_INFOROM",
+			Severity:  apiv1.HealthStateTypeDegraded,
+		},
+	}
+
+	cr := &checkResult{
+		ts:                time.Now().UTC(),
+		health:            apiv1.HealthStateTypeDegraded,
+		reason:            "InfoROM health warning: 1 incident(s) across 1 device(s) [DCGM_FR_CORRUPT_INFOROM]",
+		incidents:         dcgmcommon.ToHealthStateIncidents(enriched),
+		enrichedIncidents: enriched,
+	}
+
+	states := cr.HealthStates()
+	if len(states) != 1 {
+		t.Fatalf("len(HealthStates()) = %d, want 1", len(states))
+	}
+
+	state := states[0]
+	if len(state.Incidents) != 1 {
+		t.Fatalf("len(state.Incidents) = %d, want 1", len(state.Incidents))
+	}
+	if got := state.Incidents[0].DeviceID; got != "GPU-1234" {
+		t.Fatalf("state.Incidents[0].DeviceID = %q", got)
+	}
+
+	raw := state.ExtraInfo["dcgm_incidents"]
+	if raw == "" {
+		t.Fatal("state.ExtraInfo[dcgm_incidents] is empty")
+	}
+
+	var legacy []map[string]any
+	if err := json.Unmarshal([]byte(raw), &legacy); err != nil {
+		t.Fatalf("json.Unmarshal(dcgm_incidents) error = %v", err)
+	}
+	if got := legacy[0]["uuid"]; got != "GPU-1234" {
+		t.Fatalf("legacy uuid = %v", got)
 	}
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component.go
@@ -461,10 +461,12 @@ func (c *component) Check() components.CheckResult {
 	case dcgm.DCGM_HEALTH_RESULT_WARN:
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("memory health warning", cr.enrichedIncidents)
 	case dcgm.DCGM_HEALTH_RESULT_FAIL:
 		cr.health = apiv1.HealthStateTypeUnhealthy
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("memory health failure", cr.enrichedIncidents)
 	default:
 		cr.health = apiv1.HealthStateTypeDegraded
@@ -481,6 +483,7 @@ type checkResult struct {
 	err               error
 	health            apiv1.HealthStateType
 	reason            string
+	incidents         []apiv1.HealthStateIncident
 	enrichedIncidents []dcgmcommon.EnrichedIncident
 }
 
@@ -534,6 +537,7 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 		Reason:    cr.reason,
 		Error:     cr.getError(),
 		Health:    cr.health,
+		Incidents: cr.incidents,
 	}
 
 	// Add enriched DCGM incidents to ExtraInfo if available

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
@@ -298,10 +298,12 @@ func (c *component) Check() components.CheckResult {
 	case dcgm.DCGM_HEALTH_RESULT_WARN:
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("NVLink health warning", cr.enrichedIncidents)
 	case dcgm.DCGM_HEALTH_RESULT_FAIL:
 		cr.health = apiv1.HealthStateTypeUnhealthy
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("NVLink health failure", cr.enrichedIncidents)
 	default:
 		cr.health = apiv1.HealthStateTypeDegraded
@@ -410,6 +412,7 @@ type checkResult struct {
 	err               error
 	health            apiv1.HealthStateType
 	reason            string
+	incidents         []apiv1.HealthStateIncident
 	enrichedIncidents []dcgmcommon.EnrichedIncident
 }
 
@@ -463,6 +466,7 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 		Reason:    cr.reason,
 		Error:     cr.getError(),
 		Health:    cr.health,
+		Incidents: cr.incidents,
 	}
 
 	// Add enriched DCGM incidents to ExtraInfo if available

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component.go
@@ -191,13 +191,6 @@ func (c *component) Check() components.CheckResult {
 		return cr
 	}
 
-	// Build entity ID to UUID mapping from DCGM devices
-	// This provides the mapping from entity ID (0, 1, 2, etc.) to entity UUID
-	deviceMapping := make(map[uint]string)
-	for _, device := range c.dcgmInstance.GetDevices() {
-		deviceMapping[device.ID] = device.UUID
-	}
-
 	// Check if NVSwitch entities exist in the system
 	// Query DCGM directly for NVSwitch entities
 	switchEntities, err := dcgm.GetEntityGroupEntities(dcgm.FE_SWITCH)
@@ -266,11 +259,13 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = fmt.Sprintf("all NVSwitch health checks passed (%d switches found)", len(switchEntities))
 	case dcgm.DCGM_HEALTH_RESULT_WARN:
 		cr.health = apiv1.HealthStateTypeDegraded
-		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(allIncidents, deviceMapping)
+		cr.enrichedIncidents = dcgmcommon.EnrichSwitchIncidents(allIncidents)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("NVSwitch health warning", cr.enrichedIncidents)
 	case dcgm.DCGM_HEALTH_RESULT_FAIL:
 		cr.health = apiv1.HealthStateTypeUnhealthy
-		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(allIncidents, deviceMapping)
+		cr.enrichedIncidents = dcgmcommon.EnrichSwitchIncidents(allIncidents)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("NVSwitch health failure", cr.enrichedIncidents)
 	default:
 		cr.health = apiv1.HealthStateTypeDegraded
@@ -287,6 +282,7 @@ type checkResult struct {
 	err               error
 	health            apiv1.HealthStateType
 	reason            string
+	incidents         []apiv1.HealthStateIncident
 	enrichedIncidents []dcgmcommon.EnrichedIncident
 }
 
@@ -340,6 +336,7 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 		Reason:    cr.reason,
 		Error:     cr.getError(),
 		Health:    cr.health,
+		Incidents: cr.incidents,
 	}
 
 	// Add enriched DCGM incidents to ExtraInfo if available

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component_test.go
@@ -129,7 +129,7 @@ func TestCheckResultHealthStates_UsesNVSwitchIdentifiers(t *testing.T) {
 	cr := &checkResult{
 		ts:                time.Now().UTC(),
 		health:            apiv1.HealthStateTypeUnhealthy,
-		reason:            "NVSwitch health failure: 1 incident(s) across 1 device(s) [DCGM_FR_NVSWITCH_FATAL_ERROR]",
+		reason:            "NVSwitch health failure: 1 incident(s) across 1 device(s)",
 		incidents:         dcgmcommon.ToHealthStateIncidents(enriched),
 		enrichedIncidents: enriched,
 	}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component_test.go
@@ -17,11 +17,13 @@ package nvswitch
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
+	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
 )
 
@@ -110,5 +112,51 @@ func TestCheck(t *testing.T) {
 
 	if !validHealthTypes[healthType] {
 		t.Errorf("HealthStateType() = %v, want one of Healthy/Degraded/Unhealthy", healthType)
+	}
+}
+
+func TestCheckResultHealthStates_UsesNVSwitchIdentifiers(t *testing.T) {
+	enriched := []dcgmcommon.EnrichedIncident{
+		{
+			UUID:      "nvswitch-3",
+			Message:   "Fatal NVSwitch error",
+			ErrorCode: "DCGM_FR_NVSWITCH_FATAL_ERROR",
+			System:    "DCGM_HEALTH_WATCH_NVSWITCH_FATAL",
+			Severity:  apiv1.HealthStateTypeUnhealthy,
+		},
+	}
+
+	cr := &checkResult{
+		ts:                time.Now().UTC(),
+		health:            apiv1.HealthStateTypeUnhealthy,
+		reason:            "NVSwitch health failure: 1 incident(s) across 1 device(s) [DCGM_FR_NVSWITCH_FATAL_ERROR]",
+		incidents:         dcgmcommon.ToHealthStateIncidents(enriched),
+		enrichedIncidents: enriched,
+	}
+
+	states := cr.HealthStates()
+	if len(states) != 1 {
+		t.Fatalf("len(HealthStates()) = %d, want 1", len(states))
+	}
+
+	state := states[0]
+	if len(state.Incidents) != 1 {
+		t.Fatalf("len(state.Incidents) = %d, want 1", len(state.Incidents))
+	}
+	if got := state.Incidents[0].DeviceID; got != "nvswitch-3" {
+		t.Fatalf("state.Incidents[0].DeviceID = %q", got)
+	}
+
+	raw := state.ExtraInfo["dcgm_incidents"]
+	if raw == "" {
+		t.Fatal("state.ExtraInfo[dcgm_incidents] is empty")
+	}
+
+	var legacy []map[string]any
+	if err := json.Unmarshal([]byte(raw), &legacy); err != nil {
+		t.Fatalf("json.Unmarshal(dcgm_incidents) error = %v", err)
+	}
+	if got := legacy[0]["uuid"]; got != "nvswitch-3" {
+		t.Fatalf("legacy uuid = %v", got)
 	}
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component_test.go
@@ -119,6 +119,7 @@ func TestCheckResultHealthStates_UsesNVSwitchIdentifiers(t *testing.T) {
 	enriched := []dcgmcommon.EnrichedIncident{
 		{
 			UUID:      "nvswitch-3",
+			EntityID:  "NvSwitch-3",
 			Message:   "Fatal NVSwitch error",
 			ErrorCode: "DCGM_FR_NVSWITCH_FATAL_ERROR",
 			System:    "DCGM_HEALTH_WATCH_NVSWITCH_FATAL",
@@ -143,8 +144,8 @@ func TestCheckResultHealthStates_UsesNVSwitchIdentifiers(t *testing.T) {
 	if len(state.Incidents) != 1 {
 		t.Fatalf("len(state.Incidents) = %d, want 1", len(state.Incidents))
 	}
-	if got := state.Incidents[0].DeviceID; got != "nvswitch-3" {
-		t.Fatalf("state.Incidents[0].DeviceID = %q", got)
+	if got := state.Incidents[0].EntityID; got != "NvSwitch-3" {
+		t.Fatalf("state.Incidents[0].EntityID = %q", got)
 	}
 
 	raw := state.ExtraInfo["dcgm_incidents"]

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component.go
@@ -307,11 +307,11 @@ func (c *component) Check() components.CheckResult {
 			for _, fieldValue := range deviceData.Values {
 				// Use valid value
 				switch fieldValue.FieldID {
-			case dcgm.DCGM_FI_DEV_PCIE_REPLAY_COUNTER:
-				metricDCGMFIDevPCIeReplayCounter.With(prometheus.Labels{
-					"uuid":      deviceData.UUID,
-					"gpu": fmt.Sprintf("%d", deviceData.DeviceID),
-				}).Set(float64(fieldValue.Int64()))
+				case dcgm.DCGM_FI_DEV_PCIE_REPLAY_COUNTER:
+					metricDCGMFIDevPCIeReplayCounter.With(prometheus.Labels{
+						"uuid": deviceData.UUID,
+						"gpu":  fmt.Sprintf("%d", deviceData.DeviceID),
+					}).Set(float64(fieldValue.Int64()))
 				}
 			}
 		}
@@ -325,10 +325,12 @@ func (c *component) Check() components.CheckResult {
 	case dcgm.DCGM_HEALTH_RESULT_WARN:
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("PCIe health warning", cr.enrichedIncidents)
 	case dcgm.DCGM_HEALTH_RESULT_FAIL:
 		cr.health = apiv1.HealthStateTypeUnhealthy
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("PCIe health failure", cr.enrichedIncidents)
 	default:
 		cr.health = apiv1.HealthStateTypeDegraded
@@ -345,6 +347,7 @@ type checkResult struct {
 	err               error
 	health            apiv1.HealthStateType
 	reason            string
+	incidents         []apiv1.HealthStateIncident
 	enrichedIncidents []dcgmcommon.EnrichedIncident
 }
 
@@ -398,6 +401,7 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 		Reason:    cr.reason,
 		Error:     cr.getError(),
 		Health:    cr.health,
+		Incidents: cr.incidents,
 	}
 
 	// Add enriched DCGM incidents to ExtraInfo if available

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component.go
@@ -397,10 +397,12 @@ func (c *component) Check() components.CheckResult {
 	case dcgm.DCGM_HEALTH_RESULT_WARN:
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("power health warning", cr.enrichedIncidents)
 	case dcgm.DCGM_HEALTH_RESULT_FAIL:
 		cr.health = apiv1.HealthStateTypeUnhealthy
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("power health failure", cr.enrichedIncidents)
 	default:
 		cr.health = apiv1.HealthStateTypeDegraded
@@ -419,6 +421,7 @@ type checkResult struct {
 	err               error
 	health            apiv1.HealthStateType
 	reason            string
+	incidents         []apiv1.HealthStateIncident
 	enrichedIncidents []dcgmcommon.EnrichedIncident
 }
 
@@ -474,6 +477,7 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 		Reason:    cr.reason,
 		Error:     cr.getError(),
 		Health:    cr.health,
+		Incidents: cr.incidents,
 	}
 
 	// Add enriched DCGM incidents to ExtraInfo if available

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component_test.go
@@ -178,6 +178,7 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 	enriched := []dcgmcommon.EnrichedIncident{
 		{
 			UUID:      "GPU-1234",
+			EntityID:  "GPU-0",
 			Message:   "Clock throttled",
 			ErrorCode: "DCGM_FR_CLOCK_THROTTLE_POWER",
 			System:    "DCGM_HEALTH_WATCH_POWER",
@@ -202,8 +203,8 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 	if len(state.Incidents) != 1 {
 		t.Fatalf("len(state.Incidents) = %d, want 1", len(state.Incidents))
 	}
-	if got := state.Incidents[0].DeviceID; got != "GPU-1234" {
-		t.Fatalf("state.Incidents[0].DeviceID = %q", got)
+	if got := state.Incidents[0].EntityID; got != "GPU-0" {
+		t.Fatalf("state.Incidents[0].EntityID = %q", got)
 	}
 
 	raw := state.ExtraInfo["dcgm_incidents"]

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component_test.go
@@ -17,11 +17,13 @@ package power
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
+	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
 	pkgmetrics "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics/scraper"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
@@ -169,5 +171,57 @@ func TestCheck(t *testing.T) {
 		} else {
 			t.Logf("Found %d instance(s) of metric %s", count, metricName)
 		}
+	}
+}
+
+func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t *testing.T) {
+	enriched := []dcgmcommon.EnrichedIncident{
+		{
+			UUID:      "GPU-1234",
+			Message:   "Clock throttled",
+			ErrorCode: "DCGM_FR_CLOCK_THROTTLE_POWER",
+			System:    "DCGM_HEALTH_WATCH_POWER",
+			Severity:  apiv1.HealthStateTypeDegraded,
+		},
+	}
+
+	cr := &checkResult{
+		ts:                time.Now().UTC(),
+		health:            apiv1.HealthStateTypeDegraded,
+		reason:            "power health warning: 1 incident(s) across 1 device(s) [DCGM_FR_CLOCK_THROTTLE_POWER]",
+		incidents:         dcgmcommon.ToHealthStateIncidents(enriched),
+		enrichedIncidents: enriched,
+	}
+
+	states := cr.HealthStates()
+	if len(states) != 1 {
+		t.Fatalf("len(HealthStates()) = %d, want 1", len(states))
+	}
+
+	state := states[0]
+	if len(state.Incidents) != 1 {
+		t.Fatalf("len(state.Incidents) = %d, want 1", len(state.Incidents))
+	}
+	if got := state.Incidents[0].DeviceID; got != "GPU-1234" {
+		t.Fatalf("state.Incidents[0].DeviceID = %q", got)
+	}
+
+	raw := state.ExtraInfo["dcgm_incidents"]
+	if raw == "" {
+		t.Fatal("state.ExtraInfo[dcgm_incidents] is empty")
+	}
+
+	var legacy []map[string]any
+	if err := json.Unmarshal([]byte(raw), &legacy); err != nil {
+		t.Fatalf("json.Unmarshal(dcgm_incidents) error = %v", err)
+	}
+	if len(legacy) != 1 {
+		t.Fatalf("len(legacy incidents) = %d, want 1", len(legacy))
+	}
+	if got := legacy[0]["uuid"]; got != "GPU-1234" {
+		t.Fatalf("legacy uuid = %v", got)
+	}
+	if got := legacy[0]["code"]; got != "DCGM_FR_CLOCK_THROTTLE_POWER" {
+		t.Fatalf("legacy code = %v", got)
 	}
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component_test.go
@@ -188,7 +188,7 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 	cr := &checkResult{
 		ts:                time.Now().UTC(),
 		health:            apiv1.HealthStateTypeDegraded,
-		reason:            "power health warning: 1 incident(s) across 1 device(s) [DCGM_FR_CLOCK_THROTTLE_POWER]",
+		reason:            "power health warning: 1 incident(s) across 1 device(s)",
 		incidents:         dcgmcommon.ToHealthStateIncidents(enriched),
 		enrichedIncidents: enriched,
 	}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component.go
@@ -367,10 +367,12 @@ func (c *component) Check() components.CheckResult {
 	case dcgm.DCGM_HEALTH_RESULT_WARN:
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("thermal health warning", cr.enrichedIncidents)
 	case dcgm.DCGM_HEALTH_RESULT_FAIL:
 		cr.health = apiv1.HealthStateTypeUnhealthy
 		cr.enrichedIncidents = dcgmcommon.EnrichIncidents(incidents, deviceMapping)
+		cr.incidents = dcgmcommon.ToHealthStateIncidents(cr.enrichedIncidents)
 		cr.reason = dcgmcommon.FormatIncidents("thermal health failure", cr.enrichedIncidents)
 	default:
 		cr.health = apiv1.HealthStateTypeDegraded
@@ -449,6 +451,7 @@ type checkResult struct {
 	err               error
 	health            apiv1.HealthStateType
 	reason            string
+	incidents         []apiv1.HealthStateIncident
 	enrichedIncidents []dcgmcommon.EnrichedIncident
 }
 
@@ -504,6 +507,7 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 		Reason:    cr.reason,
 		Error:     cr.getError(),
 		Health:    cr.health,
+		Incidents: cr.incidents,
 	}
 
 	// Add enriched DCGM incidents to ExtraInfo if available


### PR DESCRIPTION
## Summary
- add typed HealthState incidents for DCGM health components
- preserve legacy dcgm_incidents compatibility while exporting structured OTLP incidents
- convert DCGM health codes and systems to symbolic names and shorten reason summaries

## Test Plan
- go test github.com/NVIDIA/fleet-intelligence-sdk/api/v1 github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie ./internal/exporter/collector ./internal/exporter/converter ./internal/exporter/... ./internal/server/... ./internal/scan/...
