### PR TITLE
docs: improve install instructions with curl and arch detection

### DIFF
--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -24,26 +24,14 @@ References:
 - Fabric Manager: <https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#installing-fabric-manager>
 - NVAT (`nvattest`/`corelib`): <https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/overview.html>
 
-Fleet Intelligence Agent package dependencies (`datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib`) are available through NVIDIA's CUDA repository. Before installing Fleet Intelligence Agent, add the appropriate NVIDIA CUDA repository for your system:
+Fleet Intelligence Agent package dependencies (`datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib`) are available through NVIDIA's CUDA repository. Before installing Fleet Intelligence Agent, add the NVIDIA CUDA repository for your system:
 
 ```bash
-# Ubuntu 22.04 (x86_64)
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-sudo dpkg -i cuda-keyring_1.1-1_all.deb
-sudo apt-get update
-
-# Ubuntu 24.04 (x86_64)
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
-sudo dpkg -i cuda-keyring_1.1-1_all.deb
-sudo apt-get update
-
-# Ubuntu 22.04 (ARM64)
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/cuda-keyring_1.1-1_all.deb
-sudo dpkg -i cuda-keyring_1.1-1_all.deb
-sudo apt-get update
-
-# Ubuntu 24.04 (ARM64)
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/cuda-keyring_1.1-1_all.deb
+. /etc/os-release
+DISTRO="${ID}${VERSION_ID//./}"
+ARCH=$(dpkg --print-architecture)
+URL_ARCH=$([ "$ARCH" = "arm64" ] && echo "sbsa" || echo "$ARCH")
+curl -fLO https://developer.download.nvidia.com/compute/cuda/repos/${DISTRO}/${URL_ARCH}/cuda-keyring_1.1-1_all.deb
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
 ```
