### PR TITLE
fix: validate derived backend endpoints

### DIFF
--- a/cmd/fleetint/enroll.go
+++ b/cmd/fleetint/enroll.go
@@ -18,13 +18,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	pkgmetadata "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metadata"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/sqlite"
 	"github.com/urfave/cli"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/endpoint"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/enrollment"
 )
 
@@ -53,25 +53,13 @@ func enrollCommand(cliContext *cli.Context) error {
 		fmt.Fprintln(writerFromContext(cliContext), "Proceeding with enrollment because --force was provided")
 	}
 
-	// Validate base endpoint
-	baseURL, err := url.Parse(baseEndpoint)
+	baseURL, err := endpoint.ValidateEnrollEndpoint(baseEndpoint)
 	if err != nil {
-		return fmt.Errorf("invalid endpoint URL: %w", err)
-	}
-
-	// Enforce HTTPS for security
-	if baseURL.Scheme != "https" {
-		return fmt.Errorf("enrollment endpoint must use HTTPS, got %s", baseURL.Scheme)
-	}
-
-	// Append /api/v1/health to base endpoint
-	healthEndpoint, err := url.JoinPath(baseURL.String(), "api", "v1", "health")
-	if err != nil {
-		return fmt.Errorf("failed to construct health endpoint: %w", err)
+		return fmt.Errorf("invalid enrollment endpoint: %w", err)
 	}
 
 	// Construct enroll endpoint
-	enrollEndpoint, err := url.JoinPath(healthEndpoint, "enroll")
+	enrollEndpoint, err := endpoint.JoinPath(baseURL, "api", "v1", "health", "enroll")
 	if err != nil {
 		return fmt.Errorf("failed to construct enroll endpoint: %w", err)
 	}
@@ -84,15 +72,15 @@ func enrollCommand(cliContext *cli.Context) error {
 	}
 
 	// Construct other endpoints using url.JoinPath for proper URL handling
-	metricsEndpoint, err := url.JoinPath(healthEndpoint, "metrics")
+	metricsEndpoint, err := endpoint.JoinPath(baseURL, "api", "v1", "health", "metrics")
 	if err != nil {
 		return fmt.Errorf("failed to construct metrics endpoint: %w", err)
 	}
-	logsEndpoint, err := url.JoinPath(healthEndpoint, "logs")
+	logsEndpoint, err := endpoint.JoinPath(baseURL, "api", "v1", "health", "logs")
 	if err != nil {
 		return fmt.Errorf("failed to construct logs endpoint: %w", err)
 	}
-	nonceEndpoint, err := url.JoinPath(healthEndpoint, "nonce")
+	nonceEndpoint, err := endpoint.JoinPath(baseURL, "api", "v1", "health", "nonce")
 	if err != nil {
 		return fmt.Errorf("failed to construct nonce endpoint: %w", err)
 	}

--- a/cmd/fleetint/enroll.go
+++ b/cmd/fleetint/enroll.go
@@ -53,7 +53,7 @@ func enrollCommand(cliContext *cli.Context) error {
 		fmt.Fprintln(writerFromContext(cliContext), "Proceeding with enrollment because --force was provided")
 	}
 
-	baseURL, err := endpoint.ValidateEnrollEndpoint(baseEndpoint)
+	baseURL, err := endpoint.ValidateBackendEndpoint(baseEndpoint)
 	if err != nil {
 		return fmt.Errorf("invalid enrollment endpoint: %w", err)
 	}

