### PR TITLE
feat: emit DCGM health incidents as events

### DIFF
--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
@@ -28,22 +28,23 @@ import (
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 )
 
-// Event name and extra-info key constants for DCGM health incident events.
+// Extra-info key constants for DCGM health incident events.
 const (
-	EventNameDCGMHealthIncident = "dcgm_health_incident"
-	EventKeyUUID                = "uuid"
-	EventKeyErrorCode           = "error_code"
-	EventKeySystem              = "system"
+	EventKeyUUID      = "uuid"
+	EventKeyErrorCode = "error_code"
+	EventKeySystem    = "system"
 )
 
 // EmitNewIncidentEvents inserts an event into eventBucket for each incident in curr
 // that is not already present in prev (onset detection). It uses UUID+ErrorCode+System
 // as the deduplication key to identify the same fault across check cycles.
+// eventName should be a component-specific constant (e.g. "dcgm_thermal_incident").
 // Errors are logged as warnings and do not propagate to the caller.
 func EmitNewIncidentEvents(
 	ctx context.Context,
 	now time.Time,
 	componentName string,
+	eventName string,
 	eventBucket eventstore.Bucket,
 	prev []EnrichedIncident,
 	curr []EnrichedIncident,
@@ -72,7 +73,7 @@ func EmitNewIncidentEvents(
 		ev := eventstore.Event{
 			Component: componentName,
 			Time:      now,
-			Name:      EventNameDCGMHealthIncident,
+			Name:      eventName,
 			Type:      string(eventType),
 			Message:   inc.Message,
 			ExtraInfo: map[string]string{

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
@@ -17,12 +17,75 @@
 package common
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
 
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 )
+
+// Event name and extra-info key constants for DCGM health incident events.
+const (
+	EventNameDCGMHealthIncident = "dcgm_health_incident"
+	EventKeyUUID                = "uuid"
+	EventKeyErrorCode           = "error_code"
+	EventKeySystem              = "system"
+)
+
+// EmitNewIncidentEvents inserts an event into eventBucket for each incident in curr
+// that is not already present in prev (onset detection). It uses UUID+ErrorCode+System
+// as the deduplication key to identify the same fault across check cycles.
+// Errors are logged as warnings and do not propagate to the caller.
+func EmitNewIncidentEvents(
+	ctx context.Context,
+	now time.Time,
+	componentName string,
+	eventBucket eventstore.Bucket,
+	prev []EnrichedIncident,
+	curr []EnrichedIncident,
+) {
+	if eventBucket == nil || len(curr) == 0 {
+		return
+	}
+
+	// Build dedup set from previous incidents.
+	prevKeys := make(map[string]struct{}, len(prev))
+	for _, inc := range prev {
+		prevKeys[inc.UUID+"/"+inc.ErrorCode+"/"+inc.System] = struct{}{}
+	}
+
+	for _, inc := range curr {
+		key := inc.UUID + "/" + inc.ErrorCode + "/" + inc.System
+		if _, seen := prevKeys[key]; seen {
+			continue
+		}
+
+		eventType := apiv1.EventTypeWarning
+		if inc.Severity == apiv1.HealthStateTypeUnhealthy {
+			eventType = apiv1.EventTypeCritical
+		}
+
+		ev := eventstore.Event{
+			Component: componentName,
+			Time:      now,
+			Name:      EventNameDCGMHealthIncident,
+			Type:      string(eventType),
+			Message:   inc.Message,
+			ExtraInfo: map[string]string{
+				EventKeyUUID:      inc.UUID,
+				EventKeyErrorCode: inc.ErrorCode,
+				EventKeySystem:    inc.System,
+			},
+		}
+		if err := eventBucket.Insert(ctx, ev); err != nil {
+			log.Logger.Warnw("failed to insert DCGM incident event", "component", componentName, "error", err)
+		}
+	}
+}
 
 var healthCheckErrorCodeNames = map[dcgm.HealthCheckErrorCode]string{
 	dcgm.DCGM_FR_OK:                              "DCGM_FR_OK",

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
@@ -30,13 +30,12 @@ import (
 
 // Extra-info key constants for DCGM health incident events.
 const (
-	EventKeyUUID      = "uuid"
+	EventKeyEntityID  = "entity_id"
 	EventKeyErrorCode = "error_code"
-	EventKeySystem    = "system"
 )
 
 // EmitNewIncidentEvents inserts an event into eventBucket for each incident in curr
-// that is not already present in prev (onset detection). It uses UUID+ErrorCode+System
+// that is not already present in prev (onset detection). It uses EntityID+Severity+Error
 // as the deduplication key to identify the same fault across check cycles.
 // eventName should be a component-specific constant (e.g. "dcgm_thermal_incident").
 // Errors are logged as warnings and do not propagate to the caller.
@@ -46,8 +45,8 @@ func EmitNewIncidentEvents(
 	componentName string,
 	eventName string,
 	eventBucket eventstore.Bucket,
-	prev []EnrichedIncident,
-	curr []EnrichedIncident,
+	prev []apiv1.HealthStateIncident,
+	curr []apiv1.HealthStateIncident,
 ) {
 	if eventBucket == nil || len(curr) == 0 {
 		return
@@ -56,11 +55,11 @@ func EmitNewIncidentEvents(
 	// Build dedup set from previous incidents.
 	prevKeys := make(map[string]struct{}, len(prev))
 	for _, inc := range prev {
-		prevKeys[inc.UUID+"/"+inc.ErrorCode+"/"+inc.System] = struct{}{}
+		prevKeys[inc.EntityID+"/"+string(inc.Severity)+"/"+inc.Error] = struct{}{}
 	}
 
 	for _, inc := range curr {
-		key := inc.UUID + "/" + inc.ErrorCode + "/" + inc.System
+		key := inc.EntityID + "/" + string(inc.Severity) + "/" + inc.Error
 		if _, seen := prevKeys[key]; seen {
 			continue
 		}
@@ -77,9 +76,8 @@ func EmitNewIncidentEvents(
 			Type:      string(eventType),
 			Message:   inc.Message,
 			ExtraInfo: map[string]string{
-				EventKeyUUID:      inc.UUID,
-				EventKeyErrorCode: inc.ErrorCode,
-				EventKeySystem:    inc.System,
+				EventKeyEntityID:  inc.EntityID,
+				EventKeyErrorCode: inc.Error,
 			},
 		}
 		if err := eventBucket.Insert(ctx, ev); err != nil {

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
@@ -83,6 +83,7 @@ func EmitNewIncidentEvents(
 		if err := eventBucket.Insert(ctx, ev); err != nil {
 			log.Logger.Warnw("failed to insert DCGM incident event", "component", componentName, "error", err)
 		}
+		prevKeys[key] = struct{}{} // suppress in-curr duplicates
 	}
 }
 

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
@@ -16,11 +16,14 @@
 package common
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
 
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 )
 
 func TestFormatEnrichedIncidents(t *testing.T) {
@@ -151,6 +154,122 @@ func TestHealthResultToSeverity(t *testing.T) {
 	}
 	if got := healthResultToSeverity(dcgm.DCGM_HEALTH_RESULT_FAIL); got != apiv1.HealthStateTypeUnhealthy {
 		t.Fatalf("healthResultToSeverity(FAIL) = %q", got)
+	}
+}
+
+// fakeEventBucket is a minimal in-memory eventstore.Bucket for testing.
+type fakeEventBucket struct {
+	inserted []eventstore.Event
+}
+
+func (f *fakeEventBucket) Name() string { return "fake" }
+func (f *fakeEventBucket) Insert(_ context.Context, ev eventstore.Event) error {
+	f.inserted = append(f.inserted, ev)
+	return nil
+}
+func (f *fakeEventBucket) Find(_ context.Context, _ eventstore.Event) (*eventstore.Event, error) {
+	return nil, nil
+}
+func (f *fakeEventBucket) Get(_ context.Context, _ time.Time) (eventstore.Events, error) {
+	return nil, nil
+}
+func (f *fakeEventBucket) Latest(_ context.Context) (*eventstore.Event, error) { return nil, nil }
+func (f *fakeEventBucket) Purge(_ context.Context, _ int64) (int, error)       { return 0, nil }
+func (f *fakeEventBucket) Close()                                               {}
+
+func TestEmitNewIncidentEvents(t *testing.T) {
+	now := time.Now().UTC()
+	ctx := context.Background()
+
+	gpu0Thermal := EnrichedIncident{
+		UUID:      "GPU-0000",
+		ErrorCode: "DCGM_FR_TEMP_VIOLATION",
+		System:    "DCGM_HEALTH_WATCH_THERMAL",
+		Message:   "temp too high",
+		Severity:  apiv1.HealthStateTypeDegraded,
+	}
+	gpu1Mem := EnrichedIncident{
+		UUID:      "GPU-0001",
+		ErrorCode: "DCGM_FR_VOLATILE_DBE_DETECTED",
+		System:    "DCGM_HEALTH_WATCH_MEM",
+		Message:   "memory error",
+		Severity:  apiv1.HealthStateTypeUnhealthy,
+	}
+
+	tests := []struct {
+		name          string
+		prev          []EnrichedIncident
+		curr          []EnrichedIncident
+		wantCount     int
+		wantEventType string // of first event, if any
+	}{
+		{
+			name:      "no incidents",
+			prev:      nil,
+			curr:      nil,
+			wantCount: 0,
+		},
+		{
+			name:      "same incident in prev and curr — no new event",
+			prev:      []EnrichedIncident{gpu0Thermal},
+			curr:      []EnrichedIncident{gpu0Thermal},
+			wantCount: 0,
+		},
+		{
+			name:          "new incident not in prev — event emitted",
+			prev:          nil,
+			curr:          []EnrichedIncident{gpu0Thermal},
+			wantCount:     1,
+			wantEventType: string(apiv1.EventTypeWarning),
+		},
+		{
+			name:          "unhealthy severity maps to critical",
+			prev:          nil,
+			curr:          []EnrichedIncident{gpu1Mem},
+			wantCount:     1,
+			wantEventType: string(apiv1.EventTypeCritical),
+		},
+		{
+			name:      "multiple new incidents all emitted",
+			prev:      nil,
+			curr:      []EnrichedIncident{gpu0Thermal, gpu1Mem},
+			wantCount: 2,
+		},
+		{
+			name:      "one existing one new — only new emitted",
+			prev:      []EnrichedIncident{gpu0Thermal},
+			curr:      []EnrichedIncident{gpu0Thermal, gpu1Mem},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket := &fakeEventBucket{}
+			EmitNewIncidentEvents(ctx, now, "test-component", bucket, tt.prev, tt.curr)
+
+			if len(bucket.inserted) != tt.wantCount {
+				t.Fatalf("inserted %d events, want %d", len(bucket.inserted), tt.wantCount)
+			}
+			if tt.wantCount > 0 {
+				ev := bucket.inserted[0]
+				if ev.Name != EventNameDCGMHealthIncident {
+					t.Errorf("event Name = %q, want %q", ev.Name, EventNameDCGMHealthIncident)
+				}
+				if tt.wantEventType != "" && ev.Type != tt.wantEventType {
+					t.Errorf("event Type = %q, want %q", ev.Type, tt.wantEventType)
+				}
+				if ev.ExtraInfo[EventKeyUUID] == "" {
+					t.Errorf("event ExtraInfo[uuid] is empty")
+				}
+				if ev.ExtraInfo[EventKeyErrorCode] == "" {
+					t.Errorf("event ExtraInfo[error_code] is empty")
+				}
+				if ev.ExtraInfo[EventKeySystem] == "" {
+					t.Errorf("event ExtraInfo[system] is empty")
+				}
+			}
+		})
 	}
 }
 

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
@@ -181,25 +181,23 @@ func TestEmitNewIncidentEvents(t *testing.T) {
 	now := time.Now().UTC()
 	ctx := context.Background()
 
-	gpu0Thermal := EnrichedIncident{
-		UUID:      "GPU-0000",
-		ErrorCode: "DCGM_FR_TEMP_VIOLATION",
-		System:    "DCGM_HEALTH_WATCH_THERMAL",
-		Message:   "temp too high",
-		Severity:  apiv1.HealthStateTypeDegraded,
+	gpu0Thermal := apiv1.HealthStateIncident{
+		EntityID: "GPU-0",
+		Error:    "DCGM_FR_TEMP_VIOLATION",
+		Message:  "temp too high",
+		Severity: apiv1.HealthStateTypeDegraded,
 	}
-	gpu1Mem := EnrichedIncident{
-		UUID:      "GPU-0001",
-		ErrorCode: "DCGM_FR_VOLATILE_DBE_DETECTED",
-		System:    "DCGM_HEALTH_WATCH_MEM",
-		Message:   "memory error",
-		Severity:  apiv1.HealthStateTypeUnhealthy,
+	gpu1Mem := apiv1.HealthStateIncident{
+		EntityID: "GPU-1",
+		Error:    "DCGM_FR_VOLATILE_DBE_DETECTED",
+		Message:  "memory error",
+		Severity: apiv1.HealthStateTypeUnhealthy,
 	}
 
 	tests := []struct {
 		name          string
-		prev          []EnrichedIncident
-		curr          []EnrichedIncident
+		prev          []apiv1.HealthStateIncident
+		curr          []apiv1.HealthStateIncident
 		wantCount     int
 		wantEventType string // of first event, if any
 	}{
@@ -211,34 +209,34 @@ func TestEmitNewIncidentEvents(t *testing.T) {
 		},
 		{
 			name:      "same incident in prev and curr — no new event",
-			prev:      []EnrichedIncident{gpu0Thermal},
-			curr:      []EnrichedIncident{gpu0Thermal},
+			prev:      []apiv1.HealthStateIncident{gpu0Thermal},
+			curr:      []apiv1.HealthStateIncident{gpu0Thermal},
 			wantCount: 0,
 		},
 		{
 			name:          "new incident not in prev — event emitted",
 			prev:          nil,
-			curr:          []EnrichedIncident{gpu0Thermal},
+			curr:          []apiv1.HealthStateIncident{gpu0Thermal},
 			wantCount:     1,
 			wantEventType: string(apiv1.EventTypeWarning),
 		},
 		{
 			name:          "unhealthy severity maps to critical",
 			prev:          nil,
-			curr:          []EnrichedIncident{gpu1Mem},
+			curr:          []apiv1.HealthStateIncident{gpu1Mem},
 			wantCount:     1,
 			wantEventType: string(apiv1.EventTypeCritical),
 		},
 		{
 			name:      "multiple new incidents all emitted",
 			prev:      nil,
-			curr:      []EnrichedIncident{gpu0Thermal, gpu1Mem},
+			curr:      []apiv1.HealthStateIncident{gpu0Thermal, gpu1Mem},
 			wantCount: 2,
 		},
 		{
 			name:      "one existing one new — only new emitted",
-			prev:      []EnrichedIncident{gpu0Thermal},
-			curr:      []EnrichedIncident{gpu0Thermal, gpu1Mem},
+			prev:      []apiv1.HealthStateIncident{gpu0Thermal},
+			curr:      []apiv1.HealthStateIncident{gpu0Thermal, gpu1Mem},
 			wantCount: 1,
 		},
 	}
@@ -259,14 +257,11 @@ func TestEmitNewIncidentEvents(t *testing.T) {
 				if tt.wantEventType != "" && ev.Type != tt.wantEventType {
 					t.Errorf("event Type = %q, want %q", ev.Type, tt.wantEventType)
 				}
-				if ev.ExtraInfo[EventKeyUUID] == "" {
-					t.Errorf("event ExtraInfo[uuid] is empty")
+				if ev.ExtraInfo[EventKeyEntityID] == "" {
+					t.Errorf("event ExtraInfo[entity_id] is empty")
 				}
 				if ev.ExtraInfo[EventKeyErrorCode] == "" {
 					t.Errorf("event ExtraInfo[error_code] is empty")
-				}
-				if ev.ExtraInfo[EventKeySystem] == "" {
-					t.Errorf("event ExtraInfo[system] is empty")
 				}
 			}
 		})

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
@@ -246,15 +246,15 @@ func TestEmitNewIncidentEvents(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bucket := &fakeEventBucket{}
-			EmitNewIncidentEvents(ctx, now, "test-component", bucket, tt.prev, tt.curr)
+			EmitNewIncidentEvents(ctx, now, "test-component", "test_incident", bucket, tt.prev, tt.curr)
 
 			if len(bucket.inserted) != tt.wantCount {
 				t.Fatalf("inserted %d events, want %d", len(bucket.inserted), tt.wantCount)
 			}
 			if tt.wantCount > 0 {
 				ev := bucket.inserted[0]
-				if ev.Name != EventNameDCGMHealthIncident {
-					t.Errorf("event Name = %q, want %q", ev.Name, EventNameDCGMHealthIncident)
+				if ev.Name != "test_incident" {
+					t.Errorf("event Name = %q, want %q", ev.Name, "test_incident")
 				}
 				if tt.wantEventType != "" && ev.Type != tt.wantEventType {
 					t.Errorf("event Type = %q, want %q", ev.Type, tt.wantEventType)

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
@@ -193,6 +193,20 @@ func TestEmitNewIncidentEvents(t *testing.T) {
 		Message:  "memory error",
 		Severity: apiv1.HealthStateTypeUnhealthy,
 	}
+	// Same EntityID as gpu0Thermal but different Severity — distinct key.
+	gpu0ThermalEscalated := apiv1.HealthStateIncident{
+		EntityID: "GPU-0",
+		Error:    "DCGM_FR_TEMP_VIOLATION",
+		Message:  "temp critical",
+		Severity: apiv1.HealthStateTypeUnhealthy,
+	}
+	// Same EntityID as gpu0Thermal but different Error — distinct key.
+	gpu0Power := apiv1.HealthStateIncident{
+		EntityID: "GPU-0",
+		Error:    "DCGM_FR_POWER_VIOLATION",
+		Message:  "power too high",
+		Severity: apiv1.HealthStateTypeDegraded,
+	}
 
 	tests := []struct {
 		name          string
@@ -237,6 +251,35 @@ func TestEmitNewIncidentEvents(t *testing.T) {
 			name:      "one existing one new — only new emitted",
 			prev:      []apiv1.HealthStateIncident{gpu0Thermal},
 			curr:      []apiv1.HealthStateIncident{gpu0Thermal, gpu1Mem},
+			wantCount: 1,
+		},
+		{
+			// Same EntityID + Error, different Severity → different key → new event.
+			name:          "same entityID and error but escalated severity — new event emitted",
+			prev:          []apiv1.HealthStateIncident{gpu0Thermal},
+			curr:          []apiv1.HealthStateIncident{gpu0ThermalEscalated},
+			wantCount:     1,
+			wantEventType: string(apiv1.EventTypeCritical),
+		},
+		{
+			// Same EntityID + Severity, different Error → different key → new event.
+			name:      "same entityID and severity but different error — new event emitted",
+			prev:      []apiv1.HealthStateIncident{gpu0Thermal},
+			curr:      []apiv1.HealthStateIncident{gpu0Power},
+			wantCount: 1,
+		},
+		{
+			// Both old and new incidents for the same GPU co-exist in curr.
+			name:      "same entityID two distinct errors — both emitted when neither in prev",
+			prev:      nil,
+			curr:      []apiv1.HealthStateIncident{gpu0Thermal, gpu0Power},
+			wantCount: 2,
+		},
+		{
+			// gpu0Thermal already seen; gpu0Power is new — only gpu0Power emitted.
+			name:      "same entityID two errors — existing suppressed new emitted",
+			prev:      []apiv1.HealthStateIncident{gpu0Thermal},
+			curr:      []apiv1.HealthStateIncident{gpu0Thermal, gpu0Power},
 			wantCount: 1,
 		},
 	}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component.go
@@ -37,6 +37,8 @@ import (
 
 const Name = "accelerator-nvidia-dcgm-inforom"
 
+const EventNameIncident = "dcgm_inforom_incident"
+
 const (
 	defaultHealthCheckInterval = time.Minute
 )
@@ -264,7 +266,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component.go
@@ -177,9 +177,9 @@ func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu InfoROM metrics via DCGM")
 
 	c.lastMu.RLock()
-	var prevIncidents []dcgmcommon.EnrichedIncident
+	var prevIncidents []apiv1.HealthStateIncident
 	if c.lastCheckResult != nil {
-		prevIncidents = c.lastCheckResult.enrichedIncidents
+		prevIncidents = c.lastCheckResult.incidents
 	}
 	c.lastMu.RUnlock()
 
@@ -266,7 +266,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.incidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component.go
@@ -30,6 +30,7 @@ import (
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
 )
@@ -50,6 +51,8 @@ type component struct {
 	dcgmInstance        nvidiadcgm.Instance
 	dcgmHealthCache     *nvidiadcgm.HealthCache
 	dcgmFieldValueCache *nvidiadcgm.FieldValueCache
+
+	eventBucket eventstore.Bucket
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -83,6 +86,15 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 			log.Logger.Warnw("failed to register inforom fields", "error", err)
 		} else {
 			log.Logger.Infow("registered inforom fields for centralized watching", "numFields", len(inforomFields))
+		}
+	}
+
+	if gpudInstance.EventStore != nil {
+		var err error
+		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name)
+		if err != nil {
+			ccancel()
+			return nil, err
 		}
 	}
 
@@ -136,17 +148,38 @@ func (c *component) LastHealthStates() apiv1.HealthStates {
 }
 
 func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
-	return nil, nil
+	if c.eventBucket == nil {
+		return nil, nil
+	}
+	events, err := c.eventBucket.Get(ctx, since)
+	if err != nil {
+		return nil, err
+	}
+	var ret apiv1.Events
+	for _, ev := range events {
+		ret = append(ret, ev.ToEvent())
+	}
+	return ret, nil
 }
 
 func (c *component) Close() error {
 	log.Logger.Debugw("closing component")
 	c.cancel()
+	if c.eventBucket != nil {
+		c.eventBucket.Close()
+	}
 	return nil
 }
 
 func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu InfoROM metrics via DCGM")
+
+	c.lastMu.RLock()
+	var prevIncidents []dcgmcommon.EnrichedIncident
+	if c.lastCheckResult != nil {
+		prevIncidents = c.lastCheckResult.enrichedIncidents
+	}
+	c.lastMu.RUnlock()
 
 	cr := &checkResult{ts: time.Now().UTC()}
 	defer func() {
@@ -230,6 +263,8 @@ func (c *component) Check() components.CheckResult {
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.reason = "unknown health status"
 	}
+
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component_test.go
@@ -200,3 +200,14 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 		t.Fatalf("legacy uuid = %v", got)
 	}
 }
+
+func TestEvents_NilBucket(t *testing.T) {
+	c := &component{}
+	events, err := c.Events(context.Background(), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("Events() returned unexpected error: %v", err)
+	}
+	if events != nil {
+		t.Fatalf("Events() returned %v, want nil", events)
+	}
+}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component.go
@@ -184,9 +184,9 @@ func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu memory via DCGM")
 
 	c.lastMu.RLock()
-	var prevIncidents []dcgmcommon.EnrichedIncident
+	var prevIncidents []apiv1.HealthStateIncident
 	if c.lastCheckResult != nil {
-		prevIncidents = c.lastCheckResult.enrichedIncidents
+		prevIncidents = c.lastCheckResult.incidents
 	}
 	c.lastMu.RUnlock()
 
@@ -368,7 +368,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.incidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component.go
@@ -39,6 +39,8 @@ const Name = "accelerator-nvidia-dcgm-mem"
 
 const (
 	defaultHealthCheckInterval = time.Minute
+
+	EventNameIncident = "dcgm_mem_incident"
 )
 
 var _ components.Component = &component{}
@@ -366,7 +368,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component.go
@@ -30,6 +30,7 @@ import (
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
 )
@@ -50,6 +51,8 @@ type component struct {
 	dcgmInstance        nvidiadcgm.Instance
 	dcgmHealthCache     *nvidiadcgm.HealthCache
 	dcgmFieldValueCache *nvidiadcgm.FieldValueCache
+
+	eventBucket eventstore.Bucket
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -87,6 +90,15 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		} else {
 			log.Logger.Infow("registered memory fields for centralized watching",
 				"numFields", len(memFields))
+		}
+	}
+
+	if gpudInstance.EventStore != nil {
+		var err error
+		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name)
+		if err != nil {
+			ccancel()
+			return nil, err
 		}
 	}
 
@@ -140,7 +152,18 @@ func (c *component) LastHealthStates() apiv1.HealthStates {
 }
 
 func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
-	return nil, nil
+	if c.eventBucket == nil {
+		return nil, nil
+	}
+	events, err := c.eventBucket.Get(ctx, since)
+	if err != nil {
+		return nil, err
+	}
+	var ret apiv1.Events
+	for _, ev := range events {
+		ret = append(ret, ev.ToEvent())
+	}
+	return ret, nil
 }
 
 func (c *component) Close() error {
@@ -149,11 +172,21 @@ func (c *component) Close() error {
 	// Field watching is managed by centralized FieldValueCache, no cleanup needed here
 
 	c.cancel()
+	if c.eventBucket != nil {
+		c.eventBucket.Close()
+	}
 	return nil
 }
 
 func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu memory via DCGM")
+
+	c.lastMu.RLock()
+	var prevIncidents []dcgmcommon.EnrichedIncident
+	if c.lastCheckResult != nil {
+		prevIncidents = c.lastCheckResult.enrichedIncidents
+	}
+	c.lastMu.RUnlock()
 
 	cr := &checkResult{ts: time.Now().UTC()}
 	defer func() {
@@ -332,6 +365,8 @@ func (c *component) Check() components.CheckResult {
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.reason = "unknown health status"
 	}
+
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component_test.go
@@ -178,3 +178,14 @@ func TestCheck(t *testing.T) {
 		}
 	}
 }
+
+func TestEvents_NilBucket(t *testing.T) {
+	c := &component{}
+	events, err := c.Events(context.Background(), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("Events() returned unexpected error: %v", err)
+	}
+	if events != nil {
+		t.Fatalf("Events() returned %v, want nil", events)
+	}
+}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
@@ -184,9 +184,9 @@ func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu NVLink metrics via DCGM")
 
 	c.lastMu.RLock()
-	var prevIncidents []dcgmcommon.EnrichedIncident
+	var prevIncidents []apiv1.HealthStateIncident
 	if c.lastCheckResult != nil {
-		prevIncidents = c.lastCheckResult.enrichedIncidents
+		prevIncidents = c.lastCheckResult.incidents
 	}
 	c.lastMu.RUnlock()
 
@@ -347,7 +347,7 @@ func (c *component) Check() components.CheckResult {
 		}
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.incidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
@@ -30,6 +30,7 @@ import (
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
 )
@@ -50,6 +51,8 @@ type component struct {
 	dcgmInstance        nvidiadcgm.Instance
 	dcgmHealthCache     *nvidiadcgm.HealthCache
 	dcgmFieldValueCache *nvidiadcgm.FieldValueCache
+
+	eventBucket eventstore.Bucket
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -87,6 +90,15 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		} else {
 			log.Logger.Infow("registered NVLink fields for centralized watching",
 				"numFields", len(nvlinkFields))
+		}
+	}
+
+	if gpudInstance.EventStore != nil {
+		var err error
+		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name)
+		if err != nil {
+			ccancel()
+			return nil, err
 		}
 	}
 
@@ -140,7 +152,18 @@ func (c *component) LastHealthStates() apiv1.HealthStates {
 }
 
 func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
-	return nil, nil
+	if c.eventBucket == nil {
+		return nil, nil
+	}
+	events, err := c.eventBucket.Get(ctx, since)
+	if err != nil {
+		return nil, err
+	}
+	var ret apiv1.Events
+	for _, ev := range events {
+		ret = append(ret, ev.ToEvent())
+	}
+	return ret, nil
 }
 
 func (c *component) Close() error {
@@ -149,11 +172,21 @@ func (c *component) Close() error {
 	// Field watching is managed by centralized FieldValueCache, no cleanup needed here
 
 	c.cancel()
+	if c.eventBucket != nil {
+		c.eventBucket.Close()
+	}
 	return nil
 }
 
 func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu NVLink metrics via DCGM")
+
+	c.lastMu.RLock()
+	var prevIncidents []dcgmcommon.EnrichedIncident
+	if c.lastCheckResult != nil {
+		prevIncidents = c.lastCheckResult.enrichedIncidents
+	}
+	c.lastMu.RUnlock()
 
 	cr := &checkResult{ts: time.Now().UTC()}
 	defer func() {
@@ -311,6 +344,8 @@ func (c *component) Check() components.CheckResult {
 			}
 		}
 	}
+
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
@@ -37,6 +37,8 @@ import (
 
 const Name = "accelerator-nvidia-dcgm-nvlink"
 
+const EventNameIncident = "dcgm_nvlink_incident"
+
 const (
 	defaultHealthCheckInterval = time.Minute
 )
@@ -345,7 +347,7 @@ func (c *component) Check() components.CheckResult {
 		}
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component_test.go
@@ -185,3 +185,14 @@ func TestCheck(t *testing.T) {
 		}
 	}
 }
+
+func TestEvents_NilBucket(t *testing.T) {
+	c := &component{}
+	events, err := c.Events(context.Background(), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("Events() returned unexpected error: %v", err)
+	}
+	if events != nil {
+		t.Fatalf("Events() returned %v, want nil", events)
+	}
+}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component.go
@@ -36,6 +36,8 @@ import (
 
 const Name = "accelerator-nvidia-dcgm-nvswitch"
 
+const EventNameIncident = "dcgm_nvswitch_incident"
+
 const (
 	defaultHealthCheckInterval = time.Minute
 )
@@ -305,7 +307,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown NVSwitch health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component.go
@@ -197,9 +197,9 @@ func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia NVSwitch metrics via DCGM")
 
 	c.lastMu.RLock()
-	var prevIncidents []dcgmcommon.EnrichedIncident
+	var prevIncidents []apiv1.HealthStateIncident
 	if c.lastCheckResult != nil {
-		prevIncidents = c.lastCheckResult.enrichedIncidents
+		prevIncidents = c.lastCheckResult.incidents
 	}
 	c.lastMu.RUnlock()
 
@@ -307,7 +307,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown NVSwitch health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.incidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component.go
@@ -29,6 +29,7 @@ import (
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
 )
@@ -48,6 +49,8 @@ type component struct {
 	healthCheckInterval time.Duration
 	dcgmInstance        nvidiadcgm.Instance
 	dcgmHealthCache     *nvidiadcgm.HealthCache
+
+	eventBucket eventstore.Bucket
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -106,6 +109,15 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		}
 	}
 
+	if gpudInstance.EventStore != nil {
+		var err error
+		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name)
+		if err != nil {
+			ccancel()
+			return nil, err
+		}
+	}
+
 	return c, nil
 }
 
@@ -156,17 +168,38 @@ func (c *component) LastHealthStates() apiv1.HealthStates {
 }
 
 func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
-	return nil, nil
+	if c.eventBucket == nil {
+		return nil, nil
+	}
+	events, err := c.eventBucket.Get(ctx, since)
+	if err != nil {
+		return nil, err
+	}
+	var ret apiv1.Events
+	for _, ev := range events {
+		ret = append(ret, ev.ToEvent())
+	}
+	return ret, nil
 }
 
 func (c *component) Close() error {
 	log.Logger.Debugw("closing component")
 	c.cancel()
+	if c.eventBucket != nil {
+		c.eventBucket.Close()
+	}
 	return nil
 }
 
 func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia NVSwitch metrics via DCGM")
