### PR TITLE
fix: export NVLink BER float metrics

### DIFF
--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
@@ -391,10 +391,10 @@ func (c *component) Check() components.CheckResult {
 					metricDCGMFIDevNvlinkCountLocalLinkIntegrityErrors.With(prometheus.Labels{"uuid": deviceData.UUID, "gpu": fmt.Sprintf("%d", deviceData.DeviceID)}).Set(float64(fieldValue.Int64()))
 				case dcgm.DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS:
 					metricDCGMFIDevNvlinkCountEffectiveErrors.With(prometheus.Labels{"uuid": deviceData.UUID, "gpu": fmt.Sprintf("%d", deviceData.DeviceID)}).Set(float64(fieldValue.Int64()))
-				case dcgm.DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER:
-					metricDCGMFIDevNvlinkCountEffectiveBER.With(prometheus.Labels{"uuid": deviceData.UUID, "gpu": fmt.Sprintf("%d", deviceData.DeviceID)}).Set(float64(fieldValue.Int64()))
-				case dcgm.DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER:
-					metricDCGMFIDevNvlinkCountSymbolBER.With(prometheus.Labels{"uuid": deviceData.UUID, "gpu": fmt.Sprintf("%d", deviceData.DeviceID)}).Set(float64(fieldValue.Int64()))
+				case dcgm.DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER_FLOAT:
+					metricDCGMFIDevNvlinkCountEffectiveBERFloat.With(prometheus.Labels{"uuid": deviceData.UUID, "gpu": fmt.Sprintf("%d", deviceData.DeviceID)}).Set(fieldValue.Float64())
+				case dcgm.DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER_FLOAT:
+					metricDCGMFIDevNvlinkCountSymbolBERFloat.With(prometheus.Labels{"uuid": deviceData.UUID, "gpu": fmt.Sprintf("%d", deviceData.DeviceID)}).Set(fieldValue.Float64())
 				case dcgm.DCGM_FI_DEV_NVLINK_COUNT_TX_DISCARDS:
 					metricDCGMFIDevNvlinkCountTxDiscards.With(prometheus.Labels{"uuid": deviceData.UUID, "gpu": fmt.Sprintf("%d", deviceData.DeviceID)}).Set(float64(fieldValue.Int64()))
 				}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component_test.go
@@ -159,8 +159,8 @@ func TestCheck(t *testing.T) {
 		"dcgm_fi_dev_nvlink_count_rx_buffer_overrun_errors":        0,
 		"dcgm_fi_dev_nvlink_count_local_link_integrity_errors":     0,
 		"dcgm_fi_dev_nvlink_count_effective_errors":                0,
-		"dcgm_fi_dev_nvlink_count_effective_ber":                   0,
-		"dcgm_fi_dev_nvlink_count_symbol_ber":                      0,
+		"dcgm_fi_dev_nvlink_count_effective_ber_float":             0,
+		"dcgm_fi_dev_nvlink_count_symbol_ber_float":                0,
 		"dcgm_fi_dev_nvlink_count_tx_discards":                     0,
 	}
 

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/metrics.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/metrics.go
@@ -41,8 +41,8 @@ var nvlinkFields = []dcgm.Short{
 	dcgm.DCGM_FI_DEV_NVLINK_COUNT_RX_BUFFER_OVERRUN_ERRORS,
 	dcgm.DCGM_FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS,
 	dcgm.DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS,
-	dcgm.DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER,
-	dcgm.DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER,
+	dcgm.DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER_FLOAT,
+	dcgm.DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER_FLOAT,
 	dcgm.DCGM_FI_DEV_NVLINK_COUNT_TX_DISCARDS,
 }
 
@@ -151,12 +151,12 @@ var (
 		prometheus.GaugeOpts{Name: "dcgm_fi_dev_nvlink_count_effective_errors", Help: "Sum of the number of errors in each Nvlink packet"},
 		[]string{pkgmetrics.MetricComponentLabelKey, "uuid", "gpu"},
 	).MustCurryWith(componentLabel)
