### PR TITLE
chore: remove unused gpu-count flag and improve configuration docs

### DIFF
--- a/cmd/fleetint/root.go
+++ b/cmd/fleetint/root.go
@@ -94,11 +94,6 @@ func App() *cli.App {
 					Usage: "sets the components to enable (comma-separated, leave empty for default to enable all components, set 'none' or any other non-matching value to disable all components, prefix component name with '-' to disable it)",
 					Value: "",
 				},
-				&cli.IntFlag{
-					Name:  "gpu-count",
-					Usage: "specifies the expected GPU count",
-					Value: 0,
-				},
 				&cli.StringFlag{
 					Name:   "infiniband-expected-port-states",
 					Usage:  "set the infiniband expected port states in JSON (leave empty for default, useful for testing)",

--- a/cmd/fleetint/root.go
+++ b/cmd/fleetint/root.go
@@ -52,11 +52,6 @@ func App() *cli.App {
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error]",
 				},
-				&cli.IntFlag{
-					Name:  "gpu-count",
-					Usage: "specifies the expected GPU count",
-					Value: 0,
-				},
 				&cli.StringFlag{
 					Name:   "infiniband-expected-port-states",
 					Usage:  "set the infiniband expected port states in JSON (leave empty for default, useful for testing)",

--- a/cmd/fleetint/run.go
+++ b/cmd/fleetint/run.go
@@ -28,7 +28,6 @@ import (
 	"syscall"
 	"time"
 
-	componentsnvidiagpucounts "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/gpu-counts"
 	nvidiainfiniband "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/infiniband"
 	infinibandtypes "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/infiniband/types"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
@@ -206,7 +205,6 @@ func runCommand(cliContext *cli.Context) error {
 	ibClassRootDir := cliContext.String("infiniband-class-root-dir")
 	components := cliContext.String("components")
 
-	gpuCount := cliContext.Int("gpu-count")
 	infinibandExpectedPortStates := cliContext.String("infiniband-expected-port-states")
 	enableFaultInjection := cliContext.Bool("enable-fault-injection")
 
@@ -231,14 +229,6 @@ func runCommand(cliContext *cli.Context) error {
 			}
 			offlineModeDuration = parsedDuration
 		}
-	}
-
-	if gpuCount > 0 {
-		componentsnvidiagpucounts.SetDefaultExpectedGPUCounts(componentsnvidiagpucounts.ExpectedGPUCounts{
-			Count: gpuCount,
-		})
-
-		log.Logger.Infow("set gpu count", "gpuCount", gpuCount)
 	}
 
 	if len(infinibandExpectedPortStates) > 0 {

--- a/cmd/fleetint/scan.go
+++ b/cmd/fleetint/scan.go
@@ -23,7 +23,6 @@ import (
 	"github.com/urfave/cli"
 	"go.uber.org/zap"
 
-	componentsnvidiagpucounts "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/gpu-counts"
 	nvidiainfiniband "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/infiniband"
 	infinibandtypes "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/infiniband/types"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
@@ -35,14 +34,13 @@ func scanCreateCommand() func(*cli.Context) error {
 	return func(cliContext *cli.Context) error {
 		return cmdScan(
 			cliContext.String("log-level"),
-			cliContext.Int("gpu-count"),
 			cliContext.String("infiniband-expected-port-states"),
 			cliContext.String("infiniband-class-root-dir"),
 		)
 	}
 }
 
-func cmdScan(logLevel string, gpuCount int, infinibandExpectedPortStates string, ibClassRootDir string) error {
+func cmdScan(logLevel string, infinibandExpectedPortStates string, ibClassRootDir string) error {
 	zapLvl, err := log.ParseLogLevel(logLevel)
 	if err != nil {
 		return err
@@ -50,14 +48,6 @@ func cmdScan(logLevel string, gpuCount int, infinibandExpectedPortStates string,
 	log.Logger = log.CreateLogger(zapLvl, "")
 
 	log.Logger.Debugw("starting scan command")
-
-	if gpuCount > 0 {
-		componentsnvidiagpucounts.SetDefaultExpectedGPUCounts(componentsnvidiagpucounts.ExpectedGPUCounts{
-			Count: gpuCount,
-		})
-
-		log.Logger.Infow("set gpu count", "gpuCount", gpuCount)
-	}
 
 	if len(infinibandExpectedPortStates) > 0 {
 		var expectedPortStates infinibandtypes.ExpectedPortStates

--- a/deployments/helm/fleet-intelligence-agent/README.md
+++ b/deployments/helm/fleet-intelligence-agent/README.md
@@ -39,6 +39,7 @@ Common values (defaults from `values.yaml`):
 | `env.HTTPS_PROXY` | `""` | Optional HTTPS proxy for outbound requests. |
 | `logLevel` | `warn` | Log level. |
 | `listenAddress` | `0.0.0.0:15133` | Listen address. |
+| `retentionPeriod` | `24h` | Retention period for stored metrics and events. |
 | `components` | `all` | Enabled components. |
 | `enroll.enabled` | `false` | Enable enrollment init container. |
 | `enroll.unenroll` | `false` | Run explicit unenroll init container (cleanup persisted enrollment metadata). |

--- a/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
+++ b/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
@@ -122,6 +122,7 @@ spec:
             - run
             - {{ printf "--log-level=%s" .Values.logLevel | quote }}
             - {{ printf "--listen-address=%s" .Values.listenAddress | quote }}
+            - {{ printf "--retention-period=%s" .Values.retentionPeriod | quote }}
             - {{ printf "--components=%s" .Values.components | quote }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/deployments/helm/fleet-intelligence-agent/values.yaml
+++ b/deployments/helm/fleet-intelligence-agent/values.yaml
@@ -47,6 +47,7 @@ env:
 
 logLevel: warn
 listenAddress: 0.0.0.0:15133
+retentionPeriod: 24h
 components: all
 
 enroll:

--- a/deployments/packages/systemd/fleetint.env
+++ b/deployments/packages/systemd/fleetint.env
@@ -1,5 +1,7 @@
 # Fleet Intelligence Agent environment configuration
 FLEETINT_FLAGS="--log-level=warn"
+DCGM_URL="localhost"
+DCGM_URL_IS_UNIX_SOCKET="false"
 FLEETINT_COLLECT_INTERVAL="1m"
 FLEETINT_INCLUDE_METRICS="true"
 FLEETINT_INCLUDE_EVENTS="true"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,7 @@ sudo systemctl restart fleetintd
 ```yaml
 logLevel: info
 listenAddress: 0.0.0.0:15133
+retentionPeriod: 24h
 components: all,-accelerator-nvidia-dcgm-prof
 
 env:
@@ -115,7 +116,7 @@ These are the `fleetint run` flags supported by the CLI.
 | `--log-level` | Log level: `debug`, `info`, `warn`, `error`. | unset by CLI; packaged bare-metal default is `warn` via `FLEETINT_FLAGS` | `FLEETINT_FLAGS="--log-level=..."` | `logLevel` |
 | `--log-file` | Log file path. Leave empty to log to stdout/stderr. | empty | `FLEETINT_FLAGS="--log-file=..."` | not exposed by chart by default |
 | `--listen-address` | HTTP listen address for the agent API server. | CLI default `127.0.0.1:15133` | `FLEETINT_FLAGS="--listen-address=..."` | `listenAddress` |
-| `--retention-period` | Retention period for stored metrics and events. Minimum `1m`. | `24h` | `FLEETINT_FLAGS="--retention-period=..."` | not exposed by chart by default |
+| `--retention-period` | Retention period for stored metrics and events. Minimum `1m`. | `24h` | `FLEETINT_FLAGS="--retention-period=..."` | `retentionPeriod` |
 | `--components` | Comma-separated component selection. Use `all`, `*`, explicit names, and `-name` exclusions. | empty flag value, which means enable all components by default | `FLEETINT_FLAGS="--components=..."` | `components` |
 | `--gpu-count` | Override expected GPU count. Useful for testing. | `0` | `FLEETINT_FLAGS="--gpu-count=..."` | not exposed by chart by default |
 | `--offline-mode` | Disable the HTTP API server and write telemetry to files instead. | `false` | `FLEETINT_FLAGS="--offline-mode ..."` | not exposed by chart by default |
@@ -191,14 +192,6 @@ Available component names:
 - `network-ethernet`
 - `os`
 - `library`
-
-## Settings Not Configured Directly Through `fleetint run`
-
-Some runtime values exist in the internal config, but they are not intended to be set directly by users through `fleetint run` flags or the documented environment variables:
-
-- `state`: defaults to `/var/lib/fleetint/fleetint.state` when running as root, or `~/.fleetint/fleetint.state` otherwise
-- `metrics_endpoint`, `logs_endpoint`, and `auth_token`: normally populated by `fleetint enroll` and stored in metadata
-- `timeout`: defaults to `30s` and is not exposed as a public flag or documented env var
 
 ## Verify Effective Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,15 +124,6 @@ These are the `fleetint run` flags supported by the CLI.
 | `--format` | Offline-mode output format: `json` or `csv`. | `json` | `FLEETINT_FLAGS="--format=csv ..."` | not exposed by chart by default |
 | `--enable-fault-injection` | Enable the local fault-injection endpoint for testing. | `false` | `FLEETINT_FLAGS="--enable-fault-injection"` | not exposed by chart by default |
 
-### Hidden Test-Only Flags
-
-These flags exist in the CLI for testing and debugging, but they are hidden from normal help output and are not intended for standard deployment configuration.
-
-| Flag | Description |
-| --- | --- |
-| `--infiniband-expected-port-states` | Override expected InfiniBand port states using JSON input. |
-| `--infiniband-class-root-dir` | Override the InfiniBand class root directory. |
-
 ## Component Selection
 
 Use `--components` to control which monitoring components are enabled.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,8 @@ These environment variables are read by `fleetint run` at startup.
 
 | Environment variable | Description | Default | Bare metal | Kubernetes |
 | --- | --- | --- | --- | --- |
+| `DCGM_URL` | DCGM HostEngine address used by the agent for DCGM-backed components. | bare metal: `localhost`, Helm chart: `nvidia-dcgm.gpu-operator.svc:5555` | `/etc/default/fleetint` | `env.DCGM_URL` |
+| `DCGM_URL_IS_UNIX_SOCKET` | Treat `DCGM_URL` as a Unix socket path instead of a network address. | `false` | `/etc/default/fleetint` | `env.DCGM_URL_IS_UNIX_SOCKET` |
 | `FLEETINT_COLLECT_INTERVAL` | Export interval for health data. Valid range: `1s` to `24h`. | `1m` | `/etc/default/fleetint` | `env.FLEETINT_COLLECT_INTERVAL` |
 | `FLEETINT_INCLUDE_METRICS` | Include metrics data in export payloads. | `true` | `/etc/default/fleetint` | `env.FLEETINT_INCLUDE_METRICS` |
 | `FLEETINT_INCLUDE_EVENTS` | Include event data in export payloads. | `true` | `/etc/default/fleetint` | `env.FLEETINT_INCLUDE_EVENTS` |
@@ -57,7 +59,7 @@ Notes:
 
 - Duration-valued environment variables use Go duration syntax such as `30s`, `1m`, `10m`, or `24h`.
 - These environment variables modify the health exporter configuration used by `fleetint run`.
-- In Kubernetes, `DCGM_URL` and `DCGM_URL_IS_UNIX_SOCKET` are separate chart environment variables for DCGM connectivity, but they are not part of the `fleetint run` exporter configuration table above.
+- `DCGM_URL` and `DCGM_URL_IS_UNIX_SOCKET` configure connectivity to DCGM HostEngine for DCGM-backed components.
 
 ### Bare Metal Example
 
@@ -67,6 +69,8 @@ sudoedit /etc/default/fleetint
 
 ```bash
 FLEETINT_FLAGS="--log-level=info --listen-address=127.0.0.1:15133 --components=all,-accelerator-nvidia-dcgm-prof"
+DCGM_URL="localhost"
+DCGM_URL_IS_UNIX_SOCKET="false"
 FLEETINT_COLLECT_INTERVAL="2m"
 FLEETINT_INCLUDE_EVENTS="false"
 FLEETINT_CHECK_INTERVAL="30s"
@@ -85,6 +89,8 @@ listenAddress: 0.0.0.0:15133
 components: all,-accelerator-nvidia-dcgm-prof
 
 env:
+  DCGM_URL: "nvidia-dcgm.gpu-operator.svc:5555"
+  DCGM_URL_IS_UNIX_SOCKET: "false"
   FLEETINT_COLLECT_INTERVAL: "2m"
   FLEETINT_INCLUDE_EVENTS: "false"
   FLEETINT_CHECK_INTERVAL: "30s"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,7 +101,7 @@ Apply with:
 
 ```bash
 helm upgrade --install fleet-intelligence-agent \
-  oci://ghcr.io/nvidia/fleet-intelligence-agent/chart \
+  oci://ghcr.io/nvidia/charts/fleet-intelligence-agent \
   -n <namespace> \
   -f values.yaml
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,53 +1,133 @@
 # Configuration
 
-This page is a quick reference for runtime configuration shared by:
-- bare metal installs (`fleetintd` via systemd)
-- Kubernetes installs (Helm chart)
+This page documents the runtime configuration for `fleetint run`:
+- configurable environment variables
+- configurable `fleetint run` flags
+- how to set them on bare metal and in Kubernetes
 
 ## Where to configure
 
-- **Bare metal**: edit `/etc/default/fleetint`, then restart:
-  ```bash
-  sudo systemctl restart fleetintd
-  ```
-- **Helm**: set values in `values.yaml` or with `--set`.
-  - Env vars live under `env.*`
-  - Main run flags map to chart values like `logLevel`, `listenAddress`, and `components`
+### Bare Metal
 
-## Configurable environment variables
+Package installs run `fleetint` through the `fleetintd` systemd service:
 
-| Environment variable | Description | Default |
-|---|---|---|
-| `FLEETINT_COLLECT_INTERVAL` | Data collection interval (1s to 24h) | `1m` |
-| `FLEETINT_INCLUDE_METRICS` | Include metrics in export | `true` |
-| `FLEETINT_INCLUDE_EVENTS` | Include events in export | `true` |
-| `FLEETINT_INCLUDE_MACHINEINFO` | Include machine info in export | `true` |
-| `FLEETINT_INCLUDE_HEALTHCHECKS` | Include component health data in export | `true` |
-| `FLEETINT_METRICS_LOOKBACK` | Metrics lookback window | `1m` |
-| `FLEETINT_EVENTS_LOOKBACK` | Events lookback window | `1m` |
-| `FLEETINT_CHECK_INTERVAL` | Component health check interval (1s to 24h) | `1m` |
-| `FLEETINT_RETRY_MAX_ATTEMPTS` | Max retry attempts for failed exports | `3` |
-| `FLEETINT_ATTESTATION_JITTER_ENABLED` | Enable/disable attestation startup jitter | `true` |
-| `FLEETINT_ATTESTATION_INTERVAL` | Attestation interval override | `24h` |
-| `HTTP_PROXY` | HTTP proxy URL | empty |
-| `HTTPS_PROXY` | HTTPS proxy URL | empty |
+```ini
+ExecStart=/usr/bin/fleetint run $FLEETINT_FLAGS
+```
 
-## Configurable CLI flags
+Configure runtime settings in `/etc/default/fleetint`, then restart the service:
 
-These are `fleetint run` flags.
+```bash
+sudo systemctl restart fleetintd
+```
 
-- **Bare metal**: set via `FLEETINT_FLAGS="..."` in `/etc/default/fleetint`
-- **Helm**: use dedicated chart values when available
+- Set environment variables directly in `/etc/default/fleetint`
+- Set `fleetint run` flags through `FLEETINT_FLAGS="..."`
 
-| CLI flag | Description | Default | Helm value |
-|---|---|---|---|
-| `--log-level` | Log level (`debug`, `info`, `warn`, `error`) | `warn` | `logLevel` |
-| `--listen-address` | API bind address | bare metal: `127.0.0.1:15133` | `listenAddress` (chart default `0.0.0.0:15133`) |
-| `--components` | Comma-separated enabled components (`all` or explicit list; use `all,-name` to exclude components) | `all` | `components` |
-| `--enable-dcgm-policy` | Enable DCGM non-XID policy monitoring | `false` | not exposed directly |
-| `--enable-fault-injection` | Enable local fault-injection endpoint (testing only) | `false` | not exposed directly |
+### Kubernetes
 
-## Component selection
+The Helm chart configures the container entrypoint as `fleetint run` and exposes:
+
+- environment variables under `env.*`
+- common `run` flags through dedicated chart values such as `logLevel`, `listenAddress`, and `components`
+
+Apply changes by updating `values.yaml` or using `helm upgrade --set ...`.
+
+## Configurable Environment Variables
+
+These environment variables are read by `fleetint run` at startup.
+
+| Environment variable | Description | Default | Bare metal | Kubernetes |
+| --- | --- | --- | --- | --- |
+| `FLEETINT_COLLECT_INTERVAL` | Export interval for health data. Valid range: `1s` to `24h`. | `1m` | `/etc/default/fleetint` | `env.FLEETINT_COLLECT_INTERVAL` |
+| `FLEETINT_INCLUDE_METRICS` | Include metrics data in export payloads. | `true` | `/etc/default/fleetint` | `env.FLEETINT_INCLUDE_METRICS` |
+| `FLEETINT_INCLUDE_EVENTS` | Include event data in export payloads. | `true` | `/etc/default/fleetint` | `env.FLEETINT_INCLUDE_EVENTS` |
+| `FLEETINT_INCLUDE_MACHINEINFO` | Include machine information in export payloads. | `true` | `/etc/default/fleetint` | `env.FLEETINT_INCLUDE_MACHINEINFO` |
+| `FLEETINT_INCLUDE_HEALTHCHECKS` | Include component data and health details in export payloads. | `true` | `/etc/default/fleetint` | `env.FLEETINT_INCLUDE_HEALTHCHECKS` |
+| `FLEETINT_METRICS_LOOKBACK` | Lookback window for metrics included in each export. | `1m` | `/etc/default/fleetint` | `env.FLEETINT_METRICS_LOOKBACK` |
+| `FLEETINT_EVENTS_LOOKBACK` | Lookback window for events included in each export. | `1m` | `/etc/default/fleetint` | `env.FLEETINT_EVENTS_LOOKBACK` |
+| `FLEETINT_CHECK_INTERVAL` | Health check interval for monitored components. Valid range: `1s` to `24h`. | `1m` | `/etc/default/fleetint` | `env.FLEETINT_CHECK_INTERVAL` |
+| `FLEETINT_RETRY_MAX_ATTEMPTS` | Maximum retry attempts for failed exports. Minimum: `0`. | `3` | `/etc/default/fleetint` | `env.FLEETINT_RETRY_MAX_ATTEMPTS` |
+| `FLEETINT_ATTESTATION_JITTER_ENABLED` | Enable random startup jitter for attestation scheduling. | `true` | `/etc/default/fleetint` | `env.FLEETINT_ATTESTATION_JITTER_ENABLED` |
+| `FLEETINT_ATTESTATION_INTERVAL` | Attestation interval override. | `24h` | `/etc/default/fleetint` | `env.FLEETINT_ATTESTATION_INTERVAL` |
+| `HTTP_PROXY` | Proxy URL for outbound HTTP requests. | empty | `/etc/default/fleetint` | `env.HTTP_PROXY` |
+| `HTTPS_PROXY` | Proxy URL for outbound HTTPS requests. | empty | `/etc/default/fleetint` | `env.HTTPS_PROXY` |
+
+Notes:
+
+- Duration-valued environment variables use Go duration syntax such as `30s`, `1m`, `10m`, or `24h`.
+- These environment variables modify the health exporter configuration used by `fleetint run`.
+- In Kubernetes, `DCGM_URL` and `DCGM_URL_IS_UNIX_SOCKET` are separate chart environment variables for DCGM connectivity, but they are not part of the `fleetint run` exporter configuration table above.
+
+### Bare Metal Example
+
+```bash
+sudoedit /etc/default/fleetint
+```
+
+```bash
+FLEETINT_FLAGS="--log-level=info --listen-address=127.0.0.1:15133 --components=all,-accelerator-nvidia-dcgm-prof"
+FLEETINT_COLLECT_INTERVAL="2m"
+FLEETINT_INCLUDE_EVENTS="false"
+FLEETINT_CHECK_INTERVAL="30s"
+HTTPS_PROXY="http://proxy.example.com:3128"
+```
+
+```bash
+sudo systemctl restart fleetintd
+```
+
+### Kubernetes Example
+
+```yaml
+logLevel: info
+listenAddress: 0.0.0.0:15133
+components: all,-accelerator-nvidia-dcgm-prof
+
+env:
+  FLEETINT_COLLECT_INTERVAL: "2m"
+  FLEETINT_INCLUDE_EVENTS: "false"
+  FLEETINT_CHECK_INTERVAL: "30s"
+  HTTPS_PROXY: "http://proxy.example.com:3128"
+```
+
+Apply with:
+
+```bash
+helm upgrade --install fleet-intelligence-agent \
+  oci://ghcr.io/nvidia/fleet-intelligence-agent/chart \
+  -n <namespace> \
+  -f values.yaml
+```
+
+## Configurable `fleetint run` Flags
+
+These are the `fleetint run` flags supported by the CLI.
+
+| Flag | Description | Default | Bare metal | Kubernetes |
+| --- | --- | --- | --- | --- |
+| `--log-level` | Log level: `debug`, `info`, `warn`, `error`. | unset by CLI; packaged bare-metal default is `warn` via `FLEETINT_FLAGS` | `FLEETINT_FLAGS="--log-level=..."` | `logLevel` |
+| `--log-file` | Log file path. Leave empty to log to stdout/stderr. | empty | `FLEETINT_FLAGS="--log-file=..."` | not exposed by chart by default |
+| `--listen-address` | HTTP listen address for the agent API server. | CLI default `127.0.0.1:15133` | `FLEETINT_FLAGS="--listen-address=..."` | `listenAddress` |
+| `--retention-period` | Retention period for stored metrics and events. Minimum `1m`. | `24h` | `FLEETINT_FLAGS="--retention-period=..."` | not exposed by chart by default |
+| `--components` | Comma-separated component selection. Use `all`, `*`, explicit names, and `-name` exclusions. | empty flag value, which means enable all components by default | `FLEETINT_FLAGS="--components=..."` | `components` |
+| `--gpu-count` | Override expected GPU count. Useful for testing. | `0` | `FLEETINT_FLAGS="--gpu-count=..."` | not exposed by chart by default |
+| `--offline-mode` | Disable the HTTP API server and write telemetry to files instead. | `false` | `FLEETINT_FLAGS="--offline-mode ..."` | not exposed by chart by default |
+| `--path` | Output directory for offline mode. Required with `--offline-mode`. | empty | `FLEETINT_FLAGS="--path=/path ..."` | not exposed by chart by default |
+| `--duration` | Offline-mode collection duration in `HH:MM:SS` format. Required with `--offline-mode`. | empty | `FLEETINT_FLAGS="--duration=00:05:00 ..."` | not exposed by chart by default |
+| `--format` | Offline-mode output format: `json` or `csv`. | `json` | `FLEETINT_FLAGS="--format=csv ..."` | not exposed by chart by default |
+| `--enable-fault-injection` | Enable the local fault-injection endpoint for testing. | `false` | `FLEETINT_FLAGS="--enable-fault-injection"` | not exposed by chart by default |
+
+### Hidden Test-Only Flags
+
+These flags exist in the CLI for testing and debugging, but they are hidden from normal help output and are not intended for standard deployment configuration.
+
+| Flag | Description |
+| --- | --- |
+| `--infiniband-expected-port-states` | Override expected InfiniBand port states using JSON input. |
+| `--infiniband-class-root-dir` | Override the InfiniBand class root directory. |
+
+## Component Selection
 
 Use `--components` to control which monitoring components are enabled.
 
@@ -64,11 +144,12 @@ fleetint run --components=accelerator-nvidia-dcgm-thermal,accelerator-nvidia-dcg
 fleetint run --components=all,-accelerator-nvidia-dcgm-prof
 ```
 
-Notes:
+Rules:
 
-- `all` (or `*`) enables the default component set.
-- Use `all,-<component-name>` to start from the default set and exclude specific components.
-- A plain explicit list enables only the listed components.
+- `all`, `*`, or an empty component list enables all components.
+- `all,-<component-name>` starts with all components, then disables specific ones.
+- An explicit comma-separated list enables only the named components.
+- A non-matching explicit value effectively disables all components.
 
 Available component names:
 
@@ -105,15 +186,28 @@ Available component names:
 - `os`
 - `library`
 
-## Verify effective config
+## Settings Not Configured Directly Through `fleetint run`
 
-- **Bare metal**:
-  ```bash
-  sudo fleetint metadata
-  sudo journalctl -u fleetintd -f
-  ```
-- **Helm**:
-  ```bash
-  helm get values fleet-intelligence-agent -n <namespace>
-  kubectl logs -n <namespace> -l app.kubernetes.io/name=fleet-intelligence-agent --tail=100
-  ```
+Some runtime values exist in the internal config, but they are not intended to be set directly by users through `fleetint run` flags or the documented environment variables:
+
+- `state`: defaults to `/var/lib/fleetint/fleetint.state` when running as root, or `~/.fleetint/fleetint.state` otherwise
+- `metrics_endpoint`, `logs_endpoint`, and `auth_token`: normally populated by `fleetint enroll` and stored in metadata
+- `timeout`: defaults to `30s` and is not exposed as a public flag or documented env var
+
+## Verify Effective Configuration
+
+### Bare Metal
+
+```bash
+sudo cat /etc/default/fleetint
+sudo systemctl status fleetintd
+sudo journalctl -u fleetintd -f
+```
+
+### Kubernetes
+
+```bash
+helm get values fleet-intelligence-agent -n <namespace>
+kubectl get daemonset fleet-intelligence-agent -n <namespace> -o yaml
+kubectl logs -n <namespace> -l app.kubernetes.io/name=fleet-intelligence-agent --tail=100
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,6 @@ These are the `fleetint run` flags supported by the CLI.
 | `--listen-address` | HTTP listen address for the agent API server. | CLI default `127.0.0.1:15133` | `FLEETINT_FLAGS="--listen-address=..."` | `listenAddress` |
 | `--retention-period` | Retention period for stored metrics and events. Minimum `1m`. | `24h` | `FLEETINT_FLAGS="--retention-period=..."` | `retentionPeriod` |
 | `--components` | Comma-separated component selection. Use `all`, `*`, explicit names, and `-name` exclusions. | empty flag value, which means enable all components by default | `FLEETINT_FLAGS="--components=..."` | `components` |
-| `--gpu-count` | Override expected GPU count. Useful for testing. | `0` | `FLEETINT_FLAGS="--gpu-count=..."` | not exposed by chart by default |
 | `--offline-mode` | Disable the HTTP API server and write telemetry to files instead. | `false` | `FLEETINT_FLAGS="--offline-mode ..."` | not exposed by chart by default |
 | `--path` | Output directory for offline mode. Required with `--offline-mode`. | empty | `FLEETINT_FLAGS="--path=/path ..."` | not exposed by chart by default |
 | `--duration` | Offline-mode collection duration in `HH:MM:SS` format. Required with `--offline-mode`. | empty | `FLEETINT_FLAGS="--duration=00:05:00 ..."` | not exposed by chart by default |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,6 +61,27 @@ sudo fleetint metadata --set-key="key" --set-value="value"
 
 Used to view or update the agent's metadata store, including remote export configuration.
 
+### Compact State Database
+
+```bash
+sudo fleetint compact
+```
+
+Compacts the local Fleet Intelligence state database to reduce disk usage.
+
+Requirements:
+- `fleetintd` must be stopped before running `compact`
+- nothing else can be listening on fleetint port `15133`
+- the command needs write access to the state database, so package installs typically require `sudo`
+
+Typical workflow:
+
+```bash
+sudo systemctl stop fleetintd
+sudo fleetint compact
+sudo systemctl start fleetintd
+```
+
 ### Validate Prerequisites
 
 ```bash


### PR DESCRIPTION
## Summary
- document the configurable environment variables used by `fleetint run`
- document the supported `fleetint run` flags and their defaults
- explain how to configure these settings on bare metal and in Kubernetes

## Testing
- not run (docs only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured configuration guide to focus on the fleetint run command with platform-aware bare-metal (systemd) and Kubernetes (Helm) examples; consolidated startup env/flags, added DCGM variables, duration syntax, offline/testing flags, and clarified component-selection semantics; updated verification steps.

* **Chores**
  * Added DCGM environment variables and a configurable retentionPeriod (with runtime flag) for the agent.
  * Removed the gpu-count flag from the scan command and related default GPU-count handling in run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->