### PR TITLE
fix: improve goreleaser tag selection and changelog grouping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           version: v2.4.1
           args: release --clean --config .goreleaser.yaml
         env:
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Get version and commit info

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -187,19 +187,19 @@ changelog:
   use: github
   groups:
     - title: 'New Features'
-      regexp: "^(\\[.*?\\]\\s+)?feat(\\(\\w+\\))?:"
+      regexp: '.*\bfeat(?:\([^)]+\))?!?:'
       order: 0
     - title: 'Bug Fixes'
-      regexp: "^(\\[.*?\\]\\s+)?fix(\\(\\w+\\))?:"
+      regexp: '.*\bfix(?:\([^)]+\))?!?:'
       order: 1
     - title: 'Performance Improvements'
-      regexp: "^(\\[.*?\\]\\s+)?perf(\\(\\w+\\))?:"
+      regexp: '.*\bperf(?:\([^)]+\))?!?:'
       order: 2
     - title: 'Documentation Updates'
-      regexp: "^(\\[.*?\\]\\s+)?docs(\\(\\w+\\))?:"
+      regexp: '.*\bdocs(?:\([^)]+\))?!?:'
       order: 3
     - title: 'Refactors'
-      regexp: "^(\\[.*?\\]\\s+)?refactor(\\(\\w+\\))?:"
+      regexp: '.*\brefactor(?:\([^)]+\))?!?:'
       order: 4
     - title: 'Other Changes'
       order: 999


### PR DESCRIPTION
## Summary
- pin GoReleaser to the triggering tag in the release workflow
- simplify changelog grouping regexes so conventional commit types match rendered changelog entries with SHA prefixes

## Notes
- targets main
- helps prevent RC releases from being overwritten when multiple tags point at the same commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation configuration to better categorize and organize changelog entries in future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->