+
+	c.lastMu.RLock()
+	var prevIncidents []dcgmcommon.EnrichedIncident
+	if c.lastCheckResult != nil {
+		prevIncidents = c.lastCheckResult.enrichedIncidents
+	}
+	c.lastMu.RUnlock()
 
 	cr := &checkResult{ts: time.Now().UTC()}
 	defer func() {
@@ -271,6 +304,8 @@ func (c *component) Check() components.CheckResult {
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.reason = "unknown NVSwitch health status"
 	}
+
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component_test.go
@@ -161,3 +161,14 @@ func TestCheckResultHealthStates_UsesNVSwitchIdentifiers(t *testing.T) {
 		t.Fatalf("legacy uuid = %v", got)
 	}
 }
+
+func TestEvents_NilBucket(t *testing.T) {
+	c := &component{}
+	events, err := c.Events(context.Background(), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("Events() returned unexpected error: %v", err)
+	}
+	if events != nil {
+		t.Fatalf("Events() returned %v, want nil", events)
+	}
+}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component.go
@@ -37,6 +37,8 @@ import (
 
 const Name = "accelerator-nvidia-dcgm-pcie"
 
+const EventNameIncident = "dcgm_pcie_incident"
+
 const (
 	defaultHealthCheckInterval = time.Minute
 )
@@ -281,7 +283,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component.go
@@ -184,9 +184,9 @@ func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu PCIe metrics via DCGM")
 
 	c.lastMu.RLock()
-	var prevIncidents []dcgmcommon.EnrichedIncident
+	var prevIncidents []apiv1.HealthStateIncident
 	if c.lastCheckResult != nil {
-		prevIncidents = c.lastCheckResult.enrichedIncidents
+		prevIncidents = c.lastCheckResult.incidents
 	}
 	c.lastMu.RUnlock()
 
@@ -283,7 +283,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.incidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component.go
@@ -30,6 +30,7 @@ import (
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
 )
@@ -50,6 +51,8 @@ type component struct {
 	dcgmInstance        nvidiadcgm.Instance
 	dcgmHealthCache     *nvidiadcgm.HealthCache
 	dcgmFieldValueCache *nvidiadcgm.FieldValueCache
+
+	eventBucket eventstore.Bucket
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -87,6 +90,15 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		} else {
 			log.Logger.Infow("registered PCIe fields for centralized watching",
 				"numFields", len(pcieFields))
+		}
+	}
+
+	if gpudInstance.EventStore != nil {
+		var err error
+		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name)
+		if err != nil {
+			ccancel()
+			return nil, err
 		}
 	}
 