-	metricDCGMFIDevNvlinkCountEffectiveBER = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{Name: "dcgm_fi_dev_nvlink_count_effective_ber", Help: "Effective BER for effective errors - raw value"},
+	metricDCGMFIDevNvlinkCountEffectiveBERFloat = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "dcgm_fi_dev_nvlink_count_effective_ber_float", Help: "Effective BER for effective errors - decoded float value"},
 		[]string{pkgmetrics.MetricComponentLabelKey, "uuid", "gpu"},
 	).MustCurryWith(componentLabel)
-	metricDCGMFIDevNvlinkCountSymbolBER = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{Name: "dcgm_fi_dev_nvlink_count_symbol_ber", Help: "BER for symbol errors - raw value"},
+	metricDCGMFIDevNvlinkCountSymbolBERFloat = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "dcgm_fi_dev_nvlink_count_symbol_ber_float", Help: "BER for symbol errors - decoded float value"},
 		[]string{pkgmetrics.MetricComponentLabelKey, "uuid", "gpu"},
 	).MustCurryWith(componentLabel)
 	metricDCGMFIDevNvlinkCountTxDiscards = prometheus.NewGaugeVec(
@@ -183,8 +183,8 @@ func init() {
 		metricDCGMFIDevNvlinkCountRxBufferOverrunErrors,
 		metricDCGMFIDevNvlinkCountLocalLinkIntegrityErrors,
 		metricDCGMFIDevNvlinkCountEffectiveErrors,
-		metricDCGMFIDevNvlinkCountEffectiveBER,
-		metricDCGMFIDevNvlinkCountSymbolBER,
+		metricDCGMFIDevNvlinkCountEffectiveBERFloat,
+		metricDCGMFIDevNvlinkCountSymbolBERFloat,
 		metricDCGMFIDevNvlinkCountTxDiscards,
 	)
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/metrics_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/metrics_test.go
@@ -16,9 +16,11 @@
 package nvlink
 
 import (
+	"strings"
 	"testing"
 
 	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestNVLinkFieldsIncludeExpectedCounters(t *testing.T) {
@@ -44,8 +46,8 @@ func TestNVLinkFieldsIncludeExpectedCounters(t *testing.T) {
 		dcgm.DCGM_FI_DEV_NVLINK_COUNT_RX_BUFFER_OVERRUN_ERRORS,
 		dcgm.DCGM_FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS,
 		dcgm.DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS,
-		dcgm.DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER,
-		dcgm.DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER,
+		dcgm.DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER_FLOAT,
+		dcgm.DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER_FLOAT,
 		dcgm.DCGM_FI_DEV_NVLINK_COUNT_TX_DISCARDS,
 	}
 
@@ -53,5 +55,38 @@ func TestNVLinkFieldsIncludeExpectedCounters(t *testing.T) {
 		if _, ok := fieldSet[field]; !ok {
 			t.Errorf("missing expected nvlink field: %d", field)
 		}
+	}
+
+	testCases := []struct {
+		name      string
+		collector interface{ Describe(chan<- *prometheus.Desc) }
+		wantName  string
+	}{
+		{
+			name:      "effective ber",
+			collector: metricDCGMFIDevNvlinkCountEffectiveBERFloat,
+			wantName:  `fqName: "dcgm_fi_dev_nvlink_count_effective_ber_float"`,
+		},
+		{
+			name:      "symbol ber",
+			collector: metricDCGMFIDevNvlinkCountSymbolBERFloat,
+			wantName:  `fqName: "dcgm_fi_dev_nvlink_count_symbol_ber_float"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			descCh := make(chan *prometheus.Desc, 1)
+			tc.collector.Describe(descCh)
+			close(descCh)
+
+			for desc := range descCh {
+				if strings.Contains(desc.String(), tc.wantName) {
+					return
+				}
+			}
+
+			t.Fatalf("collector did not describe metric name %q", tc.wantName)
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- replace the raw NVLink BER fields with the `_float` DCGM BER fields
- export `dcgm_fi_dev_nvlink_count_effective_ber_float` and `dcgm_fi_dev_nvlink_count_symbol_ber_float`
- update the existing NVLink tests to expect the float BER field IDs and metric names

## Test Plan
- `cd third_party/fleet-intelligence-sdk && go test -count=1 ./components/accelerator/nvidia/dcgm/nvlink`

[GPUHEALTH-1661]
