### PR TITLE
fix: dcgm incident integer types

### DIFF
--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -651,7 +651,7 @@ func TestCollector_CollectComponentData_WithComponents(t *testing.T) {
 					{
 						EntityID: "GPU-1234",
 						Message:  "Clock throttled",
-						Health: apiv1.HealthStateTypeDegraded,
+						Health:   apiv1.HealthStateTypeDegraded,
 						Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
 					},
 				},

--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -651,7 +651,7 @@ func TestCollector_CollectComponentData_WithComponents(t *testing.T) {
 					{
 						EntityID: "GPU-1234",
 						Message:  "Clock throttled",
-						Severity: apiv1.HealthStateTypeDegraded,
+						Health: apiv1.HealthStateTypeDegraded,
 						Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
 					},
 				},

--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -440,7 +440,7 @@ func incidentsToOTLPArrayValue(incidents []apiv1.HealthStateIncident) *commonv1.
 		kvs := []*commonv1.KeyValue{
 			{Key: "entity_id", Value: stringAnyValue(inc.EntityID)},
 			{Key: "message", Value: stringAnyValue(inc.Message)},
-			{Key: "severity", Value: stringAnyValue(string(inc.Severity))},
+			{Key: "severity", Value: stringAnyValue(string(inc.Health))},
 			{Key: "error", Value: stringAnyValue(inc.Error)},
 		}
 		values = append(values, &commonv1.AnyValue{

--- a/internal/exporter/converter/otlp_test.go
+++ b/internal/exporter/converter/otlp_test.go
@@ -262,7 +262,7 @@ func TestOTLPConverter_Convert_WithComponentData(t *testing.T) {
 					{
 						EntityID: "GPU-1234",
 						Message:  "Clock throttled",
-						Severity: apiv1.HealthStateTypeDegraded,
+						Health: apiv1.HealthStateTypeDegraded,
 						Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
 					},
 				},

--- a/internal/exporter/converter/otlp_test.go
+++ b/internal/exporter/converter/otlp_test.go
@@ -262,7 +262,7 @@ func TestOTLPConverter_Convert_WithComponentData(t *testing.T) {
 					{
 						EntityID: "GPU-1234",
 						Message:  "Clock throttled",
-						Health: apiv1.HealthStateTypeDegraded,
+						Health:   apiv1.HealthStateTypeDegraded,
 						Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
 					},
 				},

--- a/third_party/fleet-intelligence-sdk/api/v1/types.go
+++ b/third_party/fleet-intelligence-sdk/api/v1/types.go
@@ -105,8 +105,8 @@ type HealthStateIncident struct {
 	EntityID string `json:"entity_id,omitempty"`
 	// Message is the human-readable description of the fault.
 	Message string `json:"message"`
-	// Severity mirrors HealthState health levels.
-	Severity HealthStateType `json:"severity,omitempty"`
+	// Health mirrors HealthState health levels.
+	Health HealthStateType `json:"health,omitempty"`
 	// Error is a symbolic error identifier when available.
 	Error string `json:"error,omitempty"`
 }

--- a/third_party/fleet-intelligence-sdk/api/v1/types_test.go
+++ b/third_party/fleet-intelligence-sdk/api/v1/types_test.go
@@ -17,7 +17,7 @@ func TestHealthState_JSONIncludesIncidents(t *testing.T) {
 			{
 				EntityID: "GPU-0",
 				Message:  "Clock throttled",
-				Severity: HealthStateTypeDegraded,
+				Health: HealthStateTypeDegraded,
 				Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
 			},
 		},
@@ -33,7 +33,7 @@ func TestHealthState_JSONIncludesIncidents(t *testing.T) {
 		`"incidents":[`,
 		`"entity_id":"GPU-0"`,
 		`"message":"Clock throttled"`,
-		`"severity":"Degraded"`,
+		`"health":"Degraded"`,
 		`"error":"DCGM_FR_CLOCK_THROTTLE_POWER"`,
 	} {
 		if !bytes.Contains(data, []byte(want)) {

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
@@ -232,12 +232,12 @@ type EnrichedIncident struct {
 	EntityID string `json:"-"`
 	// error message from the incident
 	Message string `json:"message"`
-	// symbolic DCGM_FR_* error code
-	ErrorCode string `json:"code"`
-	// symbolic DCGM_HEALTH_WATCH_* system name
-	System string `json:"system"`
-	// health result level mapped to API severity
-	Severity apiv1.HealthStateType `json:"health"`
+	// DCGM_FR_* error code as integer (backend-compatible)
+	ErrorCode dcgm.HealthCheckErrorCode `json:"code"`
+	// DCGM_HEALTH_WATCH_* system as integer (backend-compatible)
+	System dcgm.HealthSystem `json:"system"`
+	// health result level as integer (backend-compatible)
+	Health dcgm.HealthResult `json:"health"`
 }
 
 // EnrichIncidents transforms DCGM incidents by mapping entity IDs to UUIDs.
@@ -260,9 +260,9 @@ func EnrichIncidents(incidents []dcgm.Incident, deviceMapping map[uint]string) [
 			UUID:      uuid,
 			EntityID:  dcgmEntityID(incident.EntityInfo),
 			Message:   incident.Error.Message,
-			ErrorCode: healthCheckErrorCodeString(incident.Error.Code),
-			System:    healthSystemString(incident.System),
-			Severity:  healthResultToSeverity(incident.Health),
+			ErrorCode: incident.Error.Code,
+			System:    incident.System,
+			Health:    incident.Health,
 		})
 	}
 
@@ -281,9 +281,9 @@ func EnrichSwitchIncidents(incidents []dcgm.Incident) []EnrichedIncident {
 			UUID:      fmt.Sprintf("nvswitch-%d", incident.EntityInfo.EntityId),
 			EntityID:  dcgmEntityID(incident.EntityInfo),
 			Message:   incident.Error.Message,
-			ErrorCode: healthCheckErrorCodeString(incident.Error.Code),
-			System:    healthSystemString(incident.System),
-			Severity:  healthResultToSeverity(incident.Health),
+			ErrorCode: incident.Error.Code,
+			System:    incident.System,
+			Health:    incident.Health,
 		})
 	}
 