@@ -140,7 +152,18 @@ func (c *component) LastHealthStates() apiv1.HealthStates {
 }
 
 func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
-	return nil, nil
+	if c.eventBucket == nil {
+		return nil, nil
+	}
+	events, err := c.eventBucket.Get(ctx, since)
+	if err != nil {
+		return nil, err
+	}
+	var ret apiv1.Events
+	for _, ev := range events {
+		ret = append(ret, ev.ToEvent())
+	}
+	return ret, nil
 }
 
 func (c *component) Close() error {
@@ -149,11 +172,21 @@ func (c *component) Close() error {
 	// Field watching is managed by centralized FieldValueCache, no cleanup needed here
 
 	c.cancel()
+	if c.eventBucket != nil {
+		c.eventBucket.Close()
+	}
 	return nil
 }
 
 func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu PCIe metrics via DCGM")
+
+	c.lastMu.RLock()
+	var prevIncidents []dcgmcommon.EnrichedIncident
+	if c.lastCheckResult != nil {
+		prevIncidents = c.lastCheckResult.enrichedIncidents
+	}
+	c.lastMu.RUnlock()
 
 	cr := &checkResult{ts: time.Now().UTC()}
 	defer func() {
@@ -247,6 +280,8 @@ func (c *component) Check() components.CheckResult {
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.reason = "unknown health status"
 	}
+
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component_test.go
@@ -168,3 +168,14 @@ func TestCheck(t *testing.T) {
 		}
 	}
 }