@@ -52,15 +40,16 @@ After adding the CUDA repository, package dependencies (`datacenter-gpu-manager-
 
 ## Install package
 
-Download the package from [Latest stable release](https://github.com/NVIDIA/fleet-intelligence-agent/releases/latest), then install:
-
 ```bash
-# Ubuntu (x86_64)
-sudo apt install ./fleetint_VERSION_amd64.deb
+VERSION=$(curl -fsSL https://api.github.com/repos/NVIDIA/fleet-intelligence-agent/releases/latest \
+  | grep '"tag_name"' | cut -d '"' -f 4 | tr -d 'v')
+ARCH=$(dpkg --print-architecture)
 
-# Ubuntu (ARM64)
-sudo apt install ./fleetint_VERSION_arm64.deb
+curl -fLO https://github.com/NVIDIA/fleet-intelligence-agent/releases/download/v${VERSION}/fleetint_${VERSION}_${ARCH}.deb
+sudo apt install ./fleetint_${VERSION}_${ARCH}.deb
 ```
+
+To install a specific version, set `VERSION` explicitly instead (e.g., `VERSION=0.2.0`).
 
 Verify:
 
@@ -71,14 +60,14 @@ systemctl status fleetintd
 
 ## Update
 
-Install the newer package version:
+Set `VERSION` to the target version and reinstall:
 
 ```bash
-# Ubuntu (x86_64)
-sudo apt install ./fleetint_VERSION_amd64.deb
+VERSION=<new-version>
+ARCH=$(dpkg --print-architecture)
 
-# Ubuntu (ARM64)
-sudo apt install ./fleetint_VERSION_arm64.deb
+curl -fLO https://github.com/NVIDIA/fleet-intelligence-agent/releases/download/v${VERSION}/fleetint_${VERSION}_${ARCH}.deb
+sudo apt install ./fleetint_${VERSION}_${ARCH}.deb
 ```
 
 The service will automatically restart with the new version.

--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -25,7 +25,7 @@ References:
 - Fabric Manager: <https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#installing-fabric-manager>
 - NVAT (`nvattest`/`corelib`): <https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/overview.html>
 
-Fleet Intelligence Agent package dependencies (`datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib`) are available through NVIDIA's CUDA repository. Before installing Fleet Intelligence Agent, add the appropriate NVIDIA CUDA repository for your system.
+Fleet Intelligence Agent package dependencies (`datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib`) are available through NVIDIA's CUDA repository. Before installing Fleet Intelligence Agent, add the NVIDIA CUDA repository for your system.
 
 Install `dnf-plugins-core` first if `dnf config-manager` is not available:
 
@@ -36,40 +36,19 @@ sudo dnf install -y dnf-plugins-core
 ### RHEL/Rocky/AlmaLinux Systems
 
 ```bash
-# RHEL/Rocky/AlmaLinux 8 (x86_64)
-sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
-sudo dnf clean all
-
-# RHEL/Rocky/AlmaLinux 9 (x86_64)
-sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
-sudo dnf clean all
-
-# RHEL/Rocky/AlmaLinux 10 (x86_64)
-sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel10/x86_64/cuda-rhel10.repo
-sudo dnf clean all
-
-# RHEL/Rocky/AlmaLinux 8 (ARM64)
-sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/cuda-rhel8.repo
-sudo dnf clean all
-
-# RHEL/Rocky/AlmaLinux 9 (ARM64)
-sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/cuda-rhel9.repo
-sudo dnf clean all
-
-# RHEL/Rocky/AlmaLinux 10 (ARM64)
-sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel10/sbsa/cuda-rhel10.repo
+. /etc/os-release
+ARCH=$(uname -m)
+URL_ARCH=$([ "$ARCH" = "aarch64" ] && echo "sbsa" || echo "$ARCH")
+sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel${VERSION_ID%%.*}/${URL_ARCH}/cuda-rhel${VERSION_ID%%.*}.repo
 sudo dnf clean all
 ```
 
 ### Amazon Linux 2023
 
 ```bash
-# Amazon Linux 2023 (x86_64)
-sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/cuda-amzn2023.repo
-sudo dnf clean all
-
-# Amazon Linux 2023 (ARM64)
-sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/cuda-amzn2023.repo
+ARCH=$(uname -m)
+URL_ARCH=$([ "$ARCH" = "aarch64" ] && echo "sbsa" || echo "$ARCH")
+sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/${URL_ARCH}/cuda-amzn2023.repo
 sudo dnf clean all
 ```
 
@@ -77,15 +56,16 @@ After adding the CUDA repository, package dependencies (`datacenter-gpu-manager-
 
 ## Install package
 
-Download the package from [Latest stable release](https://github.com/NVIDIA/fleet-intelligence-agent/releases/latest), then install:
-
 ```bash
-# RHEL/Rocky/AlmaLinux/Amazon Linux (x86_64)
-sudo dnf install ./fleetint-VERSION-1.x86_64.rpm
+VERSION=$(curl -fsSL https://api.github.com/repos/NVIDIA/fleet-intelligence-agent/releases/latest \
+  | grep '"tag_name"' | cut -d '"' -f 4 | tr -d 'v')
+ARCH=$(uname -m)
 
-# RHEL/Rocky/AlmaLinux/Amazon Linux (ARM64)
-sudo dnf install ./fleetint-VERSION-1.aarch64.rpm
+curl -fLO https://github.com/NVIDIA/fleet-intelligence-agent/releases/download/v${VERSION}/fleetint-${VERSION}-1.${ARCH}.rpm
+sudo dnf install ./fleetint-${VERSION}-1.${ARCH}.rpm
 ```
+
+To install a specific version, set `VERSION` explicitly instead (e.g., `VERSION=0.2.0`).
 
 Verify:
 
@@ -96,14 +76,14 @@ systemctl status fleetintd
 
 ## Update
 
-Install the newer package version:
+Set `VERSION` to the target version and reinstall:
 
 ```bash
-# RHEL/Rocky/AlmaLinux/Amazon Linux (x86_64)
-sudo dnf install ./fleetint-VERSION-1.x86_64.rpm
+VERSION=<new-version>
+ARCH=$(uname -m)
 
-# RHEL/Rocky/AlmaLinux/Amazon Linux (ARM64)
-sudo dnf install ./fleetint-VERSION-1.aarch64.rpm
+curl -fLO https://github.com/NVIDIA/fleet-intelligence-agent/releases/download/v${VERSION}/fleetint-${VERSION}-1.${ARCH}.rpm
+sudo dnf install ./fleetint-${VERSION}-1.${ARCH}.rpm
 ```
 
 The service will automatically restart with the new version.


### PR DESCRIPTION
## Summary

- Replace manual download steps in `install-deb.md` and `install-rpm.md` with `curl` commands that auto-detect the latest release version via the GitHub API
- Use `dpkg --print-architecture` for DEB arch detection (`amd64`/`arm64` matches DEB filename convention)
- Use `uname -m` for RPM arch detection (`x86_64`/`aarch64` matches RPM filename convention)
- Replace `wget` with `curl -fLO` in the CUDA keyring setup section of `install-deb.md` for consistency

## Test plan

- [x] Verify DEB install command on Ubuntu x86_64
- [x] Verify DEB install command on Ubuntu ARM64
- [x] Verify RPM install command on RHEL/Rocky x86_64
- [x] Verify RPM install command on RHEL/Rocky ARM64