@@ -294,8 +294,8 @@ func (e EnrichedIncident) ToHealthStateIncident() apiv1.HealthStateIncident {
 	return apiv1.HealthStateIncident{
 		EntityID: e.EntityID,
 		Message:  e.Message,
-		Severity: e.Severity,
-		Error:    e.ErrorCode,
+		Severity: healthResultToSeverity(e.Health),
+		Error:    healthCheckErrorCodeString(e.ErrorCode),
 	}
 }
 

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils.go
@@ -55,17 +55,17 @@ func EmitNewIncidentEvents(
 	// Build dedup set from previous incidents.
 	prevKeys := make(map[string]struct{}, len(prev))
 	for _, inc := range prev {
-		prevKeys[inc.EntityID+"/"+string(inc.Severity)+"/"+inc.Error] = struct{}{}
+		prevKeys[inc.EntityID+"/"+string(inc.Health)+"/"+inc.Error] = struct{}{}
 	}
 
 	for _, inc := range curr {
-		key := inc.EntityID + "/" + string(inc.Severity) + "/" + inc.Error
+		key := inc.EntityID + "/" + string(inc.Health) + "/" + inc.Error
 		if _, seen := prevKeys[key]; seen {
 			continue
 		}
 
 		eventType := apiv1.EventTypeWarning
-		if inc.Severity == apiv1.HealthStateTypeUnhealthy {
+		if inc.Health == apiv1.HealthStateTypeUnhealthy {
 			eventType = apiv1.EventTypeCritical
 		}
 
@@ -294,7 +294,7 @@ func (e EnrichedIncident) ToHealthStateIncident() apiv1.HealthStateIncident {
 	return apiv1.HealthStateIncident{
 		EntityID: e.EntityID,
 		Message:  e.Message,
-		Severity: healthResultToSeverity(e.Health),
+		Health: healthResultToSeverity(e.Health),
 		Error:    healthCheckErrorCodeString(e.ErrorCode),
 	}
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
@@ -358,22 +358,25 @@ func TestEnrichedIncidentJSON_SerializesIntegers(t *testing.T) {
 		t.Fatalf("json.Unmarshal error = %v", err)
 	}
 
-	if _, ok := parsed["code"].(float64); !ok {
-		t.Errorf("code should be numeric, got %T: %v", parsed["code"], parsed["code"])
+	code, ok := parsed["code"].(float64)
+	if !ok {
+		t.Fatalf("code should be numeric, got %T: %v", parsed["code"], parsed["code"])
 	}
-	if _, ok := parsed["system"].(float64); !ok {
-		t.Errorf("system should be numeric, got %T: %v", parsed["system"], parsed["system"])
+	system, ok := parsed["system"].(float64)
+	if !ok {
+		t.Fatalf("system should be numeric, got %T: %v", parsed["system"], parsed["system"])
 	}
-	if _, ok := parsed["health"].(float64); !ok {
-		t.Errorf("health should be numeric, got %T: %v", parsed["health"], parsed["health"])
+	health, ok := parsed["health"].(float64)
+	if !ok {
+		t.Fatalf("health should be numeric, got %T: %v", parsed["health"], parsed["health"])
 	}
-	if got := parsed["code"].(float64); got != float64(dcgm.DCGM_FR_VOLATILE_SBE_DETECTED_TS) {
-		t.Errorf("code = %v, want %v", got, float64(dcgm.DCGM_FR_VOLATILE_SBE_DETECTED_TS))
+	if code != float64(dcgm.DCGM_FR_VOLATILE_SBE_DETECTED_TS) {
+		t.Errorf("code = %v, want %v", code, float64(dcgm.DCGM_FR_VOLATILE_SBE_DETECTED_TS))
 	}
-	if got := parsed["system"].(float64); got != float64(dcgm.DCGM_HEALTH_WATCH_MEM) {
-		t.Errorf("system = %v, want %v", got, float64(dcgm.DCGM_HEALTH_WATCH_MEM))
+	if system != float64(dcgm.DCGM_HEALTH_WATCH_MEM) {
+		t.Errorf("system = %v, want %v", system, float64(dcgm.DCGM_HEALTH_WATCH_MEM))
 	}
-	if got := parsed["health"].(float64); got != float64(dcgm.DCGM_HEALTH_RESULT_WARN) {
-		t.Errorf("health = %v, want %v", got, float64(dcgm.DCGM_HEALTH_RESULT_WARN))
+	if health != float64(dcgm.DCGM_HEALTH_RESULT_WARN) {
+		t.Errorf("health = %v, want %v", health, float64(dcgm.DCGM_HEALTH_RESULT_WARN))
 	}
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
@@ -105,7 +105,7 @@ func TestToHealthStateIncidents(t *testing.T) {
 	want := apiv1.HealthStateIncident{
 		EntityID: "GPU-0",
 		Message:  "Power violation",
-		Severity: apiv1.HealthStateTypeUnhealthy,
+		Health: apiv1.HealthStateTypeUnhealthy,
 		Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
 	}
 	if got[0] != want {
@@ -186,27 +186,27 @@ func TestEmitNewIncidentEvents(t *testing.T) {
 		EntityID: "GPU-0",
 		Error:    "DCGM_FR_TEMP_VIOLATION",
 		Message:  "temp too high",
-		Severity: apiv1.HealthStateTypeDegraded,
+		Health: apiv1.HealthStateTypeDegraded,
 	}
 	gpu1Mem := apiv1.HealthStateIncident{
 		EntityID: "GPU-1",
 		Error:    "DCGM_FR_VOLATILE_DBE_DETECTED",
 		Message:  "memory error",
-		Severity: apiv1.HealthStateTypeUnhealthy,
+		Health: apiv1.HealthStateTypeUnhealthy,
 	}
 	// Same EntityID as gpu0Thermal but different Severity — distinct key.
 	gpu0ThermalEscalated := apiv1.HealthStateIncident{
 		EntityID: "GPU-0",
 		Error:    "DCGM_FR_TEMP_VIOLATION",
 		Message:  "temp critical",
-		Severity: apiv1.HealthStateTypeUnhealthy,
+		Health: apiv1.HealthStateTypeUnhealthy,
 	}
 	// Same EntityID as gpu0Thermal but different Error — distinct key.
 	gpu0Power := apiv1.HealthStateIncident{
 		EntityID: "GPU-0",
 		Error:    "DCGM_FR_POWER_VIOLATION",
 		Message:  "power too high",
-		Severity: apiv1.HealthStateTypeDegraded,
+		Health: apiv1.HealthStateTypeDegraded,
 	}
 
 	tests := []struct {

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common/utils_test.go
@@ -17,6 +17,7 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -52,7 +53,7 @@ func TestFormatEnrichedIncidents(t *testing.T) {
 				{
 					UUID:      "GPU-46a3bbe2-3e87-3dde-b464-a03eba0c21d7",
 					Message:   "Temperature above threshold",
-					ErrorCode: "DCGM_FR_TEMP_VIOLATION",
+					ErrorCode: dcgm.DCGM_FR_TEMP_VIOLATION,
 				},
 			},
 			want: "thermal warning: 1 incident(s) across 1 device(s)",
@@ -64,12 +65,12 @@ func TestFormatEnrichedIncidents(t *testing.T) {
 				{
 					UUID:      "GPU-46a3bbe2-3e87-3dde-b464-a03eba0c21d7",
 					Message:   "DBE detected",
-					ErrorCode: "DCGM_FR_VOLATILE_DBE_DETECTED",
+					ErrorCode: dcgm.DCGM_FR_VOLATILE_DBE_DETECTED,
 				},
 				{
 					UUID:      "GPU-7b4f2c1a-8d6e-4c5b-9a1f-2e3d4c5a6b7c",
 					Message:   "Row remap failure",
-					ErrorCode: "DCGM_FR_ROW_REMAP_FAILURE",
+					ErrorCode: dcgm.DCGM_FR_ROW_REMAP_FAILURE,
 				},
 			},
 			want: "memory failure: 2 incident(s) across 2 device(s)",
@@ -92,8 +93,8 @@ func TestToHealthStateIncidents(t *testing.T) {
 			UUID:      "GPU-1234",
 			EntityID:  "GPU-0",
 			Message:   "Power violation",
-			ErrorCode: "DCGM_FR_POWER_VIOLATION",
-			Severity:  apiv1.HealthStateTypeUnhealthy,
+			ErrorCode: dcgm.DCGM_FR_CLOCK_THROTTLE_POWER,
+			Health:    dcgm.DCGM_HEALTH_RESULT_FAIL,
 		},
 	})
 
@@ -105,7 +106,7 @@ func TestToHealthStateIncidents(t *testing.T) {
 		EntityID: "GPU-0",
 		Message:  "Power violation",
 		Severity: apiv1.HealthStateTypeUnhealthy,
-		Error:    "DCGM_FR_POWER_VIOLATION",
+		Error:    "DCGM_FR_CLOCK_THROTTLE_POWER",
 	}
 	if got[0] != want {
 		t.Fatalf("ToHealthStateIncidents()[0] = %#v, want %#v", got[0], want)
@@ -333,5 +334,46 @@ func TestEnrichSwitchIncidents_UsesSwitchIdentifiers(t *testing.T) {
 	}
 	if got[0].UUID != "nvswitch-7" {
 		t.Fatalf("EnrichSwitchIncidents()[0].UUID = %q, want nvswitch-7", got[0].UUID)
+	}
+}
+
+// TestEnrichedIncidentJSON_SerializesIntegers verifies that the dcgm_incidents JSON
+// uses integer values for code/system/health so the backend can unmarshal them correctly.
+func TestEnrichedIncidentJSON_SerializesIntegers(t *testing.T) {
+	incident := EnrichedIncident{
+		UUID:      "GPU-1234",
+		Message:   "SBE detected",
+		ErrorCode: dcgm.DCGM_FR_VOLATILE_SBE_DETECTED_TS,
+		System:    dcgm.DCGM_HEALTH_WATCH_MEM,
+		Health:    dcgm.DCGM_HEALTH_RESULT_WARN,
+	}
+
+	data, err := json.Marshal(incident)
+	if err != nil {
+		t.Fatalf("json.Marshal error = %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("json.Unmarshal error = %v", err)
+	}
+
+	if _, ok := parsed["code"].(float64); !ok {
+		t.Errorf("code should be numeric, got %T: %v", parsed["code"], parsed["code"])
+	}
+	if _, ok := parsed["system"].(float64); !ok {
+		t.Errorf("system should be numeric, got %T: %v", parsed["system"], parsed["system"])
+	}
+	if _, ok := parsed["health"].(float64); !ok {
+		t.Errorf("health should be numeric, got %T: %v", parsed["health"], parsed["health"])
+	}
+	if got := parsed["code"].(float64); got != float64(dcgm.DCGM_FR_VOLATILE_SBE_DETECTED_TS) {
+		t.Errorf("code = %v, want %v", got, float64(dcgm.DCGM_FR_VOLATILE_SBE_DETECTED_TS))
+	}
+	if got := parsed["system"].(float64); got != float64(dcgm.DCGM_HEALTH_WATCH_MEM) {
+		t.Errorf("system = %v, want %v", got, float64(dcgm.DCGM_HEALTH_WATCH_MEM))
+	}
+	if got := parsed["health"].(float64); got != float64(dcgm.DCGM_HEALTH_RESULT_WARN) {
+		t.Errorf("health = %v, want %v", got, float64(dcgm.DCGM_HEALTH_RESULT_WARN))
 	}
 }

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
@@ -160,9 +162,9 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 			UUID:      "GPU-1234",
 			EntityID:  "GPU-0",
 			Message:   "Inforom corruption detected",
-			ErrorCode: "DCGM_FR_CORRUPT_INFOROM",
-			System:    "DCGM_HEALTH_WATCH_INFOROM",
-			Severity:  apiv1.HealthStateTypeDegraded,
+			ErrorCode: dcgm.DCGM_FR_CORRUPT_INFOROM,
+			System:    dcgm.DCGM_HEALTH_WATCH_INFOROM,
+			Health:    dcgm.DCGM_HEALTH_RESULT_WARN,
 		},
 	}
 

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
@@ -121,9 +123,9 @@ func TestCheckResultHealthStates_UsesNVSwitchIdentifiers(t *testing.T) {
 			UUID:      "nvswitch-3",
 			EntityID:  "NvSwitch-3",
 			Message:   "Fatal NVSwitch error",
-			ErrorCode: "DCGM_FR_NVSWITCH_FATAL_ERROR",
-			System:    "DCGM_HEALTH_WATCH_NVSWITCH_FATAL",
-			Severity:  apiv1.HealthStateTypeUnhealthy,
+			ErrorCode: dcgm.DCGM_FR_NVSWITCH_FATAL_ERROR,
+			System:    dcgm.DCGM_HEALTH_WATCH_NVSWITCH_FATAL,
+			Health:    dcgm.DCGM_HEALTH_RESULT_FAIL,
 		},
 	}
 

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	dcgmcommon "github.com/NVIDIA/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/common"
@@ -180,9 +182,9 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 			UUID:      "GPU-1234",
 			EntityID:  "GPU-0",
 			Message:   "Clock throttled",
-			ErrorCode: "DCGM_FR_CLOCK_THROTTLE_POWER",
-			System:    "DCGM_HEALTH_WATCH_POWER",
-			Severity:  apiv1.HealthStateTypeDegraded,
+			ErrorCode: dcgm.DCGM_FR_CLOCK_THROTTLE_POWER,
+			System:    dcgm.DCGM_HEALTH_WATCH_POWER,
+			Health:    dcgm.DCGM_HEALTH_RESULT_WARN,
 		},
 	}
 
@@ -222,8 +224,8 @@ func TestCheckResultHealthStates_PreservesLegacyIncidentsAndAddsTypedIncidents(t
 	if got := legacy[0]["uuid"]; got != "GPU-1234" {
 		t.Fatalf("legacy uuid = %v", got)
 	}
-	if got := legacy[0]["code"]; got != "DCGM_FR_CLOCK_THROTTLE_POWER" {
-		t.Fatalf("legacy code = %v", got)
+	if got := legacy[0]["code"]; got != float64(dcgm.DCGM_FR_CLOCK_THROTTLE_POWER) {
+		t.Fatalf("legacy code = %v, want %v", got, float64(dcgm.DCGM_FR_CLOCK_THROTTLE_POWER))
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Incident payloads now use a dedicated "health" field with typed numeric DCGM result/code values for GPU health reporting.
* **API**
  * Incident JSON field formerly labeled "severity" is now "health" in API responses.
* **Tests**
  * Test suites updated to match the new incident representation and numeric serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->