+
+func TestEvents_NilBucket(t *testing.T) {
+	c := &component{}
+	events, err := c.Events(context.Background(), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("Events() returned unexpected error: %v", err)
+	}
+	if events != nil {
+		t.Fatalf("Events() returned %v, want nil", events)
+	}
+}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component.go
@@ -30,6 +30,7 @@ import (
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
 )
@@ -51,6 +52,8 @@ type component struct {
 	dcgmInstance        nvidiadcgm.Instance
 	dcgmHealthCache     *nvidiadcgm.HealthCache
 	dcgmFieldValueCache *nvidiadcgm.FieldValueCache
+
+	eventBucket eventstore.Bucket
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -89,6 +92,15 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		} else {
 			log.Logger.Infow("registered power fields for centralized watching",
 				"numFields", len(powerFields))
+		}
+	}
+
+	if gpudInstance.EventStore != nil {
+		var err error
+		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name)
+		if err != nil {
+			ccancel()
+			return nil, err
 		}
 	}
 
@@ -148,7 +160,18 @@ func (c *component) LastHealthStates() apiv1.HealthStates {
 }
 
 func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
-	return nil, nil
+	if c.eventBucket == nil {
+		return nil, nil
+	}
+	events, err := c.eventBucket.Get(ctx, since)
+	if err != nil {
+		return nil, err
+	}
+	var ret apiv1.Events
+	for _, ev := range events {
+		ret = append(ret, ev.ToEvent())
+	}
+	return ret, nil
 }
 
 func (c *component) Close() error {
@@ -157,11 +180,21 @@ func (c *component) Close() error {
 	// Field watching is managed by centralized FieldValueCache, no cleanup needed here
 
 	c.cancel()
+	if c.eventBucket != nil {
+		c.eventBucket.Close()
+	}
 	return nil
 }
 
 func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu power via DCGM")
+
+	c.lastMu.RLock()
+	var prevIncidents []dcgmcommon.EnrichedIncident
+	if c.lastCheckResult != nil {
+		prevIncidents = c.lastCheckResult.enrichedIncidents
+	}
+	c.lastMu.RUnlock()
 
 	cr := &checkResult{
 		ts: time.Now().UTC(),
@@ -269,6 +302,8 @@ func (c *component) Check() components.CheckResult {
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.reason = "unknown health status"
 	}
+
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component.go
@@ -39,6 +39,8 @@ const Name = "accelerator-nvidia-dcgm-power"
 
 const (
 	defaultHealthCheckInterval = time.Minute
+
+	EventNameIncident = "dcgm_power_incident"
 )
 
 var _ components.Component = &component{}
@@ -303,7 +305,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component.go
@@ -192,9 +192,9 @@ func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu power via DCGM")
 
 	c.lastMu.RLock()
-	var prevIncidents []dcgmcommon.EnrichedIncident
+	var prevIncidents []apiv1.HealthStateIncident
 	if c.lastCheckResult != nil {
-		prevIncidents = c.lastCheckResult.enrichedIncidents
+		prevIncidents = c.lastCheckResult.incidents
 	}
 	c.lastMu.RUnlock()
 
@@ -305,7 +305,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.incidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component_test.go
@@ -226,3 +226,14 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 		t.Fatalf("legacy code = %v", got)
 	}
 }
