### PR TITLE
fix: isolate exporter timeout phases

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,10 +28,30 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func useTempHomeDir(t *testing.T) string {
+	t.Helper()
+
+	origGeteuid := osGeteuid
+	origHomeDirFn := homeDirFn
+
+	tmpHome := t.TempDir()
+	osGeteuid = func() int { return 1000 }
+	homeDirFn = func() (string, error) { return tmpHome, nil }
+
+	t.Cleanup(func() {
+		osGeteuid = origGeteuid
+		homeDirFn = origHomeDirFn
+	})
+
+	return tmpHome
+}
+
 func TestDefault(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("default values", func(t *testing.T) {
+		useTempHomeDir(t)
+
 		cfg, err := Default(ctx)
 		require.NoError(t, err)
 
@@ -45,6 +65,8 @@ func TestDefault(t *testing.T) {
 	})
 
 	t.Run("with infiniband class dir option", func(t *testing.T) {
+		useTempHomeDir(t)
+
 		classDir := "/custom/class"
 
 		cfg, err := Default(ctx, WithInfinibandClassRootDir(classDir))
@@ -551,6 +573,8 @@ func TestDefaultWithHealthExporter(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("default includes health exporter", func(t *testing.T) {
+		useTempHomeDir(t)
+
 		cfg, err := Default(ctx)
 		require.NoError(t, err)
 

--- a/internal/exporter/collector/collector.go
+++ b/internal/exporter/collector/collector.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
@@ -124,25 +125,44 @@ func (c *collector) Collect(ctx context.Context) (*HealthData, error) {
 		Timestamp:    time.Now().UTC(),
 	}
 
+	if err := ctx.Err(); err != nil {
+		return data, err
+	}
+
 	// Collect machine info if enabled
 	if c.config.IncludeMachineInfo {
 		if err := c.collectMachineInfo(data); err != nil {
 			log.Logger.Errorw("Failed to collect machine info", "error", err)
 		}
 	}
+	if err := ctx.Err(); err != nil {
+		return data, err
+	}
 
 	// Collect metrics if enabled
 	if c.config.IncludeMetrics {
 		if err := c.collectMetrics(ctx, data); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return data, err
+			}
 			log.Logger.Errorw("Failed to collect metrics", "error", err)
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return data, err
 	}
 
 	// Collect events if enabled
 	if c.config.IncludeEvents {
 		if err := c.collectEvents(ctx, data); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return data, err
+			}
 			log.Logger.Errorw("Failed to collect events", "error", err)
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return data, err
 	}
 
 	// Collect component data if enabled
@@ -150,6 +170,9 @@ func (c *collector) Collect(ctx context.Context) (*HealthData, error) {
 		if err := c.collectComponentData(data); err != nil {
 			log.Logger.Errorw("Failed to collect component data", "error", err)
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return data, err
 	}
 
 	// Collect attestation data if provider is available
@@ -219,8 +242,17 @@ func (c *collector) collectEvents(ctx context.Context, data *HealthData) error {
 	}
 
 	for _, component := range components {
+		if err := ctx.Err(); err != nil {
+			data.Events = allEvents
+			return err
+		}
+
 		componentEvents, err := component.Events(ctx, since)
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				data.Events = allEvents
+				return err
+			}
 			log.Logger.Errorw("Failed to get events from component",
 				"component", component.Name(), "error", err)
 			continue

--- a/internal/exporter/collector/collector.go
+++ b/internal/exporter/collector/collector.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
@@ -73,7 +74,12 @@ type collector struct {
 	lastAttestationCollection time.Time
 	machineID                 string            // Agent's stable identity from server initialization
 	dcgmGPUIndexes            map[string]string // UUID → DCGM device ID override for GPU indices
+	machineInfoMu             sync.RWMutex
+	cachedMachineInfo         *machineinfo.MachineInfo
+	machineInfoCollecting     bool
 }
+
+var getMachineInfo = machineinfo.GetMachineInfo
 
 // New creates a new health data collector
 func New(
@@ -131,7 +137,7 @@ func (c *collector) Collect(ctx context.Context) (*HealthData, error) {
 
 	// Collect machine info if enabled
 	if c.config.IncludeMachineInfo {
-		if err := c.collectMachineInfo(data); err != nil {
+		if err := c.collectMachineInfo(ctx, data); err != nil {
 			log.Logger.Errorw("Failed to collect machine info", "error", err)
 		}
 	}
@@ -167,7 +173,10 @@ func (c *collector) Collect(ctx context.Context) (*HealthData, error) {
 
 	// Collect component data if enabled
 	if c.config.IncludeComponentData {
-		if err := c.collectComponentData(data); err != nil {
+		if err := c.collectComponentData(ctx, data); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return data, err
+			}
 			log.Logger.Errorw("Failed to collect component data", "error", err)
 		}
 	}
@@ -189,25 +198,65 @@ func (c *collector) Collect(ctx context.Context) (*HealthData, error) {
 	return data, nil
 }
 
-// collectMachineInfo collects machine hardware information
-func (c *collector) collectMachineInfo(data *HealthData) error {
+// collectMachineInfo attaches cached machine info when available and triggers
+// a background refresh if one is not already in progress.
+func (c *collector) collectMachineInfo(ctx context.Context, data *HealthData) error {
 	if c.nvmlInstance == nil {
 		return fmt.Errorf("NVML instance not available")
 	}
 
-	var opts []machineinfo.MachineInfoOption
-	if len(c.dcgmGPUIndexes) > 0 {
-		opts = append(opts, machineinfo.WithDCGMGPUIndexes(c.dcgmGPUIndexes))
+	if cached := c.getCachedMachineInfo(); cached != nil {
+		data.MachineInfo = cached
+		log.Logger.Debugw("Using cached machine info")
 	}
 
-	machineInfo, err := machineinfo.GetMachineInfo(c.nvmlInstance, opts...)
-	if err != nil {
-		return fmt.Errorf("failed to get machine info: %w", err)
+	c.startMachineInfoRefresh()
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
-	data.MachineInfo = machineInfo
-	log.Logger.Debugw("Collected machine info", "machine_info", data.MachineInfo)
 	return nil
+}
+
+func (c *collector) startMachineInfoRefresh() {
+	c.machineInfoMu.Lock()
+	if c.machineInfoCollecting {
+		c.machineInfoMu.Unlock()
+		return
+	}
+	c.machineInfoCollecting = true
+	c.machineInfoMu.Unlock()
+
+	go func() {
+		defer func() {
+			c.machineInfoMu.Lock()
+			c.machineInfoCollecting = false
+			c.machineInfoMu.Unlock()
+		}()
+
+		var opts []machineinfo.MachineInfoOption
+		if len(c.dcgmGPUIndexes) > 0 {
+			opts = append(opts, machineinfo.WithDCGMGPUIndexes(c.dcgmGPUIndexes))
+		}
+
+		machineInfo, err := getMachineInfo(c.nvmlInstance, opts...)
+		if err != nil {
+			log.Logger.Errorw("Failed to refresh machine info", "error", err)
+			return
+		}
+
+		c.machineInfoMu.Lock()
+		c.cachedMachineInfo = machineInfo
+		c.machineInfoMu.Unlock()
+		log.Logger.Debugw("Refreshed machine info", "machine_info", machineInfo)
+	}()
+}
+
+func (c *collector) getCachedMachineInfo() *machineinfo.MachineInfo {
+	c.machineInfoMu.RLock()
+	defer c.machineInfoMu.RUnlock()
+
+	return c.cachedMachineInfo
 }
 
 // collectMetrics collects metrics data from the metrics store
@@ -282,7 +331,7 @@ func (c *collector) collectEvents(ctx context.Context, data *HealthData) error {
 }
 
 // collectComponentData collects health states from all components
-func (c *collector) collectComponentData(data *HealthData) error {
+func (c *collector) collectComponentData(ctx context.Context, data *HealthData) error {
 	if c.componentsRegistry == nil {
 		return fmt.Errorf("components registry not available")
 	}
@@ -291,10 +340,19 @@ func (c *collector) collectComponentData(data *HealthData) error {
 	components := c.componentsRegistry.All()
 
 	for _, component := range components {
+		if err := ctx.Err(); err != nil {
+			data.ComponentData = componentData
+			return err
+		}
+
 		componentName := component.Name()
 
 		// Get health states
 		healthStates := component.LastHealthStates()
+		if err := ctx.Err(); err != nil {
+			data.ComponentData = componentData
+			return err
+		}
 		log.Logger.Debugw("Collecting health states",
 			"component", componentName, "health_states", healthStates)
 

--- a/internal/exporter/collector/collector.go
+++ b/internal/exporter/collector/collector.go
@@ -77,9 +77,8 @@ type collector struct {
 	machineInfoMu             sync.RWMutex
 	cachedMachineInfo         *machineinfo.MachineInfo
 	machineInfoCollecting     bool
+	machineInfoFetcher        func(nvidianvml.Instance, ...machineinfo.MachineInfoOption) (*machineinfo.MachineInfo, error)
 }
-
-var getMachineInfo = machineinfo.GetMachineInfo
 
 // New creates a new health data collector
 func New(
@@ -111,6 +110,7 @@ func New(
 		attestationManager: attestationManager,
 		machineID:          machineID,
 		dcgmGPUIndexes:     dcgmGPUIndexes,
+		machineInfoFetcher: machineinfo.GetMachineInfo,
 	}
 }
 
@@ -199,7 +199,7 @@ func (c *collector) Collect(ctx context.Context) (*HealthData, error) {
 }
 
 // collectMachineInfo attaches cached machine info when available and triggers
-// a background refresh if one is not already in progress.
+// a background refresh only until the cache has been populated.
 func (c *collector) collectMachineInfo(ctx context.Context, data *HealthData) error {
 	if c.nvmlInstance == nil {
 		return fmt.Errorf("NVML instance not available")
@@ -220,7 +220,7 @@ func (c *collector) collectMachineInfo(ctx context.Context, data *HealthData) er
 
 func (c *collector) startMachineInfoRefresh() {
 	c.machineInfoMu.Lock()
-	if c.machineInfoCollecting {
+	if c.machineInfoCollecting || c.cachedMachineInfo != nil {
 		c.machineInfoMu.Unlock()
 		return
 	}
@@ -239,7 +239,7 @@ func (c *collector) startMachineInfoRefresh() {
 			opts = append(opts, machineinfo.WithDCGMGPUIndexes(c.dcgmGPUIndexes))
 		}
 
-		machineInfo, err := getMachineInfo(c.nvmlInstance, opts...)
+		machineInfo, err := c.machineInfoFetcher(c.nvmlInstance, opts...)
 		if err != nil {
 			log.Logger.Errorw("Failed to refresh machine info", "error", err)
 			return

--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -483,12 +483,9 @@ func TestCollector_CollectMachineInfo_NoNVML(t *testing.T) {
 }
 
 func TestCollector_CollectMachineInfoHangDoesNotBlockOtherData(t *testing.T) {
-	originalGetMachineInfo := getMachineInfo
-	defer func() { getMachineInfo = originalGetMachineInfo }()
-
 	release := make(chan struct{})
 	started := make(chan struct{}, 1)
-	getMachineInfo = func(nvmlInstance nvidianvml.Instance, opts ...machineinfo.MachineInfoOption) (*machineinfo.MachineInfo, error) {
+	machineInfoFetcher := func(nvmlInstance nvidianvml.Instance, opts ...machineinfo.MachineInfoOption) (*machineinfo.MachineInfo, error) {
 		started <- struct{}{}
 		<-release
 		return &machineinfo.MachineInfo{MachineID: "machine-info-id"}, nil
@@ -521,7 +518,8 @@ func TestCollector_CollectMachineInfoHangDoesNotBlockOtherData(t *testing.T) {
 	}
 	mockRegistry := &mockRegistry{components: []components.Component{mockComp}}
 
-	collector := New(cfg, nil, nil, mockStore, &mockEventStore{}, mockRegistry, nvidianvml.NewNoOp(), nil, "test-machine-id", nil)
+	collector := New(cfg, nil, nil, mockStore, &mockEventStore{}, mockRegistry, nvidianvml.NewNoOp(), nil, "test-machine-id", nil).(*collector)
+	collector.machineInfoFetcher = machineInfoFetcher
 
 	done := make(chan struct{})
 	var (
@@ -555,12 +553,9 @@ func TestCollector_CollectMachineInfoHangDoesNotBlockOtherData(t *testing.T) {
 }
 
 func TestCollector_CollectMachineInfoUsesCachedRefreshResult(t *testing.T) {
-	originalGetMachineInfo := getMachineInfo
-	defer func() { getMachineInfo = originalGetMachineInfo }()
-
 	var callCount atomic.Int32
 	refreshed := make(chan struct{}, 1)
-	getMachineInfo = func(nvmlInstance nvidianvml.Instance, opts ...machineinfo.MachineInfoOption) (*machineinfo.MachineInfo, error) {
+	machineInfoFetcher := func(nvmlInstance nvidianvml.Instance, opts ...machineinfo.MachineInfoOption) (*machineinfo.MachineInfo, error) {
 		callCount.Add(1)
 		info := &machineinfo.MachineInfo{
 			MachineID:               "machine-info-id",
@@ -575,7 +570,8 @@ func TestCollector_CollectMachineInfoUsesCachedRefreshResult(t *testing.T) {
 		IncludeMachineInfo: true,
 	}
 
-	collector := New(cfg, nil, nil, nil, nil, nil, nvidianvml.NewNoOp(), nil, "test-machine-id", nil)
+	collector := New(cfg, nil, nil, nil, nil, nil, nvidianvml.NewNoOp(), nil, "test-machine-id", nil).(*collector)
+	collector.machineInfoFetcher = machineInfoFetcher
 
 	data1, err := collector.Collect(context.Background())
 	require.NoError(t, err)

--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -378,6 +378,60 @@ func TestNew(t *testing.T) {
 	var _ = c
 }
 
+func TestCollectReturnsPartialDataWhenEventCollectionTimesOut(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	firstEvent := apiv1.Event{
+		Component: "cpu",
+		Time:      metav1.NewTime(time.Now().UTC()),
+		Name:      "test_event",
+		Type:      apiv1.EventTypeWarning,
+		Message:   "first event",
+	}
+
+	registry := &mockRegistry{
+		components: []components.Component{
+			&mockComponent{
+				name:   "cpu",
+				events: []apiv1.Event{firstEvent},
+			},
+			&mockComponent{
+				name: "memory",
+				eventFunc: func(ctx context.Context, since time.Time) (apiv1.Events, error) {
+					cancel()
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+			},
+		},
+	}
+
+	c := New(
+		&config.HealthExporterConfig{
+			IncludeEvents: true,
+			EventsLookback: metav1.Duration{
+				Duration: time.Minute,
+			},
+		},
+		nil,
+		nil,
+		nil,
+		&mockEventStore{},
+		registry,
+		nil,
+		nil,
+		"test-machine-id",
+		nil,
+	)
+
+	data, err := c.Collect(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotNil(t, data)
+	require.Len(t, data.Events, 1)
+	assert.Equal(t, "cpu", data.Events[0].Component)
+	assert.Equal(t, "test_event", data.Events[0].Name)
+}
+
 func TestCollector_Collect_BasicFlow(t *testing.T) {
 	ctx := context.Background()
 	cfg := &config.HealthExporterConfig{
@@ -843,6 +897,7 @@ type mockComponent struct {
 	events       []apiv1.Event
 	healthStates []apiv1.HealthState
 	shouldError  bool
+	eventFunc    func(ctx context.Context, since time.Time) (apiv1.Events, error)
 }
 
 func (m *mockComponent) Name() string {
@@ -850,6 +905,9 @@ func (m *mockComponent) Name() string {
 }
 
 func (m *mockComponent) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
+	if m.eventFunc != nil {
+		return m.eventFunc(ctx, since)
+	}
 	if m.shouldError {
 		return nil, errors.New("mock component error")
 	}

--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,12 +27,14 @@ import (
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	pkgmetrics "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics"
+	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/attestation"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
 )
 
 func TestCollector_AttestationDataCollection(t *testing.T) {
@@ -479,6 +482,120 @@ func TestCollector_CollectMachineInfo_NoNVML(t *testing.T) {
 	assert.Nil(t, data.MachineInfo, "MachineInfo should be nil without NVML")
 }
 
+func TestCollector_CollectMachineInfoHangDoesNotBlockOtherData(t *testing.T) {
+	originalGetMachineInfo := getMachineInfo
+	defer func() { getMachineInfo = originalGetMachineInfo }()
+
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	getMachineInfo = func(nvmlInstance nvidianvml.Instance, opts ...machineinfo.MachineInfoOption) (*machineinfo.MachineInfo, error) {
+		started <- struct{}{}
+		<-release
+		return &machineinfo.MachineInfo{MachineID: "machine-info-id"}, nil
+	}
+
+	cfg := &config.HealthExporterConfig{
+		IncludeMachineInfo: true,
+		IncludeMetrics:     true,
+		IncludeEvents:      true,
+		MetricsLookback:    metav1.Duration{Duration: 5 * time.Minute},
+		EventsLookback:     metav1.Duration{Duration: 5 * time.Minute},
+	}
+
+	mockStore := &mockMetricsStore{
+		metrics: pkgmetrics.Metrics{
+			{Component: "gpu", Name: "temperature", Value: 75.0},
+		},
+	}
+	mockComp := &mockComponent{
+		name: "test-component",
+		events: []apiv1.Event{
+			{
+				Time:      metav1.Time{Time: time.Now()},
+				Component: "test-component",
+				Name:      "test-event",
+				Type:      apiv1.EventTypeWarning,
+				Message:   "Test warning",
+			},
+		},
+	}
+	mockRegistry := &mockRegistry{components: []components.Component{mockComp}}
+
+	collector := New(cfg, nil, nil, mockStore, &mockEventStore{}, mockRegistry, nvidianvml.NewNoOp(), nil, "test-machine-id", nil)
+
+	done := make(chan struct{})
+	var (
+		data *HealthData
+		err  error
+	)
+	go func() {
+		data, err = collector.Collect(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("machine info collection did not start")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("collection blocked on machine info")
+	}
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	assert.Nil(t, data.MachineInfo, "MachineInfo should be absent while background refresh is still running")
+	assert.Len(t, data.Metrics, 1, "metrics collection should still complete")
+	assert.Len(t, data.Events, 1, "event collection should still complete")
+
+	close(release)
+}
+
+func TestCollector_CollectMachineInfoUsesCachedRefreshResult(t *testing.T) {
+	originalGetMachineInfo := getMachineInfo
+	defer func() { getMachineInfo = originalGetMachineInfo }()
+
+	var callCount atomic.Int32
+	refreshed := make(chan struct{}, 1)
+	getMachineInfo = func(nvmlInstance nvidianvml.Instance, opts ...machineinfo.MachineInfoOption) (*machineinfo.MachineInfo, error) {
+		callCount.Add(1)
+		info := &machineinfo.MachineInfo{
+			MachineID:               "machine-info-id",
+			FleetintVersion:         "test-version",
+			ContainerRuntimeVersion: "containerd://1.0.0",
+		}
+		refreshed <- struct{}{}
+		return info, nil
+	}
+
+	cfg := &config.HealthExporterConfig{
+		IncludeMachineInfo: true,
+	}
+
+	collector := New(cfg, nil, nil, nil, nil, nil, nvidianvml.NewNoOp(), nil, "test-machine-id", nil)
+
+	data1, err := collector.Collect(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, data1)
+	assert.Nil(t, data1.MachineInfo, "first collection should not block waiting for machine info refresh")
+
+	select {
+	case <-refreshed:
+	case <-time.After(time.Second):
+		t.Fatal("machine info refresh did not complete")
+	}
+
+	data2, err := collector.Collect(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, data2)
+	require.NotNil(t, data2.MachineInfo)
+	assert.Equal(t, "machine-info-id", data2.MachineInfo.MachineID)
+	assert.EqualValues(t, 1, callCount.Load())
+}
+
 func TestCollector_CollectMetrics_NoStore(t *testing.T) {
 	ctx := context.Background()
 	cfg := &config.HealthExporterConfig{
@@ -765,6 +882,54 @@ func TestCollector_CollectComponentData_NoHealthStates(t *testing.T) {
 	assert.Equal(t, "No health data", compData["reason"])
 }
 
+func TestCollectReturnsPartialDataWhenComponentDataCollectionTimesOut(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	registry := &mockRegistry{
+		components: []components.Component{
+			&mockComponent{
+				name: "cpu",
+				healthStates: []apiv1.HealthState{
+					{
+						Component: "cpu",
+						Health:    "Healthy",
+						Reason:    "OK",
+						Time:      metav1.NewTime(time.Now().UTC()),
+					},
+				},
+			},
+			&cancelingHealthStateComponent{
+				name:   "memory",
+				cancel: cancel,
+			},
+		},
+	}
+
+	c := New(
+		&config.HealthExporterConfig{
+			IncludeComponentData: true,
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+		registry,
+		nil,
+		nil,
+		"test-machine-id",
+		nil,
+	)
+
+	data, err := c.Collect(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotNil(t, data)
+	require.Len(t, data.ComponentData, 1)
+
+	compData := data.ComponentData["cpu"].(map[string]interface{})
+	assert.Equal(t, "cpu", compData["component_name"])
+	assert.Equal(t, "Healthy", compData["health"])
+}
+
 func TestCollector_AllFeaturesEnabled(t *testing.T) {
 	ctx := context.Background()
 	cfg := &config.HealthExporterConfig{
@@ -942,3 +1107,39 @@ func (m *mockComponent) IsSupported() bool {
 func (m *mockComponent) Tags() []string {
 	return []string{}
 }
+
+type cancelingHealthStateComponent struct {
+	name   string
+	cancel context.CancelFunc
+}
+
+func (c *cancelingHealthStateComponent) Name() string { return c.name }
+
+func (c *cancelingHealthStateComponent) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
+	return nil, nil
+}
+
+func (c *cancelingHealthStateComponent) LastHealthStates() apiv1.HealthStates {
+	c.cancel()
+	return nil
+}
+
+func (c *cancelingHealthStateComponent) Start() error { return nil }
+
+func (c *cancelingHealthStateComponent) Stop(ctx context.Context) error { return nil }
+
+func (c *cancelingHealthStateComponent) States(ctx context.Context) ([]any, error) {
+	return nil, nil
+}
+
+func (c *cancelingHealthStateComponent) Metrics(ctx context.Context, since time.Time) ([]pkgmetrics.Metric, error) {
+	return nil, nil
+}
+
+func (c *cancelingHealthStateComponent) Check() components.CheckResult { return nil }
+
+func (c *cancelingHealthStateComponent) Close() error { return nil }
+
+func (c *cancelingHealthStateComponent) IsSupported() bool { return true }
+
+func (c *cancelingHealthStateComponent) Tags() []string { return nil }

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -24,6 +24,7 @@ package exporter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -173,26 +174,35 @@ func (e *healthExporter) ExportNow(ctx context.Context) error {
 // export performs the actual data export operation
 func (e *healthExporter) export() error {
 	log.Logger.Infow("Starting health export")
-	ctx, cancel := context.WithTimeout(e.ctx, e.options.timeout)
-	defer cancel()
+	collectCtx, cancelCollect := context.WithTimeout(e.ctx, e.options.timeout)
+	defer cancelCollect()
 
 	// Refresh configuration from metadata on every export
 	// If the endpoints/auth token are not empty, export will continue
 	// If the endpoints/auth token are empty, exportHTTP will skip
-	e.refreshConfigFromMetadata(ctx)
+	e.refreshConfigFromMetadata(collectCtx)
 
 	// Collect health data
-	healthData, err := e.collector.Collect(ctx)
-	if err != nil {
+	healthData, err := e.collector.Collect(collectCtx)
+	if err != nil && healthData == nil {
 		return fmt.Errorf("collection failed: %w", err)
+	}
+	if err != nil {
+		log.Logger.Warnw("Collection completed with partial data",
+			"error", err,
+			"timed_out", errors.Is(err, context.DeadlineExceeded),
+			"canceled", errors.Is(err, context.Canceled))
 	}
 
 	// Export data based on mode
 	if e.options.config.OfflineMode {
 		return e.exportToFile(healthData)
-	} else {
-		return e.exportToHTTP(ctx, healthData)
 	}
+
+	uploadCtx, cancelUpload := context.WithTimeout(e.ctx, e.options.timeout)
+	defer cancelUpload()
+
+	return e.exportToHTTP(uploadCtx, healthData)
 }
 
 // exportToFile writes health data to files

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -174,6 +174,9 @@ func (e *healthExporter) ExportNow(ctx context.Context) error {
 // export performs the actual data export operation
 func (e *healthExporter) export() error {
 	log.Logger.Infow("Starting health export")
+
+	// Collection and upload get independent timeout budgets so partial collection
+	// does not immediately starve the subsequent HTTP send.
 	collectCtx, cancelCollect := context.WithTimeout(e.ctx, e.options.timeout)
 	defer cancelCollect()
 

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/exporter/collector"
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/exporter/writer"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
 )
 
@@ -57,6 +58,16 @@ func (m *MockCollector) Collect(ctx context.Context) (*collector.HealthData, err
 	}
 	return args.Get(0).(*collector.HealthData), args.Error(1)
 }
+
+type mockHTTPWriter struct {
+	sendFunc func(ctx context.Context, data *collector.HealthData, metricsEndpoint string, logsEndpoint string, maxRetries int, authToken string) (string, error)
+}
+
+func (m *mockHTTPWriter) Send(ctx context.Context, data *collector.HealthData, metricsEndpoint string, logsEndpoint string, maxRetries int, authToken string) (string, error) {
+	return m.sendFunc(ctx, data, metricsEndpoint, logsEndpoint, maxRetries, authToken)
+}
+
+func (m *mockHTTPWriter) SetJWTRefreshFunc(refreshFunc writer.JWTRefreshFunc) {}
 
 // MockMetricsStore is a mock implementation of pkgmetrics.Store
 type MockMetricsStore struct {
@@ -1111,6 +1122,53 @@ func TestExportWithCollectorError(t *testing.T) {
 	assert.Contains(t, err.Error(), "collection failed")
 
 	// Cleanup
+	err = exporter.Stop()
+	require.NoError(t, err)
+}
+
+func TestExportUsesFreshUploadContextAfterPartialCollection(t *testing.T) {
+	cfg := &config.HealthExporterConfig{
+		Interval:        metav1.Duration{Duration: 1 * time.Minute},
+		Timeout:         metav1.Duration{Duration: 20 * time.Millisecond},
+		MetricsEndpoint: "https://metrics.example.com",
+		LogsEndpoint:    "https://logs.example.com",
+		AuthToken:       "test-token",
+	}
+
+	ctx := context.Background()
+	exporter, err := New(ctx, WithConfig(cfg), WithMachineID("test-machine-id"))
+	require.NoError(t, err)
+
+	he := exporter.(*healthExporter)
+	healthData := &collector.HealthData{
+		CollectionID: "test-collection",
+		MachineID:    "test-machine-id",
+		Timestamp:    time.Now(),
+	}
+
+	mockCollector := &MockCollector{}
+	mockCollector.
+		On("Collect", mock.Anything).
+		Run(func(args mock.Arguments) {
+			<-args.Get(0).(context.Context).Done()
+		}).
+		Return(healthData, context.DeadlineExceeded)
+	he.collector = mockCollector
+
+	sendCalled := false
+	he.httpWriter = &mockHTTPWriter{
+		sendFunc: func(ctx context.Context, data *collector.HealthData, metricsEndpoint string, logsEndpoint string, maxRetries int, authToken string) (string, error) {
+			sendCalled = true
+			assert.NoError(t, ctx.Err(), "upload should use a fresh context")
+			assert.Equal(t, healthData, data)
+			return "", nil
+		},
+	}
+
+	err = he.export()
+	require.NoError(t, err)
+	assert.True(t, sendCalled, "upload should still run with partial collection data")
+
 	err = exporter.Stop()
 	require.NoError(t, err)
 }

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -1126,6 +1126,42 @@ func TestExportWithCollectorError(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestExportDoesNotAttemptUploadWhenCollectionReturnsNoData(t *testing.T) {
+	cfg := &config.HealthExporterConfig{
+		Interval:        metav1.Duration{Duration: 1 * time.Minute},
+		Timeout:         metav1.Duration{Duration: 30 * time.Second},
+		MetricsEndpoint: "https://metrics.example.com",
+		LogsEndpoint:    "https://logs.example.com",
+		AuthToken:       "test-token",
+	}
+
+	ctx := context.Background()
+	exporter, err := New(ctx, WithConfig(cfg), WithMachineID("test-machine-id"))
+	require.NoError(t, err)
+
+	he := exporter.(*healthExporter)
+
+	mockCollector := &MockCollector{}
+	mockCollector.On("Collect", mock.Anything).Return(nil, errors.New("collection failed"))
+	he.collector = mockCollector
+
+	sendCalled := false
+	he.httpWriter = &mockHTTPWriter{
+		sendFunc: func(ctx context.Context, data *collector.HealthData, metricsEndpoint string, logsEndpoint string, maxRetries int, authToken string) (string, error) {
+			sendCalled = true
+			return "", nil
+		},
+	}
+
+	err = he.export()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collection failed")
+	assert.False(t, sendCalled, "upload should not run when collection returns no data")
+
+	err = exporter.Stop()
+	require.NoError(t, err)
+}
+
 func TestExportUsesFreshUploadContextAfterPartialCollection(t *testing.T) {
 	cfg := &config.HealthExporterConfig{
 		Interval:        metav1.Duration{Duration: 1 * time.Minute},


### PR DESCRIPTION
## Summary
Fix exporter timeout handling so a stalled collection phase does not force HTTP upload to inherit an expired context.

## What Changed
- split exporter collection and upload into separate timeout-scoped contexts
- stop collector work promptly when cancellation or deadline expiry is observed
- preserve partial event data collected before cancellation
- add regression tests for partial collection and fresh upload context behavior

## Root Cause
The exporter previously used one shared timeout for metadata refresh, collection, and upload. When GPU-facing collection work stalled, the shared context expired and the later event-read and HTTP-upload phases inherited a dead context, causing cascading `context deadline exceeded` failures.

## Impact
The agent now degrades more cleanly under driver/NVML stalls: partial collection can still be uploaded, and cancellation no longer produces misleading per-phase timeout cascades.

## Validation
- `go test ./internal/exporter/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collection now returns partial health data when components time out or are canceled, and preserves accumulated events/component data on early return.
  * Machine info refresh runs asynchronously and uses a cached result so metrics/events aren’t blocked by slow machine-info reads.
  * Upload uses a fresh timeout and is skipped when collection returns no data, avoiding unnecessary uploads.

* **Tests**
  * Added tests covering partial returns, machine-info caching/refresh behavior, and upload context handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->