### PR TITLE
feat: add dcgm version to machine info

### DIFF
--- a/internal/dcgmversion/dcgmversion.go
+++ b/internal/dcgmversion/dcgmversion.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dcgmversion
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	godcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+)
+
+var getenv = os.Getenv
+
+// DetectHostengineVersion returns the DCGM HostEngine version for the current
+// environment. It initializes a standalone DCGM connection and extracts the
+// semantic version from the build info string.
+func DetectHostengineVersion() (string, error) {
+	initParams := resolveInitParams()
+	cleanup, err := godcgm.Init(godcgm.Standalone, initParams.address, initParams.isUnixSocket)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
+	versionInfo, err := godcgm.GetHostengineVersionInfo()
+	if err != nil {
+		return "", err
+	}
+
+	return extractVersion(versionInfo.RawBuildInfoString), nil
+}
+
+type initParams struct {
+	address      string
+	isUnixSocket string
+}
+
+func resolveInitParams() initParams {
+	address := strings.TrimSpace(getenv("DCGM_URL"))
+	isUnixSocket := "0"
+
+	if truthy, err := strconv.ParseBool(strings.TrimSpace(getenv("DCGM_URL_IS_UNIX_SOCKET"))); err == nil && truthy {
+		isUnixSocket = "1"
+	}
+
+	if address == "" {
+		address = "localhost"
+	}
+
+	return initParams{
+		address:      address,
+		isUnixSocket: isUnixSocket,
+	}
+}
+
+func extractVersion(raw string) string {
+	for _, pair := range strings.Split(raw, ";") {
+		key, value, ok := strings.Cut(pair, ":")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) == "version" {
+			return strings.TrimSpace(value)
+		}
+	}
+
+	return ""
+}

--- a/internal/dcgmversion/dcgmversion_test.go
+++ b/internal/dcgmversion/dcgmversion_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dcgmversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveInitParams(t *testing.T) {
+	originalGetenv := getenv
+	t.Cleanup(func() {
+		getenv = originalGetenv
+	})
+
+	t.Run("defaults", func(t *testing.T) {
+		getenv = func(string) string { return "" }
+
+		params := resolveInitParams()
+		assert.Equal(t, "localhost", params.address)
+		assert.Equal(t, "0", params.isUnixSocket)
+	})
+
+	t.Run("respects env", func(t *testing.T) {
+		getenv = func(key string) string {
+			switch key {
+			case "DCGM_URL":
+				return "nvidia-dcgm.gpu-operator.svc:5555"
+			case "DCGM_URL_IS_UNIX_SOCKET":
+				return "true"
+			default:
+				return ""
+			}
+		}
+
+		params := resolveInitParams()
+		assert.Equal(t, "nvidia-dcgm.gpu-operator.svc:5555", params.address)
+		assert.Equal(t, "1", params.isUnixSocket)
+	})
+}
+
+func TestExtractVersion(t *testing.T) {
+	t.Run("extracts version", func(t *testing.T) {
+		assert.Equal(t, "4.2.3", extractVersion("arch:x86_64;version: 4.2.3;build:123"))
+	})
+
+	t.Run("returns empty when missing", func(t *testing.T) {
+		assert.Empty(t, extractVersion("arch:x86_64;build:123"))
+	})
+}

--- a/internal/exporter/converter/csv.go
+++ b/internal/exporter/converter/csv.go
@@ -286,6 +286,7 @@ func (c *csvConverter) writeMachineInfoCSV(outputDir, filename string, data *col
 		[]string{"Container Runtime Version", i.ContainerRuntimeVersion},
 		[]string{"OS Image", i.OSImage},
 		[]string{"Kernel Version", i.KernelVersion},
+		[]string{"DCGM Version", i.DCGMVersion},
 	)
 
 	// CPU info