+
+func TestEvents_NilBucket(t *testing.T) {
+	c := &component{}
+	events, err := c.Events(context.Background(), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("Events() returned unexpected error: %v", err)
+	}
+	if events != nil {
+		t.Fatalf("Events() returned %v, want nil", events)
+	}
+}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component.go
@@ -192,9 +192,9 @@ func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu thermal via DCGM")
 
 	c.lastMu.RLock()
-	var prevIncidents []dcgmcommon.EnrichedIncident
+	var prevIncidents []apiv1.HealthStateIncident
 	if c.lastCheckResult != nil {
-		prevIncidents = c.lastCheckResult.enrichedIncidents
+		prevIncidents = c.lastCheckResult.incidents
 	}
 	c.lastMu.RUnlock()
 
@@ -307,7 +307,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.incidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component.go
@@ -39,6 +39,8 @@ const Name = "accelerator-nvidia-dcgm-thermal"
 
 const (
 	defaultHealthCheckInterval = time.Minute
+
+	EventNameIncident = "dcgm_thermal_incident"
 )
 
 var _ components.Component = &component{}
@@ -305,7 +307,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "unknown health status"
 	}
 
-	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component.go
@@ -30,6 +30,7 @@ import (
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
 )
@@ -51,6 +52,8 @@ type component struct {
 	dcgmInstance        nvidiadcgm.Instance
 	dcgmHealthCache     *nvidiadcgm.HealthCache
 	dcgmFieldValueCache *nvidiadcgm.FieldValueCache
+
+	eventBucket eventstore.Bucket
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -89,6 +92,15 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		} else {
 			log.Logger.Infow("registered temperature fields for centralized watching",
 				"numFields", len(temperatureFields))
+		}
+	}
+
+	if gpudInstance.EventStore != nil {
+		var err error
+		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name)
+		if err != nil {
+			ccancel()
+			return nil, err
 		}
 	}
 