--- a/cmd/fleetint/inject.go
+++ b/cmd/fleetint/inject.go
@@ -20,8 +20,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/urfave/cli"
+
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/endpoint"
 )
 
 func injectCommand(c *cli.Context) error {
@@ -32,11 +35,15 @@ func injectCommand(c *cli.Context) error {
 
 	// Get the server URL from flag
 	address := c.String("server-url")
+	serverURL, err := endpoint.ValidateLocalServerURL(address)
+	if err != nil {
+		return fmt.Errorf("invalid server URL: %w", err)
+	}
 
 	// Check if clear flag is set
 	clearFault := c.Bool("clear")
 	if clearFault {
-		return clearComponentFault(component, address)
+		return clearComponentFault(component, serverURL)
 	}
 
 	faultType := c.String("fault-type")
@@ -98,7 +105,10 @@ func injectCommand(c *cli.Context) error {
 	}
 
 	// Make the POST request to the inject-fault endpoint
-	url := fmt.Sprintf("%s/inject-fault", address)
+	url, err := endpoint.JoinPath(serverURL, "inject-fault")
+	if err != nil {
+		return fmt.Errorf("failed to construct inject-fault URL: %w", err)
+	}
 	fmt.Printf("Injecting fault into %s component at %s...\n", component, url)
 
 	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
@@ -153,7 +163,7 @@ func getKernelMessageForComponent(component, faultMessage string) (string, error
 }
 
 // clearComponentFault sends a request to clear injected faults from a component
-func clearComponentFault(component, address string) error {
+func clearComponentFault(component string, serverURL *url.URL) error {
 	// Create the clear request
 	requestBody := map[string]interface{}{
 		"component_clear": map[string]string{
@@ -168,7 +178,10 @@ func clearComponentFault(component, address string) error {
 	}
 
 	// Make the POST request to the inject-fault endpoint with clear action
-	url := fmt.Sprintf("%s/inject-fault", address)
+	url, err := endpoint.JoinPath(serverURL, "inject-fault")
+	if err != nil {
+		return fmt.Errorf("failed to construct inject-fault URL: %w", err)
+	}
 	fmt.Printf("Clearing fault from %s component at %s...\n", component, url)
 
 	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))

--- a/cmd/fleetint/inject.go
+++ b/cmd/fleetint/inject.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/urfave/cli"
 
@@ -111,7 +112,8 @@ func injectCommand(c *cli.Context) error {
 	}
 	fmt.Printf("Injecting fault into %s component at %s...\n", component, url)
 
-	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Post(url, "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
 		return fmt.Errorf("failed to make request to %s: %w", url, err)
 	}
@@ -184,7 +186,8 @@ func clearComponentFault(component string, serverURL *url.URL) error {
 	}
 	fmt.Printf("Clearing fault from %s component at %s...\n", component, url)
 
-	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Post(url, "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
 		return fmt.Errorf("failed to make request to %s: %w", url, err)
 	}

--- a/cmd/fleetint/security_test.go
+++ b/cmd/fleetint/security_test.go
@@ -44,3 +44,14 @@ func TestInjectCommandRejectsNonLocalServerURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid server URL")
 	assert.Contains(t, err.Error(), "user info")
 }
+
+func TestStatusCommandRejectsServerURLWithPath(t *testing.T) {
+	app := App()
+	app.Writer = &bytes.Buffer{}
+
+	err := app.Run([]string{"fleetint", "status", "--server-url", "http://localhost:15133/api"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid server URL")
+	assert.Contains(t, err.Error(), "must not include a path")
+}

--- a/cmd/fleetint/security_test.go
+++ b/cmd/fleetint/security_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusCommandRejectsNonLocalServerURL(t *testing.T) {
+	app := App()
+	app.Writer = &bytes.Buffer{}
+
+	err := app.Run([]string{"fleetint", "status", "--server-url", "http://169.254.169.254"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid server URL")
+	assert.Contains(t, err.Error(), "loopback")
+}
+
+func TestInjectCommandRejectsNonLocalServerURL(t *testing.T) {
+	app := App()
+	app.Writer = &bytes.Buffer{}
+
+	err := app.Run([]string{"fleetint", "inject", "--component", "cpu", "--server-url", "http://localhost@evil.example:15133"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid server URL")
+	assert.Contains(t, err.Error(), "user info")
+}

--- a/cmd/fleetint/status.go
+++ b/cmd/fleetint/status.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/cmdutil"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/endpoint"
 )
 
 func statusCommand(cliContext *cli.Context) error {
@@ -45,6 +46,11 @@ func statusCommand(cliContext *cli.Context) error {
 	log.Logger = log.CreateLogger(zapLvl, "")
 
 	log.Logger.Debugw("starting status command")
+
+	validatedServerURL, err := endpoint.ValidateLocalServerURL(serverURL)
+	if err != nil {
+		return fmt.Errorf("invalid server URL: %w", err)
+	}
 
 	rootCtx, rootCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer rootCancel()
@@ -126,7 +132,12 @@ func statusCommand(cliContext *cli.Context) error {
 		Timeout: 5 * time.Second,
 	}
 
-	resp, err := client.Get(serverURL + "/healthz")
+	healthURL, err := endpoint.JoinPath(validatedServerURL, "healthz")
+	if err != nil {
+		return fmt.Errorf("failed to construct health URL: %w", err)
+	}
+
+	resp, err := client.Get(healthURL)
 	if err != nil {
 		return fmt.Errorf("failed to connect to server: %w", err)
 	}

--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -350,10 +350,6 @@ func (m *Manager) getNonce(jwtToken string, machineId string) (string, time.Time
 }
 
 func (m *Manager) getValidatedNonceEndpoint(ctx context.Context) (string, error) {
-	if enrollEndpoint := m.getEnrollEndpointFromMetadata(ctx); enrollEndpoint != "" {
-		return endpoint.BuildNonceEndpointFromEnroll(enrollEndpoint)
-	}
-
 	nonceEndpoint := m.getNonceEndpointFromMetadata(ctx)
 	if nonceEndpoint == "" {
 		return "", fmt.Errorf("nonce endpoint not found in metadata")
@@ -411,28 +407,6 @@ func (m *Manager) getEndpointFromMetadata(ctx context.Context) string {
 	}
 
 	log.Logger.Debugw("backend endpoint not found in metadata")
-	return ""
-}
-
-func (m *Manager) getEnrollEndpointFromMetadata(ctx context.Context) string {
-	stateFile, err := defaultStateFileFn()
-	if err != nil {
-		log.Logger.Debugw("failed to get state file path", "error", err)
-		return ""
-	}
-
-	dbRO, err := sqlite.Open(stateFile)
-	if err != nil {
-		log.Logger.Debugw("failed to open state database", "error", err)
-		return ""
-	}
-	defer dbRO.Close()
-
-	if endpoint, err := pkgmetadata.ReadMetadata(ctx, dbRO, "enroll_endpoint"); err == nil && endpoint != "" {
-		return endpoint
-	}
-
-	log.Logger.Debugw("enroll endpoint not found in metadata")
 	return ""
 }
 

--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -359,7 +359,7 @@ func (m *Manager) getValidatedNonceEndpoint(ctx context.Context) (string, error)
 		return "", fmt.Errorf("nonce endpoint not found in metadata")
 	}
 
-	validated, err := endpoint.ValidateEnrollEndpoint(nonceEndpoint)
+	validated, err := endpoint.ValidateBackendEndpoint(nonceEndpoint)
 	if err != nil {
 		return "", fmt.Errorf("invalid nonce endpoint: %w", err)
 	}

--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -34,6 +34,7 @@ import (
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/sqlite"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/endpoint"
 )
 
 var defaultStateFileFn = config.DefaultStateFile
@@ -288,11 +289,9 @@ func (m *Manager) runAttestation() bool {
 }
 
 func (m *Manager) getNonce(jwtToken string, machineId string) (string, time.Time, error) {
-	// Load nonce endpoint from metadata database
-	url := m.getNonceEndpointFromMetadata(m.ctx)
-	if url == "" {
-		// Return error if nonce endpoint not found in metadata
-		return "", time.Time{}, fmt.Errorf("nonce endpoint not found in metadata")
+	endpointURL, err := m.getValidatedNonceEndpoint(m.ctx)
+	if err != nil {
+		return "", time.Time{}, err
 	}
 
 	// Request payload (only include machine ID, JWT token goes in header)
@@ -305,7 +304,7 @@ func (m *Manager) getNonce(jwtToken string, machineId string) (string, time.Time
 	}
 
 	// Create HTTP request with proper Bearer authorization
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBody))
+	req, err := http.NewRequest("POST", endpointURL, bytes.NewBuffer(requestBody))
 	if err != nil {
 		log.Logger.Debugw("failed to create HTTP request in nonce endpoint request", "error", err)
 		return "", time.Time{}, err
@@ -348,6 +347,24 @@ func (m *Manager) getNonce(jwtToken string, machineId string) (string, time.Time
 	}
 
 	return response.Nonce, response.NonceRefreshTimestamp, nil
+}
+
+func (m *Manager) getValidatedNonceEndpoint(ctx context.Context) (string, error) {
+	if enrollEndpoint := m.getEnrollEndpointFromMetadata(ctx); enrollEndpoint != "" {
+		return endpoint.BuildNonceEndpointFromEnroll(enrollEndpoint)
+	}
+
+	nonceEndpoint := m.getNonceEndpointFromMetadata(ctx)
+	if nonceEndpoint == "" {
+		return "", fmt.Errorf("nonce endpoint not found in metadata")
+	}
+
+	validated, err := endpoint.ValidateEnrollEndpoint(nonceEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid nonce endpoint: %w", err)
+	}
+
+	return validated.String(), nil
 }
 
 // getJWTTokenFromMetadata retrieves the JWT token from the metadata database
@@ -394,6 +411,28 @@ func (m *Manager) getEndpointFromMetadata(ctx context.Context) string {
 	}
 
 	log.Logger.Debugw("backend endpoint not found in metadata")
+	return ""
+}
+
+func (m *Manager) getEnrollEndpointFromMetadata(ctx context.Context) string {
+	stateFile, err := defaultStateFileFn()
+	if err != nil {
+		log.Logger.Debugw("failed to get state file path", "error", err)
+		return ""
+	}
+
+	dbRO, err := sqlite.Open(stateFile)
+	if err != nil {
+		log.Logger.Debugw("failed to open state database", "error", err)
+		return ""
+	}
+	defer dbRO.Close()
+
+	if endpoint, err := pkgmetadata.ReadMetadata(ctx, dbRO, "enroll_endpoint"); err == nil && endpoint != "" {
+		return endpoint
+	}
+
+	log.Logger.Debugw("enroll endpoint not found in metadata")
 	return ""
 }
 

--- a/internal/attestation/attestation_test.go
+++ b/internal/attestation/attestation_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	pkgmetadata "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metadata"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -288,6 +290,76 @@ func TestManager_GetNonce_ServerError(t *testing.T) {
 	assert.Equal(t, "Invalid token", response.Error)
 	assert.Empty(t, response.Nonce)
 	assert.True(t, response.NonceRefreshTimestamp.IsZero())
+}
+
+func TestManager_GetValidatedNonceEndpoint_DerivesFromEnrollEndpoint(t *testing.T) {
+	manager := newTestManager(t)
+	stateFile := setupAttestationMetadataDB(t, map[string]string{
+		"enroll_endpoint": "https://backend.example.com/api/v1/health/enroll",
+		"nonce_endpoint":  "https://evil.example.com/api/v1/health/nonce",
+	})
+	useTestStateFile(t, stateFile)
+
+	got, err := manager.getValidatedNonceEndpoint(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "https://backend.example.com/api/v1/health/nonce", got)
+}
+
+func TestManager_GetValidatedNonceEndpoint_RejectsTamperedStoredNonceEndpoint(t *testing.T) {
+	manager := newTestManager(t)
+	stateFile := setupAttestationMetadataDB(t, map[string]string{
+		"nonce_endpoint": "http://evil.example.com/api/v1/health/nonce",
+	})
+	useTestStateFile(t, stateFile)
+
+	_, err := manager.getValidatedNonceEndpoint(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid nonce endpoint")
+	assert.Contains(t, err.Error(), "https")
+}
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+
+	ctx := context.Background()
+	cfg := &config.AttestationConfig{
+		Interval:      metav1.Duration{Duration: 20 * time.Second},
+		JitterEnabled: false,
+	}
+	return NewManager(ctx, nil, cfg)
+}
+
+func setupAttestationMetadataDB(t *testing.T, entries map[string]string) string {
+	t.Helper()
+
+	stateFile := filepath.Join(t.TempDir(), "fleetint.state")
+	db, err := sqlite.Open(stateFile)
+	require.NoError(t, err)
+
+	err = pkgmetadata.CreateTableMetadata(context.Background(), db)
+	require.NoError(t, err)
+
+	for key, value := range entries {
+		err = pkgmetadata.SetMetadata(context.Background(), db, key, value)
+		require.NoError(t, err)
+	}
+
+	err = db.Close()
+	require.NoError(t, err)
+
+	return stateFile
+}
+
+func useTestStateFile(t *testing.T, stateFile string) {
+	t.Helper()
+
+	orig := defaultStateFileFn
+	defaultStateFileFn = func() (string, error) {
+		return stateFile, nil
+	}
+	t.Cleanup(func() {
+		defaultStateFileFn = orig
+	})
 }
 
 func TestManager_GetEvidences(t *testing.T) {

--- a/internal/attestation/attestation_test.go
+++ b/internal/attestation/attestation_test.go
@@ -292,11 +292,10 @@ func TestManager_GetNonce_ServerError(t *testing.T) {
 	assert.True(t, response.NonceRefreshTimestamp.IsZero())
 }
 
-func TestManager_GetValidatedNonceEndpoint_DerivesFromEnrollEndpoint(t *testing.T) {
+func TestManager_GetValidatedNonceEndpoint_UsesStoredNonceEndpoint(t *testing.T) {
 	manager := newTestManager(t)
 	stateFile := setupAttestationMetadataDB(t, map[string]string{
-		"enroll_endpoint": "https://backend.example.com/api/v1/health/enroll",
-		"nonce_endpoint":  "https://evil.example.com/api/v1/health/nonce",
+		"nonce_endpoint": "https://backend.example.com/api/v1/health/nonce",
 	})
 	useTestStateFile(t, stateFile)
 

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// ValidateLocalServerURL validates a CLI-supplied URL for the local fleetint daemon.
+func ValidateLocalServerURL(raw string) (*url.URL, error) {
+	parsed, err := parseURL(raw)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireScheme(parsed, "http", "https"); err != nil {
+		return nil, err
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("server URL must include a host")
+	}
+	if !isLoopbackHost(host) {
+		return nil, fmt.Errorf("server URL host must be localhost or a loopback IP, got %q", host)
+	}
+
+	return parsed, nil
+}
+
+// ValidateEnrollEndpoint validates a trusted backend HTTPS endpoint.
+func ValidateEnrollEndpoint(raw string) (*url.URL, error) {
+	parsed, err := parseURL(raw)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireScheme(parsed, "https"); err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+// BuildNonceEndpointFromEnroll derives the nonce endpoint from an enroll endpoint.
+func BuildNonceEndpointFromEnroll(raw string) (string, error) {
+	enrollURL, err := ValidateEnrollEndpoint(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid enroll endpoint: %w", err)
+	}
+	if !strings.HasSuffix(enrollURL.Path, "/enroll") {
+		return "", fmt.Errorf("enroll endpoint path must end with /enroll, got %q", enrollURL.Path)
+	}
+
+	nonceURL := *enrollURL
+	nonceURL.Path = path.Clean(strings.TrimSuffix(enrollURL.Path, "/enroll") + "/nonce")
+	nonceURL.RawPath = ""
+	nonceURL.RawQuery = ""
+	nonceURL.Fragment = ""
+
+	return nonceURL.String(), nil
+}
+
+// JoinPath appends path elements to a validated base URL.
+func JoinPath(base *url.URL, elems ...string) (string, error) {
+	return url.JoinPath(base.String(), elems...)
+}
+
+func parseURL(raw string) (*url.URL, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.User != nil {
+		return nil, fmt.Errorf("URL must not include user info")
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("URL must include a host")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("URL must not include query parameters or fragments")
+	}
+	return parsed, nil
+}
+
+func requireScheme(parsed *url.URL, allowed ...string) error {
+	for _, scheme := range allowed {
+		if parsed.Scheme == scheme {
+			return nil
+		}
+	}
+	return fmt.Errorf("URL scheme must be one of %q, got %q", allowed, parsed.Scheme)
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -54,25 +53,6 @@ func ValidateBackendEndpoint(raw string) (*url.URL, error) {
 		return nil, err
 	}
 	return parsed, nil
-}
-
-// BuildNonceEndpointFromEnroll derives the nonce endpoint from an enroll endpoint.
-func BuildNonceEndpointFromEnroll(raw string) (string, error) {
-	enrollURL, err := ValidateBackendEndpoint(raw)
-	if err != nil {
-		return "", fmt.Errorf("invalid enroll endpoint: %w", err)
-	}
-	if !strings.HasSuffix(enrollURL.Path, "/enroll") {
-		return "", fmt.Errorf("enroll endpoint path must end with /enroll, got %q", enrollURL.Path)
-	}
-
-	nonceURL := *enrollURL
-	nonceURL.Path = path.Clean(strings.TrimSuffix(enrollURL.Path, "/enroll") + "/nonce")
-	nonceURL.RawPath = ""
-	nonceURL.RawQuery = ""
-	nonceURL.Fragment = ""
-
-	return nonceURL.String(), nil
 }
 
 // JoinPath appends path elements to a validated base URL.

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -31,6 +31,9 @@ func ValidateLocalServerURL(raw string) (*url.URL, error) {
 	if err := requireScheme(parsed, "http", "https"); err != nil {
 		return nil, err
 	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return nil, fmt.Errorf("server URL must not include a path, got %q", parsed.Path)
+	}
 
 	host := parsed.Hostname()
 	if host == "" {

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -44,8 +44,8 @@ func ValidateLocalServerURL(raw string) (*url.URL, error) {
 	return parsed, nil
 }
 
-// ValidateEnrollEndpoint validates a trusted backend HTTPS endpoint.
-func ValidateEnrollEndpoint(raw string) (*url.URL, error) {
+// ValidateBackendEndpoint validates a trusted backend HTTPS endpoint.
+func ValidateBackendEndpoint(raw string) (*url.URL, error) {
 	parsed, err := parseURL(raw)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func ValidateEnrollEndpoint(raw string) (*url.URL, error) {
 
 // BuildNonceEndpointFromEnroll derives the nonce endpoint from an enroll endpoint.
 func BuildNonceEndpointFromEnroll(raw string) (string, error) {
-	enrollURL, err := ValidateEnrollEndpoint(raw)
+	enrollURL, err := ValidateBackendEndpoint(raw)
 	if err != nil {
 		return "", fmt.Errorf("invalid enroll endpoint: %w", err)
 	}

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -65,13 +65,13 @@ func TestBuildNonceEndpointFromEnroll(t *testing.T) {
 	assert.Equal(t, "https://example.com/api/v1/health/nonce", got)
 }
 
-func TestValidateEnrollEndpoint(t *testing.T) {
+func TestValidateBackendEndpoint(t *testing.T) {
 	t.Parallel()
 
-	_, err := ValidateEnrollEndpoint("https://example.com/base")
+	_, err := ValidateBackendEndpoint("https://example.com/base")
 	require.NoError(t, err)
 
-	_, err = ValidateEnrollEndpoint("http://example.com/base")
+	_, err = ValidateBackendEndpoint("http://example.com/base")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "https")
 }

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -57,14 +57,6 @@ func TestValidateLocalServerURL(t *testing.T) {
 	}
 }
 
-func TestBuildNonceEndpointFromEnroll(t *testing.T) {
-	t.Parallel()
-
-	got, err := BuildNonceEndpointFromEnroll("https://example.com/api/v1/health/enroll")
-	require.NoError(t, err)
-	assert.Equal(t, "https://example.com/api/v1/health/nonce", got)
-}
-
 func TestValidateBackendEndpoint(t *testing.T) {
 	t.Parallel()
 

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateLocalServerURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{name: "localhost_http", raw: "http://localhost:15133"},
+		{name: "loopback_ipv4", raw: "http://127.0.0.1:15133"},
+		{name: "loopback_ipv6", raw: "http://[::1]:15133"},
+		{name: "non_localhost_rejected", raw: "http://169.254.169.254:80", wantErr: "loopback"},
+		{name: "userinfo_rejected", raw: "http://localhost@evil.example:15133", wantErr: "user info"},
+		{name: "suffix_attack_rejected", raw: "http://127.0.0.1.evil.example:15133", wantErr: "loopback"},
+		{name: "path_query_rejected", raw: "http://localhost:15133?x=1", wantErr: "query parameters"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ValidateLocalServerURL(tc.raw)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.raw, got.String())
+		})
+	}
+}
+
+func TestBuildNonceEndpointFromEnroll(t *testing.T) {
+	t.Parallel()
+
+	got, err := BuildNonceEndpointFromEnroll("https://example.com/api/v1/health/enroll")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/api/v1/health/nonce", got)
+}
+
+func TestValidateEnrollEndpoint(t *testing.T) {
+	t.Parallel()
+
+	_, err := ValidateEnrollEndpoint("https://example.com/base")
+	require.NoError(t, err)
+
+	_, err = ValidateEnrollEndpoint("http://example.com/base")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -268,7 +268,7 @@ func (e *healthExporter) refreshConfigFromMetadata(ctx context.Context) {
 	// Load metrics endpoint (update even if empty to handle un-enrollment)
 	if metricsEndpoint, err := pkgmetadata.ReadMetadata(ctx, e.options.dbRO, "metrics_endpoint"); err == nil {
 		if metricsEndpoint != "" {
-			validated, validateErr := endpoint.ValidateEnrollEndpoint(metricsEndpoint)
+			validated, validateErr := endpoint.ValidateBackendEndpoint(metricsEndpoint)
 			if validateErr != nil {
 				log.Logger.Errorw("ignoring invalid metrics endpoint from metadata", "error", validateErr)
 				metricsEndpoint = ""
@@ -291,7 +291,7 @@ func (e *healthExporter) refreshConfigFromMetadata(ctx context.Context) {
 	// Load logs endpoint (update even if empty to handle un-enrollment)
 	if logsEndpoint, err := pkgmetadata.ReadMetadata(ctx, e.options.dbRO, "logs_endpoint"); err == nil {
 		if logsEndpoint != "" {
-			validated, validateErr := endpoint.ValidateEnrollEndpoint(logsEndpoint)
+			validated, validateErr := endpoint.ValidateBackendEndpoint(logsEndpoint)
 			if validateErr != nil {
 				log.Logger.Errorw("ignoring invalid logs endpoint from metadata", "error", validateErr)
 				logsEndpoint = ""

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -31,6 +31,7 @@ import (
 	pkgmetadata "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metadata"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/attestation"
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/endpoint"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/enrollment"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/exporter/collector"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/exporter/converter"
@@ -266,6 +267,15 @@ func (e *healthExporter) refreshConfigFromMetadata(ctx context.Context) {
 
 	// Load metrics endpoint (update even if empty to handle un-enrollment)
 	if metricsEndpoint, err := pkgmetadata.ReadMetadata(ctx, e.options.dbRO, "metrics_endpoint"); err == nil {
+		if metricsEndpoint != "" {
+			validated, validateErr := endpoint.ValidateEnrollEndpoint(metricsEndpoint)
+			if validateErr != nil {
+				log.Logger.Errorw("ignoring invalid metrics endpoint from metadata", "error", validateErr)
+				metricsEndpoint = ""
+			} else {
+				metricsEndpoint = validated.String()
+			}
+		}
 		if e.options.config.MetricsEndpoint != metricsEndpoint {
 			e.options.config.MetricsEndpoint = metricsEndpoint
 			if metricsEndpoint == "" {
@@ -280,6 +290,15 @@ func (e *healthExporter) refreshConfigFromMetadata(ctx context.Context) {
 
 	// Load logs endpoint (update even if empty to handle un-enrollment)
 	if logsEndpoint, err := pkgmetadata.ReadMetadata(ctx, e.options.dbRO, "logs_endpoint"); err == nil {
+		if logsEndpoint != "" {
+			validated, validateErr := endpoint.ValidateEnrollEndpoint(logsEndpoint)
+			if validateErr != nil {
+				log.Logger.Errorw("ignoring invalid logs endpoint from metadata", "error", validateErr)
+				logsEndpoint = ""
+			} else {
+				logsEndpoint = validated.String()
+			}
+		}
 		if e.options.config.LogsEndpoint != logsEndpoint {
 			e.options.config.LogsEndpoint = logsEndpoint
 			if logsEndpoint == "" {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -689,9 +689,9 @@ func TestRefreshConfigFromMetadata(t *testing.T) {
 		ctx := context.Background()
 
 		// Insert test data into metadata table using SetMetadata
-		err := pkgmetadata.SetMetadata(ctx, tmpDB, "metrics_endpoint", "http://new-metrics.example.com")
+		err := pkgmetadata.SetMetadata(ctx, tmpDB, "metrics_endpoint", "https://new-metrics.example.com")
 		require.NoError(t, err)
-		err = pkgmetadata.SetMetadata(ctx, tmpDB, "logs_endpoint", "http://new-logs.example.com")
+		err = pkgmetadata.SetMetadata(ctx, tmpDB, "logs_endpoint", "https://new-logs.example.com")
 		require.NoError(t, err)
 		err = pkgmetadata.SetMetadata(ctx, tmpDB, pkgmetadata.MetadataKeyToken, "new-test-token")
 		require.NoError(t, err)
@@ -699,8 +699,8 @@ func TestRefreshConfigFromMetadata(t *testing.T) {
 		cfg := &config.HealthExporterConfig{
 			Interval:        metav1.Duration{Duration: 1 * time.Minute},
 			Timeout:         metav1.Duration{Duration: 30 * time.Second},
-			MetricsEndpoint: "http://old-metrics.example.com",
-			LogsEndpoint:    "http://old-logs.example.com",
+			MetricsEndpoint: "https://old-metrics.example.com",
+			LogsEndpoint:    "https://old-logs.example.com",
 			AuthToken:       "old-token",
 		}
 
@@ -718,8 +718,8 @@ func TestRefreshConfigFromMetadata(t *testing.T) {
 		he.refreshConfigFromMetadata(ctx)
 
 		// Verify config was updated
-		assert.Equal(t, "http://new-metrics.example.com", he.options.config.MetricsEndpoint)
-		assert.Equal(t, "http://new-logs.example.com", he.options.config.LogsEndpoint)
+		assert.Equal(t, "https://new-metrics.example.com", he.options.config.MetricsEndpoint)
+		assert.Equal(t, "https://new-logs.example.com", he.options.config.LogsEndpoint)
 		assert.Equal(t, "new-test-token", he.options.config.AuthToken)
 
 		// Cleanup
@@ -742,8 +742,8 @@ func TestRefreshConfigFromMetadata(t *testing.T) {
 		cfg := &config.HealthExporterConfig{
 			Interval:        metav1.Duration{Duration: 1 * time.Minute},
 			Timeout:         metav1.Duration{Duration: 30 * time.Second},
-			MetricsEndpoint: "http://old-metrics.example.com",
-			LogsEndpoint:    "http://old-logs.example.com",
+			MetricsEndpoint: "https://old-metrics.example.com",
+			LogsEndpoint:    "https://old-logs.example.com",
 		}
 
 		exporter, err := New(ctx,
@@ -764,6 +764,42 @@ func TestRefreshConfigFromMetadata(t *testing.T) {
 		assert.Empty(t, he.options.config.LogsEndpoint)
 
 		// Cleanup
+		err = exporter.Stop()
+		require.NoError(t, err)
+	})
+
+	t.Run("ignores invalid endpoints from metadata", func(t *testing.T) {
+		tmpDB := setupTestDB(t)
+		defer tmpDB.Close()
+
+		ctx := context.Background()
+
+		err := pkgmetadata.SetMetadata(ctx, tmpDB, "metrics_endpoint", "http://bad-metrics.example.com")
+		require.NoError(t, err)
+		err = pkgmetadata.SetMetadata(ctx, tmpDB, "logs_endpoint", "https://user@bad-logs.example.com")
+		require.NoError(t, err)
+
+		cfg := &config.HealthExporterConfig{
+			Interval:        metav1.Duration{Duration: 1 * time.Minute},
+			Timeout:         metav1.Duration{Duration: 30 * time.Second},
+			MetricsEndpoint: "https://old-metrics.example.com",
+			LogsEndpoint:    "https://old-logs.example.com",
+		}
+
+		exporter, err := New(ctx,
+			WithConfig(cfg),
+			WithDatabaseConnections(tmpDB, tmpDB),
+			WithMachineID("test-machine-id"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, exporter)
+
+		he := exporter.(*healthExporter)
+		he.refreshConfigFromMetadata(ctx)
+
+		assert.Empty(t, he.options.config.MetricsEndpoint)
+		assert.Empty(t, he.options.config.LogsEndpoint)
+
 		err = exporter.Stop()
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
## Summary
- add shared endpoint validation helpers for backend and local daemon URLs
- validate enrollment input before deriving enroll, metrics, logs, and nonce endpoints
- validate stored nonce, metrics, and logs endpoints before use and add regression tests for hostile URL inputs

## Why
The agent was trusting derived or stored endpoint values too loosely in a few paths. The main trust anchor is the enrollment endpoint shape, and downstream endpoints should get at least basic validation before use.

## Impact
This hardens `enroll`, `status`, `inject`, attestation nonce fetches, and exporter metadata refreshes against malformed or unsafe endpoint values while preserving the intended localhost client flow.

## Validation
- `go test ./internal/exporter ./cmd/fleetint ./internal/endpoint ./internal/attestation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened URL validation for server and backend endpoints and clarified error text for invalid endpoints
  * Prevented use of non-loopback or malformed server URLs and disallowed non-HTTPS backend endpoints
  * Safer endpoint construction for health/nonce/enroll/metrics/logs and injection flows; injection requests now use a client with a 5s timeout

* **Tests**
  * Added security tests rejecting non-local server URLs and expanded endpoint validation coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->