### PR TITLE
fix: restore localhost-only server defaults

### DIFF
--- a/deployments/helm/fleet-intelligence-agent/values.yaml
+++ b/deployments/helm/fleet-intelligence-agent/values.yaml
@@ -46,7 +46,7 @@ env:
   HTTPS_PROXY: ""
 
 logLevel: warn
-listenAddress: 0.0.0.0:15133
+listenAddress: 127.0.0.1:15133
 retentionPeriod: 24h
 components: all
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -630,12 +630,12 @@ func TestInstallMiddlewares(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			name:   "GET_request_with_CORS",
+			name:   "GET_request_without_CORS",
 			method: "GET",
 			checkHeaders: func(t *testing.T, w *httptest.ResponseRecorder) {
-				assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
-				assert.Equal(t, "GET, OPTIONS", w.Header().Get("Access-Control-Allow-Methods"))
-				assert.Equal(t, "Content-Type", w.Header().Get("Access-Control-Allow-Headers"))
+				assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+				assert.Empty(t, w.Header().Get("Access-Control-Allow-Methods"))
+				assert.Empty(t, w.Header().Get("Access-Control-Allow-Headers"))
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -643,7 +643,7 @@ func TestInstallMiddlewares(t *testing.T) {
 			name:           "OPTIONS_request",
 			method:         "OPTIONS",
 			checkHeaders:   nil,
-			expectedStatus: http.StatusNoContent,
+			expectedStatus: http.StatusNotFound,
 		},
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -465,16 +465,6 @@ func (s *Server) startServer(ctx context.Context, nvmlInstance nvidianvml.Instan
 // installMiddlewares installs basic middleware for the router
 func (s *Server) installMiddlewares(router *gin.Engine) {
 	router.Use(gin.Recovery())
-	router.Use(func(c *gin.Context) {
-		c.Header("Access-Control-Allow-Origin", "*")
-		c.Header("Access-Control-Allow-Methods", "GET, OPTIONS")
-		c.Header("Access-Control-Allow-Headers", "Content-Type")
-		if c.Request.Method == "OPTIONS" {
-			c.AbortWithStatus(204)
-			return
-		}
-		c.Next()
-	})
 }
 
 // healthz returns a simple health check handler


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Agent network binding changed to listen on localhost (127.0.0.1:15133) instead of all network interfaces.

* **Refactor**
  * Removed CORS header handling from server middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->