@@ -148,7 +160,18 @@ func (c *component) LastHealthStates() apiv1.HealthStates {
 }
 
 func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
-	return nil, nil
+	if c.eventBucket == nil {
+		return nil, nil
+	}
+	events, err := c.eventBucket.Get(ctx, since)
+	if err != nil {
+		return nil, err
+	}
+	var ret apiv1.Events
+	for _, ev := range events {
+		ret = append(ret, ev.ToEvent())
+	}
+	return ret, nil
 }
 
 func (c *component) Close() error {
@@ -157,11 +180,21 @@ func (c *component) Close() error {
 	// Field watching is managed by centralized FieldValueCache, no cleanup needed here
 
 	c.cancel()
+	if c.eventBucket != nil {
+		c.eventBucket.Close()
+	}
 	return nil
 }
 
 func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking nvidia gpu thermal via DCGM")
+
+	c.lastMu.RLock()
+	var prevIncidents []dcgmcommon.EnrichedIncident
+	if c.lastCheckResult != nil {
+		prevIncidents = c.lastCheckResult.enrichedIncidents
+	}
+	c.lastMu.RUnlock()
 
 	cr := &checkResult{
 		ts: time.Now().UTC(),
@@ -271,6 +304,8 @@ func (c *component) Check() components.CheckResult {
 		cr.health = apiv1.HealthStateTypeDegraded
 		cr.reason = "unknown health status"
 	}
+
+	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, c.eventBucket, prevIncidents, cr.enrichedIncidents)
 
 	return cr
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component_test.go
@@ -176,3 +176,14 @@ func TestCheck(t *testing.T) {
 		}
 	}
 }