--- a/internal/exporter/converter/csv_test.go
+++ b/internal/exporter/converter/csv_test.go
@@ -178,6 +178,7 @@ func TestCSVConverter_Convert_MachineInfo(t *testing.T) {
 
 	machineInfo := &machineinfo.MachineInfo{
 		FleetintVersion: "0.1.5",
+		DCGMVersion:     "4.2.3",
 		OSImage:         "Ubuntu 22.04",
 		KernelVersion:   "5.15.0",
 		CPUInfo: &apiv1.MachineCPUInfo{
@@ -223,6 +224,7 @@ func TestCSVConverter_Convert_MachineInfo(t *testing.T) {
 	// Should have multiple rows for machine info attributes
 	assert.Greater(t, len(records), 5)
 	assert.Equal(t, []string{"attribute_name", "attribute_value"}, records[0])
+	assert.Contains(t, records, []string{"DCGM Version", "4.2.3"})
 }
 
 func TestCSVConverter_Convert_EmptyData(t *testing.T) {

--- a/internal/exporter/converter/otlp_test.go
+++ b/internal/exporter/converter/otlp_test.go
@@ -313,6 +313,7 @@ func TestOTLPConverter_Convert_WithMachineInfo(t *testing.T) {
 		MachineID: "test-machine",
 		MachineInfo: &machineinfo.MachineInfo{
 			FleetintVersion: "0.1.5",
+			DCGMVersion:     "4.2.3",
 			OSImage:         "Ubuntu 22.04",
 			KernelVersion:   "5.15.0",
 			CPUInfo: &apiv1.MachineCPUInfo{
@@ -354,6 +355,7 @@ func TestOTLPConverter_Convert_WithMachineInfo(t *testing.T) {
 		}
 	}
 	assert.True(t, hasServiceName, "Should have service.name attribute")
+	assert.Equal(t, "4.2.3", findAttribute(t, rm.Resource.Attributes, "dcgmVersion").GetStringValue())
 }
 
 func TestOTLPConverter_Convert_WithAttestationData(t *testing.T) {

--- a/internal/machineinfo/machineinfo.go
+++ b/internal/machineinfo/machineinfo.go
@@ -31,8 +31,11 @@ import (
 	"github.com/olekukonko/tablewriter"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/dcgmversion"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/version"
 )
+
+var getDCGMVersion = dcgmversion.DetectHostengineVersion
 
 // MachineInfo is a custom struct that replaces GPUdVersion with FleetintVersion
 type MachineInfo struct {
@@ -42,6 +45,8 @@ type MachineInfo struct {
 	GPUDriverVersion string `json:"gpuDriverVersion,omitempty"`
 	// CUDAVersion represents the current version of cuda library.
 	CUDAVersion string `json:"cudaVersion,omitempty"`
+	// DCGMVersion represents the current version of the DCGM HostEngine when reachable.
+	DCGMVersion string `json:"dcgmVersion,omitempty"`
 	// ContainerRuntime Version reported by the node through runtime remote API (e.g. containerd://1.4.2).
 	ContainerRuntimeVersion string `json:"containerRuntimeVersion,omitempty"`
 	// Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
@@ -117,11 +122,14 @@ func GetMachineInfo(nvmlInstance nvidianvml.Instance, opts ...MachineInfoOption)
 		}
 	}
 
+	dcgmVersion, _ := getDCGMVersion()
+
 	// Convert to our custom MachineInfo struct with Fleet Intelligence version
 	return &MachineInfo{
 		FleetintVersion:         version.Version,
 		GPUDriverVersion:        gpudInfo.GPUDriverVersion,
 		CUDAVersion:             gpudInfo.CUDAVersion,
+		DCGMVersion:             dcgmVersion,
 		ContainerRuntimeVersion: gpudInfo.ContainerRuntimeVersion,
 		KernelVersion:           gpudInfo.KernelVersion,
 		OSImage:                 gpudInfo.OSImage,
@@ -165,6 +173,7 @@ func (i *MachineInfo) RenderTable(wr io.Writer) {
 	}
 
 	table.Append([]string{"CUDA Version", i.CUDAVersion})
+	table.Append([]string{"DCGM Version", i.DCGMVersion})
 	if i.GPUInfo != nil {
 		table.Append([]string{"GPU Driver Version", i.GPUDriverVersion})
 		table.Append([]string{"GPU Product", i.GPUInfo.Product})

--- a/internal/machineinfo/machineinfo_test.go
+++ b/internal/machineinfo/machineinfo_test.go
@@ -34,6 +34,15 @@ import (
 
 // TestGetMachineInfo tests the GetMachineInfo function
 func TestGetMachineInfo(t *testing.T) {
+	originalGetDCGMVersion := getDCGMVersion
+	t.Cleanup(func() {
+		getDCGMVersion = originalGetDCGMVersion
+	})
+
+	getDCGMVersion = func() (string, error) {
+		return "4.2.3", nil
+	}
+
 	tests := []struct {
 		name     string
 		wantErr  bool
@@ -46,6 +55,7 @@ func TestGetMachineInfo(t *testing.T) {
 				assert.NotNil(t, info)
 				// The version should be set from the version package
 				assert.Equal(t, version.Version, info.FleetintVersion)
+				assert.Equal(t, "4.2.3", info.DCGMVersion)
 				// Other fields should be populated by the underlying GetMachineInfo
 				assert.NotEmpty(t, info.Hostname)
 			},
@@ -78,6 +88,7 @@ func TestMachineInfoStruct(t *testing.T) {
 		FleetintVersion:         "1.0.0-test",
 		GPUDriverVersion:        "550.54.15",
 		CUDAVersion:             "12.4",
+		DCGMVersion:             "4.2.3",
 		ContainerRuntimeVersion: "containerd://1.7.13",
 		KernelVersion:           "6.5.0-28-generic",
 		OSImage:                 "Ubuntu 22.04.4 LTS",
@@ -120,6 +131,7 @@ func TestMachineInfoStruct(t *testing.T) {
 	assert.Equal(t, "1.0.0-test", testInfo.FleetintVersion)
 	assert.Equal(t, "550.54.15", testInfo.GPUDriverVersion)
 	assert.Equal(t, "12.4", testInfo.CUDAVersion)
+	assert.Equal(t, "4.2.3", testInfo.DCGMVersion)
 	assert.Equal(t, "containerd://1.7.13", testInfo.ContainerRuntimeVersion)
 	assert.Equal(t, "6.5.0-28-generic", testInfo.KernelVersion)
 	assert.Equal(t, "Ubuntu 22.04.4 LTS", testInfo.OSImage)
@@ -192,6 +204,7 @@ func TestRenderTable_BasicFields(t *testing.T) {
 		OSImage:                 "Ubuntu 22.04.4 LTS",
 		KernelVersion:           "6.5.0-28-generic",
 		CUDAVersion:             "12.4",
+		DCGMVersion:             "4.2.3",
 	}
 	var buf bytes.Buffer
 
@@ -206,6 +219,7 @@ func TestRenderTable_BasicFields(t *testing.T) {
 	assert.Contains(t, output, "Ubuntu 22.04.4 LTS")
 	assert.Contains(t, output, "6.5.0-28-generic")
 	assert.Contains(t, output, "12.4")
+	assert.Contains(t, output, "4.2.3")
 
 	// Verify labels are present
 	assert.Contains(t, output, "Fleetint Version")
@@ -213,6 +227,7 @@ func TestRenderTable_BasicFields(t *testing.T) {
 	assert.Contains(t, output, "OS Image")
 	assert.Contains(t, output, "Kernel Version")
 	assert.Contains(t, output, "CUDA Version")
+	assert.Contains(t, output, "DCGM Version")
 }
 
 // TestRenderTable_WithCPUInfo tests RenderTable with CPU information
@@ -454,6 +469,7 @@ func TestMachineInfo_JSONMarshaling(t *testing.T) {
 		FleetintVersion:         "1.0.0",
 		GPUDriverVersion:        "550.54.15",
 		CUDAVersion:             "12.4",
+		DCGMVersion:             "4.2.3",
 		ContainerRuntimeVersion: "containerd://1.7.13",
 		KernelVersion:           "6.5.0-28-generic",
 		OSImage:                 "Ubuntu 22.04.4 LTS",
@@ -469,6 +485,22 @@ func TestMachineInfo_JSONMarshaling(t *testing.T) {
 	assert.NotEmpty(t, info.FleetintVersion)
 	assert.NotEmpty(t, info.GPUDriverVersion)
 	assert.NotEmpty(t, info.CUDAVersion)
+	assert.NotEmpty(t, info.DCGMVersion)
+}
+
+func TestGetMachineInfo_DCGMVersionBestEffort(t *testing.T) {
+	originalGetDCGMVersion := getDCGMVersion
+	t.Cleanup(func() {
+		getDCGMVersion = originalGetDCGMVersion
+	})
+
+	getDCGMVersion = func() (string, error) {
+		return "", assert.AnError
+	}
+
+	info, err := GetMachineInfo(nvidianvml.NewNoOp())
+	require.NoError(t, err)
+	assert.Empty(t, info.DCGMVersion)
 }
 
 // TestRenderTable_WithNilSubStructs tests that RenderTable handles nil sub-structs gracefully

--- a/internal/precheck/precheck.go
+++ b/internal/precheck/precheck.go
@@ -18,15 +18,14 @@ package precheck
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"slices"
 	"strconv"
 	"strings"
 
 	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
-	godcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
 
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/dcgmversion"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
 )
 
@@ -36,12 +35,10 @@ const minimumDCGMVersion = "4.2.3"
 const minimumDriverMajorVersion = 510
 
 var (
-	newNVML              = nvidianvml.New
-	getMachineInfo       = machineinfo.GetMachineInfo
-	lookPath             = exec.LookPath
-	dcgmInit             = initDCGMStandalone
-	getHostengineVersion = getDCGMHostengineVersion
-	getenv               = os.Getenv
+	newNVML           = nvidianvml.New
+	getMachineInfo    = machineinfo.GetMachineInfo
+	lookPath          = exec.LookPath
+	detectDCGMVersion = dcgmversion.DetectHostengineVersion
 )
 
 type nvmlInstance = nvidianvml.Instance
@@ -331,67 +328,10 @@ func detectNVAttest() bool {
 }
 
 func detectDCGM() (bool, string) {
-	cleanup, err := dcgmInit()
+	version, err := detectDCGMVersion()
 	if err != nil {
 		return false, ""
 	}
-	defer cleanup()
-
-	version, err := getHostengineVersion()
-	if err != nil {
-		return true, ""
-	}
 
 	return true, version
-}
-
-func extractVersion(raw string) string {
-	for _, pair := range strings.Split(raw, ";") {
-		key, value, ok := strings.Cut(pair, ":")
-		if !ok {
-			continue
-		}
-		if strings.TrimSpace(key) == "version" {
-			return strings.TrimSpace(value)
-		}
-	}
-
-	return ""
-}
-
-func initDCGMStandalone() (func(), error) {
-	initParams := resolveDCGMInitFromEnv()
-	return godcgm.Init(godcgm.Standalone, initParams.address, initParams.isUnixSocket)
-}
-
-func getDCGMHostengineVersion() (string, error) {
-	versionInfo, err := godcgm.GetHostengineVersionInfo()
-	if err != nil {
-		return "", err
-	}
-
-	return extractVersion(versionInfo.RawBuildInfoString), nil
-}
-
-type dcgmInitParams struct {
-	address      string
-	isUnixSocket string
-}
-
-func resolveDCGMInitFromEnv() dcgmInitParams {
-	address := strings.TrimSpace(getenv("DCGM_URL"))
-	isUnixSocket := "0"
-
-	if truthy, err := strconv.ParseBool(strings.TrimSpace(getenv("DCGM_URL_IS_UNIX_SOCKET"))); err == nil && truthy {
-		isUnixSocket = "1"
-	}
-
-	if address == "" {
-		address = "localhost"
-	}
-
-	return dcgmInitParams{
-		address:      address,
-		isUnixSocket: isUnixSocket,
-	}
 }

--- a/internal/precheck/precheck_test.go
+++ b/internal/precheck/precheck_test.go
@@ -304,15 +304,11 @@ func TestCollectInputCallsDCGMInit(t *testing.T) {
 
 	originalNewNVML := newNVML
 	originalLookPath := lookPath
-	originalDCGMInit := dcgmInit
-	originalGetHostengineVersion := getHostengineVersion
-	originalGetenv := getenv
+	originalDetectDCGMVersion := detectDCGMVersion
 	t.Cleanup(func() {
 		newNVML = originalNewNVML
 		lookPath = originalLookPath
-		dcgmInit = originalDCGMInit
-		getHostengineVersion = originalGetHostengineVersion
-		getenv = originalGetenv
+		detectDCGMVersion = originalDetectDCGMVersion
 	})
 
 	newNVML = func() (nvmlInstance, error) {
@@ -321,16 +317,10 @@ func TestCollectInputCallsDCGMInit(t *testing.T) {
 	lookPath = func(file string) (string, error) {
 		return "/usr/bin/" + file, nil
 	}
-	getenv = func(string) string {
-		return ""
-	}
 
-	dcgmInitCalled := false
-	dcgmInit = func() (func(), error) {
-		dcgmInitCalled = true
-		return func() {}, nil
-	}
-	getHostengineVersion = func() (string, error) {
+	detectDCGMCalled := false
+	detectDCGMVersion = func() (string, error) {
+		detectDCGMCalled = true
 		return "4.2.3", nil
 	}
 
@@ -340,7 +330,7 @@ func TestCollectInputCallsDCGMInit(t *testing.T) {
 	require.NotNil(t, input.DCGMReachable)
 	assert.True(t, *input.DCGMReachable)
 	assert.Equal(t, "4.2.3", input.DCGMVersion)
-	assert.True(t, dcgmInitCalled)
+	assert.True(t, detectDCGMCalled)
 }
 
 func machineInfoWithGPU(architecture, driverVersion string) *machineinfo.MachineInfo {


### PR DESCRIPTION
## Summary
- add DCGM HostEngine version detection to machine info as a best-effort field
- reuse shared DCGM version lookup from precheck and surface the field in table and CSV output
- add tests covering machine info, precheck, CSV, and OTLP export paths

## Behavior Changes
- machine info exports now include `dcgmVersion` when DCGM HostEngine is reachable
- machine info collection does not fail if the DCGM version cannot be determined

## Testing
- go test ./internal/dcgmversion ./internal/machineinfo ./internal/precheck ./internal/exporter/converter

[#1490]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now detects and reports DCGM HostEngine version in machine information
  * DCGM version automatically included in CSV output and OTLP telemetry exports
  * Flexible DCGM connection configuration via environment variables with intelligent defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->