+
+func TestEvents_NilBucket(t *testing.T) {
+	c := &component{}
+	events, err := c.Events(context.Background(), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("Events() returned unexpected error: %v", err)
+	}
+	if events != nil {
+		t.Fatalf("Events() returned %v, want nil", events)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `EmitNewIncidentEvents()` helper in `dcgmcommon` that detects newly appearing DCGM incidents by comparing current vs. previous `EnrichedIncident` slices (dedup key: `UUID+ErrorCode+System`), emitting only onset events (`Unhealthy` → `Critical`, `Degraded` → `Warning`)
- Implements `Events()` on 7 DCGM health components (`thermal`, `power`, `mem`, `pcie`, `nvlink`, `nvswitch`, `inforom`) — previously returned `nil`; now reads from a per-component `eventstore.Bucket`
- Each component initializes an `eventBucket` from `gpudInstance.EventStore` in `New()`, following the same pattern as the XID component

## Motivation

DCGM health incidents were only visible via `LastHealthStates()` (current state only). This change persists incident onset events to the event store, making them:
- Queryable historically via `GET /v1/events`
- Included in OTLP event log exports to the remote backend

## Test plan

- [x] `TestEmitNewIncidentEvents` in `dcgmcommon` covers: no incidents, dedup suppression, new incident emission, severity mapping (Unhealthy→Critical, Degraded→Warning), multiple incidents
- [x] `TestEvents_NilBucket` added to each of the 7 component test files — verifies graceful nil-guard when no event store is configured
- [x] All existing tests pass: `go test ./...` (agent) and `go test ./components/accelerator/nvidia/dcgm/...` (SDK)
- [x] Manual: with DCGM available, verify incidents appear at `curl http://127.0.0.1:15133/v1/events` when GPU health degrades

[closes #]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent incident event recording added across DCGM GPU components; new incidents are emitted (with severity mapped to warning/critical) and deduplicated within a run, and buckets are closed on shutdown.
  * Incident events are queryable historically with time-based filtering.

* **Tests**
  * Added tests for event emission, deduplication and severity behavior, and for behavior when no event bucket is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->