### PR TITLE
fix: harden startup and export under slow DCGM and machine info

### DIFF
--- a/internal/exporter/collector/collector.go
+++ b/internal/exporter/collector/collector.go
@@ -185,7 +185,7 @@ func (c *collector) collectMachineInfo(ctx context.Context, data *HealthData) {
 	}
 
 	if _, ok := c.machineInfoProvider.Get(); !ok {
-		c.machineInfoProvider.WaitForInitialRefresh(initialMachineInfoWait)
+		c.machineInfoProvider.WaitForInitialRefresh(ctx, initialMachineInfoWait)
 	}
 
 	if machineInfo, ok := c.machineInfoProvider.Get(); ok {

--- a/internal/exporter/collector/collector.go
+++ b/internal/exporter/collector/collector.go
@@ -35,6 +35,8 @@ import (
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
 )
 
+const initialMachineInfoWait = 5 * time.Second
+
 // GenerateCollectionID generates a unique identifier for a data collection cycle
 func GenerateCollectionID() string {
 	bytes := make([]byte, 16)
@@ -72,6 +74,7 @@ type collector struct {
 	lastAttestationCollection time.Time
 	machineID                 string            // Agent's stable identity from server initialization
 	dcgmGPUIndexes            map[string]string // UUID → DCGM device ID override for GPU indices
+	machineInfoProvider       machineInfoProvider
 }
 
 // New creates a new health data collector
@@ -94,16 +97,27 @@ func New(
 		log.Logger.Infow("Config entries computed at startup", "entries_count", len(configEntries))
 	}
 
+	var provider machineInfoProvider
+	if cfg != nil && cfg.IncludeMachineInfo && nvmlInstance != nil {
+		var opts []machineinfo.MachineInfoOption
+		if len(dcgmGPUIndexes) > 0 {
+			opts = append(opts, machineinfo.WithDCGMGPUIndexes(dcgmGPUIndexes))
+		}
+		provider = newCachedMachineInfoProvider(nvmlInstance, 0, opts...)
+		provider.RefreshAsync(context.Background())
+	}
+
 	return &collector{
-		config:             cfg,
-		configEntries:      configEntries,
-		metricsStore:       metricsStore,
-		eventStore:         eventStore,
-		componentsRegistry: componentsRegistry,
-		nvmlInstance:       nvmlInstance,
-		attestationManager: attestationManager,
-		machineID:          machineID,
-		dcgmGPUIndexes:     dcgmGPUIndexes,
+		config:              cfg,
+		configEntries:       configEntries,
+		metricsStore:        metricsStore,
+		eventStore:          eventStore,
+		componentsRegistry:  componentsRegistry,
+		nvmlInstance:        nvmlInstance,
+		attestationManager:  attestationManager,
+		machineID:           machineID,
+		dcgmGPUIndexes:      dcgmGPUIndexes,
+		machineInfoProvider: provider,
 	}
 }
 
@@ -126,9 +140,7 @@ func (c *collector) Collect(ctx context.Context) (*HealthData, error) {
 
 	// Collect machine info if enabled
 	if c.config.IncludeMachineInfo {
-		if err := c.collectMachineInfo(data); err != nil {
-			log.Logger.Errorw("Failed to collect machine info", "error", err)
-		}
+		c.collectMachineInfo(ctx, data)
 	}
 
 	// Collect metrics if enabled
@@ -166,25 +178,21 @@ func (c *collector) Collect(ctx context.Context) (*HealthData, error) {
 	return data, nil
 }
 
-// collectMachineInfo collects machine hardware information
-func (c *collector) collectMachineInfo(data *HealthData) error {
-	if c.nvmlInstance == nil {
-		return fmt.Errorf("NVML instance not available")
+// collectMachineInfo reads cached machine info and triggers a best-effort refresh.
+func (c *collector) collectMachineInfo(ctx context.Context, data *HealthData) {
+	if c.machineInfoProvider == nil {
+		return
 	}
 
-	var opts []machineinfo.MachineInfoOption
-	if len(c.dcgmGPUIndexes) > 0 {
-		opts = append(opts, machineinfo.WithDCGMGPUIndexes(c.dcgmGPUIndexes))
+	if _, ok := c.machineInfoProvider.Get(); !ok {
+		c.machineInfoProvider.WaitForInitialRefresh(initialMachineInfoWait)
 	}
 
-	machineInfo, err := machineinfo.GetMachineInfo(c.nvmlInstance, opts...)
-	if err != nil {
-		return fmt.Errorf("failed to get machine info: %w", err)
+	if machineInfo, ok := c.machineInfoProvider.Get(); ok {
+		data.MachineInfo = machineInfo
 	}
 
-	data.MachineInfo = machineInfo
-	log.Logger.Debugw("Collected machine info", "machine_info", data.MachineInfo)
-	return nil
+	c.machineInfoProvider.RefreshAsync(ctx)
 }
 
 // collectMetrics collects metrics data from the metrics store

--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -560,6 +560,28 @@ func TestCollector_CollectMachineInfo_InitialWaitDoesNotRepeatAfterTimeout(t *te
 	assert.Less(t, secondElapsed, 200*time.Millisecond)
 }
 
+func TestCollector_CollectMachineInfo_InitialWaitHonorsContextCancellation(t *testing.T) {
+	cfg := &config.HealthExporterConfig{
+		IncludeMachineInfo: true,
+	}
+
+	c := New(cfg, nil, nil, nil, nil, nil, nil, nil, "test-machine-id", nil).(*collector)
+	provider := newMockMachineInfoProvider()
+	provider.refreshFn = func(parent context.Context) {}
+	c.machineInfoProvider = provider
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	data, err := c.Collect(ctx)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	assert.Less(t, elapsed, 200*time.Millisecond)
+}
+
 func TestCollector_CollectMachineInfo_RetainsLastGoodOnRefreshFailure(t *testing.T) {
 	ctx := context.Background()
 	cfg := &config.HealthExporterConfig{
@@ -623,7 +645,7 @@ func TestCachedMachineInfoProvider_WaitForInitialRefreshReturnsAfterCompletion(t
 	}()
 
 	start := time.Now()
-	provider.WaitForInitialRefresh(time.Second)
+	provider.WaitForInitialRefresh(context.Background(), time.Second)
 	elapsed := time.Since(start)
 
 	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond)
@@ -634,7 +656,7 @@ func TestCachedMachineInfoProvider_WaitForInitialRefreshTimesOut(t *testing.T) {
 	provider := newCachedMachineInfoProvider(nvidianvml.NewNoOp(), time.Minute).(*cachedMachineInfoProvider)
 
 	start := time.Now()
-	provider.WaitForInitialRefresh(100 * time.Millisecond)
+	provider.WaitForInitialRefresh(context.Background(), 100*time.Millisecond)
 	elapsed := time.Since(start)
 
 	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond)
@@ -1038,7 +1060,7 @@ func (m *mockMachineInfoProvider) RefreshAsync(parent context.Context) {
 	}()
 }
 
-func (m *mockMachineInfoProvider) WaitForInitialRefresh(maxWait time.Duration) bool {
+func (m *mockMachineInfoProvider) WaitForInitialRefresh(ctx context.Context, maxWait time.Duration) bool {
 	if maxWait <= 0 {
 		return false
 	}
@@ -1057,6 +1079,8 @@ func (m *mockMachineInfoProvider) WaitForInitialRefresh(maxWait time.Duration) b
 	select {
 	case <-m.initialRefreshDone:
 		return true
+	case <-ctx.Done():
+		return false
 	case <-timer.C:
 		return false
 	}

--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -531,6 +531,35 @@ func TestCollector_CollectMachineInfo_InitialWaitDoesNotRepeatAfterFirstRefresh(
 	assert.Less(t, elapsed, 200*time.Millisecond)
 }
 
+func TestCollector_CollectMachineInfo_InitialWaitDoesNotRepeatAfterTimeout(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.HealthExporterConfig{
+		IncludeMachineInfo: true,
+	}
+
+	c := New(cfg, nil, nil, nil, nil, nil, nil, nil, "test-machine-id", nil).(*collector)
+	provider := newMockMachineInfoProvider()
+	provider.refreshFn = func(parent context.Context) {}
+	c.machineInfoProvider = provider
+
+	start := time.Now()
+	data, err := c.Collect(ctx)
+	firstElapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	assert.GreaterOrEqual(t, firstElapsed, 4900*time.Millisecond)
+	assert.Less(t, firstElapsed, 5500*time.Millisecond)
+
+	start = time.Now()
+	data, err = c.Collect(ctx)
+	secondElapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	assert.Less(t, secondElapsed, 200*time.Millisecond)
+}
+
 func TestCollector_CollectMachineInfo_RetainsLastGoodOnRefreshFailure(t *testing.T) {
 	ctx := context.Background()
 	cfg := &config.HealthExporterConfig{
@@ -971,9 +1000,11 @@ type mockMetricsStore struct {
 }
 
 type mockMachineInfoProvider struct {
+	mu                 sync.RWMutex
 	cached             *machineinfo.MachineInfo
 	refreshFn          func(context.Context)
 	refreshCalls       atomic.Int32
+	initialWaited      bool
 	initialRefreshDone chan struct{}
 	initialRefreshOnce sync.Once
 }
@@ -985,6 +1016,9 @@ func newMockMachineInfoProvider() *mockMachineInfoProvider {
 }
 
 func (m *mockMachineInfoProvider) Get() (*machineinfo.MachineInfo, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	if m.cached == nil {
 		return nil, false
 	}
@@ -1004,21 +1038,33 @@ func (m *mockMachineInfoProvider) RefreshAsync(parent context.Context) {
 	}()
 }
 
-func (m *mockMachineInfoProvider) WaitForInitialRefresh(maxWait time.Duration) {
+func (m *mockMachineInfoProvider) WaitForInitialRefresh(maxWait time.Duration) bool {
 	if maxWait <= 0 {
-		return
+		return false
 	}
+
+	m.mu.Lock()
+	if m.initialWaited {
+		m.mu.Unlock()
+		return false
+	}
+	m.initialWaited = true
+	m.mu.Unlock()
 
 	timer := time.NewTimer(maxWait)
 	defer timer.Stop()
 
 	select {
 	case <-m.initialRefreshDone:
+		return true
 	case <-timer.C:
+		return false
 	}
 }
 
 func (m *mockMachineInfoProvider) setCached(info *machineinfo.MachineInfo) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.cached = info
 }
 

--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,12 +28,14 @@ import (
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	pkgmetrics "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics"
+	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/attestation"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
 )
 
 func TestCollector_AttestationDataCollection(t *testing.T) {
@@ -425,6 +429,189 @@ func TestCollector_CollectMachineInfo_NoNVML(t *testing.T) {
 	assert.Nil(t, data.MachineInfo, "MachineInfo should be nil without NVML")
 }
 
+func TestCollector_CollectMachineInfo_UsesCachedValue(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.HealthExporterConfig{
+		IncludeMachineInfo: true,
+	}
+
+	c := New(cfg, nil, nil, nil, nil, nil, nil, nil, "test-machine-id", nil).(*collector)
+	expected := &machineinfo.MachineInfo{Hostname: "cached-host"}
+	provider := &mockMachineInfoProvider{
+		cached: expected,
+	}
+	c.machineInfoProvider = provider
+
+	data, err := c.Collect(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.NotNil(t, data.MachineInfo)
+	assert.Equal(t, expected, data.MachineInfo)
+	assert.Equal(t, int32(1), provider.refreshCalls.Load())
+}
+
+func TestCollector_CollectMachineInfo_WaitsBrieflyForInitialRefresh(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.HealthExporterConfig{
+		IncludeMachineInfo: true,
+	}
+
+	c := New(cfg, nil, nil, nil, nil, nil, nil, nil, "test-machine-id", nil).(*collector)
+	provider := newMockMachineInfoProvider()
+	c.machineInfoProvider = provider
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		provider.setCached(&machineinfo.MachineInfo{Hostname: "prewarmed-host"})
+		provider.markInitialRefreshDone()
+	}()
+
+	data, err := c.Collect(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.NotNil(t, data.MachineInfo)
+	assert.Equal(t, "prewarmed-host", data.MachineInfo.Hostname)
+}
+
+func TestCollector_CollectMachineInfo_RefreshDoesNotBlockMetrics(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.HealthExporterConfig{
+		IncludeMachineInfo: true,
+		IncludeMetrics:     true,
+		MetricsLookback:    metav1.Duration{Duration: 5 * time.Minute},
+	}
+
+	c := New(cfg, nil, nil, &mockMetricsStore{
+		metrics: pkgmetrics.Metrics{
+			{Component: "gpu", Name: "temperature", Value: 70, UnixMilliseconds: time.Now().UnixMilli()},
+		},
+	}, nil, nil, nil, nil, "test-machine-id", nil).(*collector)
+
+	blocker := make(chan struct{})
+	provider := newMockMachineInfoProvider()
+	provider.refreshFn = func(parent context.Context) {
+		provider.markInitialRefreshDone()
+		<-blocker
+	}
+	c.machineInfoProvider = provider
+
+	start := time.Now()
+	data, err := c.Collect(ctx)
+	elapsed := time.Since(start)
+	close(blocker)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	assert.Len(t, data.Metrics, 1)
+	assert.Nil(t, data.MachineInfo)
+	assert.GreaterOrEqual(t, elapsed, 4900*time.Millisecond)
+	assert.Less(t, elapsed, 5500*time.Millisecond)
+}
+
+func TestCollector_CollectMachineInfo_InitialWaitDoesNotRepeatAfterFirstRefresh(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.HealthExporterConfig{
+		IncludeMachineInfo: true,
+	}
+
+	c := New(cfg, nil, nil, nil, nil, nil, nil, nil, "test-machine-id", nil).(*collector)
+	provider := newMockMachineInfoProvider()
+	provider.markInitialRefreshDone()
+	provider.refreshFn = func(parent context.Context) {}
+	c.machineInfoProvider = provider
+
+	start := time.Now()
+	data, err := c.Collect(ctx)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	assert.Less(t, elapsed, 200*time.Millisecond)
+}
+
+func TestCollector_CollectMachineInfo_RetainsLastGoodOnRefreshFailure(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.HealthExporterConfig{
+		IncludeMachineInfo: true,
+	}
+
+	c := New(cfg, nil, nil, nil, nil, nil, nil, nil, "test-machine-id", nil).(*collector)
+	expected := &machineinfo.MachineInfo{Hostname: "last-good"}
+	provider := newMockMachineInfoProvider()
+	provider.cached = expected
+	provider.initialRefreshOnce.Do(func() { close(provider.initialRefreshDone) })
+	provider.refreshFn = func(parent context.Context) {}
+	c.machineInfoProvider = provider
+
+	data, err := c.Collect(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	assert.Equal(t, expected, data.MachineInfo)
+}
+
+func TestCachedMachineInfoProvider_DeduplicatesConcurrentRefresh(t *testing.T) {
+	originalGetMachineInfo := getMachineInfo
+	defer func() {
+		getMachineInfo = originalGetMachineInfo
+	}()
+
+	var calls atomic.Int32
+	blocker := make(chan struct{})
+	getMachineInfo = func(nvmlInstance nvidianvml.Instance, opts ...machineinfo.MachineInfoOption) (*machineinfo.MachineInfo, error) {
+		calls.Add(1)
+		<-blocker
+		return &machineinfo.MachineInfo{Hostname: "refreshed"}, nil
+	}
+
+	provider := newCachedMachineInfoProvider(nvidianvml.NewNoOp(), time.Minute).(*cachedMachineInfoProvider)
+	ctx := context.Background()
+
+	for range 3 {
+		provider.RefreshAsync(ctx)
+	}
+
+	require.Eventually(t, func() bool {
+		return calls.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	close(blocker)
+
+	require.Eventually(t, func() bool {
+		info, ok := provider.Get()
+		return ok && info.Hostname == "refreshed"
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestCachedMachineInfoProvider_WaitForInitialRefreshReturnsAfterCompletion(t *testing.T) {
+	provider := newCachedMachineInfoProvider(nvidianvml.NewNoOp(), time.Minute).(*cachedMachineInfoProvider)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		provider.markInitialRefreshDone()
+	}()
+
+	start := time.Now()
+	provider.WaitForInitialRefresh(time.Second)
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond)
+	assert.Less(t, elapsed, 300*time.Millisecond)
+}
+
+func TestCachedMachineInfoProvider_WaitForInitialRefreshTimesOut(t *testing.T) {
+	provider := newCachedMachineInfoProvider(nvidianvml.NewNoOp(), time.Minute).(*cachedMachineInfoProvider)
+
+	start := time.Now()
+	provider.WaitForInitialRefresh(100 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond)
+	assert.Less(t, elapsed, 300*time.Millisecond)
+}
+
 func TestCollector_CollectMetrics_NoStore(t *testing.T) {
 	ctx := context.Background()
 	cfg := &config.HealthExporterConfig{
@@ -781,6 +968,64 @@ func TestCollector_AllFeaturesEnabled(t *testing.T) {
 type mockMetricsStore struct {
 	metrics     pkgmetrics.Metrics
 	shouldError bool
+}
+
+type mockMachineInfoProvider struct {
+	cached             *machineinfo.MachineInfo
+	refreshFn          func(context.Context)
+	refreshCalls       atomic.Int32
+	initialRefreshDone chan struct{}
+	initialRefreshOnce sync.Once
+}
+
+func newMockMachineInfoProvider() *mockMachineInfoProvider {
+	return &mockMachineInfoProvider{
+		initialRefreshDone: make(chan struct{}),
+	}
+}
+
+func (m *mockMachineInfoProvider) Get() (*machineinfo.MachineInfo, bool) {
+	if m.cached == nil {
+		return nil, false
+	}
+	return m.cached, true
+}
+
+func (m *mockMachineInfoProvider) RefreshAsync(parent context.Context) {
+	m.refreshCalls.Add(1)
+	if m.refreshFn == nil {
+		return
+	}
+	go func() {
+		defer func() {
+			_ = recover()
+		}()
+		m.refreshFn(parent)
+	}()
+}
+
+func (m *mockMachineInfoProvider) WaitForInitialRefresh(maxWait time.Duration) {
+	if maxWait <= 0 {
+		return
+	}
+
+	timer := time.NewTimer(maxWait)
+	defer timer.Stop()
+
+	select {
+	case <-m.initialRefreshDone:
+	case <-timer.C:
+	}
+}
+
+func (m *mockMachineInfoProvider) setCached(info *machineinfo.MachineInfo) {
+	m.cached = info
+}
+
+func (m *mockMachineInfoProvider) markInitialRefreshDone() {
+	m.initialRefreshOnce.Do(func() {
+		close(m.initialRefreshDone)
+	})
 }
 
 func (m *mockMetricsStore) Read(ctx context.Context, opts ...pkgmetrics.OpOption) (pkgmetrics.Metrics, error) {

--- a/internal/exporter/collector/machine_info_provider.go
+++ b/internal/exporter/collector/machine_info_provider.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
+	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
+
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
+)
+
+const (
+	defaultMachineInfoStaleAfter = 5 * time.Minute
+)
+
+var getMachineInfo = machineinfo.GetMachineInfo
+
+type machineInfoProvider interface {
+	Get() (*machineinfo.MachineInfo, bool)
+	RefreshAsync(parent context.Context)
+	WaitForInitialRefresh(maxWait time.Duration)
+}
+
+type cachedMachineInfoProvider struct {
+	nvmlInstance nvidianvml.Instance
+	opts         []machineinfo.MachineInfoOption
+	staleAfter   time.Duration
+
+	mu                 sync.RWMutex
+	cached             *machineinfo.MachineInfo
+	lastUpdate         time.Time
+	refreshing         bool
+	initialRefreshDone chan struct{}
+	initialRefreshOnce sync.Once
+}
+
+func newCachedMachineInfoProvider(
+	nvmlInstance nvidianvml.Instance,
+	staleAfter time.Duration,
+	opts ...machineinfo.MachineInfoOption,
+) machineInfoProvider {
+	if staleAfter <= 0 {
+		staleAfter = defaultMachineInfoStaleAfter
+	}
+
+	return &cachedMachineInfoProvider{
+		nvmlInstance:       nvmlInstance,
+		opts:               opts,
+		staleAfter:         staleAfter,
+		initialRefreshDone: make(chan struct{}),
+	}
+}
+
+func (p *cachedMachineInfoProvider) Get() (*machineinfo.MachineInfo, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.cached == nil {
+		return nil, false
+	}
+
+	return p.cached, true
+}
+
+func (p *cachedMachineInfoProvider) RefreshAsync(parent context.Context) {
+	if p == nil || p.nvmlInstance == nil {
+		return
+	}
+
+	p.mu.Lock()
+	if p.refreshing || !p.shouldRefreshLocked() {
+		p.mu.Unlock()
+		return
+	}
+	p.refreshing = true
+	p.mu.Unlock()
+
+	go func() {
+		defer func() {
+			p.mu.Lock()
+			p.refreshing = false
+			p.mu.Unlock()
+			p.markInitialRefreshDone()
+		}()
+
+		info, err := getMachineInfo(p.nvmlInstance, p.opts...)
+		if err != nil {
+			log.Logger.Warnw("Machine info refresh failed", "error", err)
+			return
+		}
+
+		p.mu.Lock()
+		p.cached = info
+		p.lastUpdate = time.Now().UTC()
+		p.mu.Unlock()
+
+		log.Logger.Debugw("Refreshed machine info cache")
+	}()
+}
+
+func (p *cachedMachineInfoProvider) WaitForInitialRefresh(maxWait time.Duration) {
+	if p == nil || maxWait <= 0 {
+		return
+	}
+
+	timer := time.NewTimer(maxWait)
+	defer timer.Stop()
+
+	select {
+	case <-p.initialRefreshDone:
+	case <-timer.C:
+	}
+}
+
+func (p *cachedMachineInfoProvider) shouldRefreshLocked() bool {
+	if p.cached == nil {
+		return true
+	}
+	if p.lastUpdate.IsZero() {
+		return true
+	}
+	return time.Since(p.lastUpdate) >= p.staleAfter
+}
+
+func (p *cachedMachineInfoProvider) markInitialRefreshDone() {
+	p.initialRefreshOnce.Do(func() {
+		close(p.initialRefreshDone)
+	})
+}

--- a/internal/exporter/collector/machine_info_provider.go
+++ b/internal/exporter/collector/machine_info_provider.go
@@ -35,7 +35,7 @@ var getMachineInfo = machineinfo.GetMachineInfo
 type machineInfoProvider interface {
 	Get() (*machineinfo.MachineInfo, bool)
 	RefreshAsync(parent context.Context)
-	WaitForInitialRefresh(maxWait time.Duration)
+	WaitForInitialRefresh(maxWait time.Duration) bool
 }
 
 type cachedMachineInfoProvider struct {
@@ -47,6 +47,7 @@ type cachedMachineInfoProvider struct {
 	cached             *machineinfo.MachineInfo
 	lastUpdate         time.Time
 	refreshing         bool
+	initialWaited      bool
 	initialRefreshDone chan struct{}
 	initialRefreshOnce sync.Once
 }
@@ -115,17 +116,27 @@ func (p *cachedMachineInfoProvider) RefreshAsync(parent context.Context) {
 	}()
 }
 
-func (p *cachedMachineInfoProvider) WaitForInitialRefresh(maxWait time.Duration) {
+func (p *cachedMachineInfoProvider) WaitForInitialRefresh(maxWait time.Duration) bool {
 	if p == nil || maxWait <= 0 {
-		return
+		return false
 	}
+
+	p.mu.Lock()
+	if p.initialWaited {
+		p.mu.Unlock()
+		return false
+	}
+	p.initialWaited = true
+	p.mu.Unlock()
 
 	timer := time.NewTimer(maxWait)
 	defer timer.Stop()
 
 	select {
 	case <-p.initialRefreshDone:
+		return true
 	case <-timer.C:
+		return false
 	}
 }
 

--- a/internal/exporter/collector/machine_info_provider.go
+++ b/internal/exporter/collector/machine_info_provider.go
@@ -35,7 +35,7 @@ var getMachineInfo = machineinfo.GetMachineInfo
 type machineInfoProvider interface {
 	Get() (*machineinfo.MachineInfo, bool)
 	RefreshAsync(parent context.Context)
-	WaitForInitialRefresh(maxWait time.Duration) bool
+	WaitForInitialRefresh(ctx context.Context, maxWait time.Duration) bool
 }
 
 type cachedMachineInfoProvider struct {
@@ -116,7 +116,7 @@ func (p *cachedMachineInfoProvider) RefreshAsync(parent context.Context) {
 	}()
 }
 
-func (p *cachedMachineInfoProvider) WaitForInitialRefresh(maxWait time.Duration) bool {
+func (p *cachedMachineInfoProvider) WaitForInitialRefresh(ctx context.Context, maxWait time.Duration) bool {
 	if p == nil || maxWait <= 0 {
 		return false
 	}
@@ -135,6 +135,8 @@ func (p *cachedMachineInfoProvider) WaitForInitialRefresh(maxWait time.Duration)
 	select {
 	case <-p.initialRefreshDone:
 		return true
+	case <-ctx.Done():
+		return false
 	case <-timer.C:
 		return false
 	}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -173,16 +173,16 @@ func (e *healthExporter) ExportNow(ctx context.Context) error {
 // export performs the actual data export operation
 func (e *healthExporter) export() error {
 	log.Logger.Infow("Starting health export")
-	ctx, cancel := context.WithTimeout(e.ctx, e.options.timeout)
-	defer cancel()
+	collectionCtx, cancelCollection := context.WithTimeout(e.ctx, e.options.timeout)
+	defer cancelCollection()
 
 	// Refresh configuration from metadata on every export
 	// If the endpoints/auth token are not empty, export will continue
 	// If the endpoints/auth token are empty, exportHTTP will skip
-	e.refreshConfigFromMetadata(ctx)
+	e.refreshConfigFromMetadata(collectionCtx)
 
 	// Collect health data
-	healthData, err := e.collector.Collect(ctx)
+	healthData, err := e.collector.Collect(collectionCtx)
 	if err != nil {
 		return fmt.Errorf("collection failed: %w", err)
 	}
@@ -191,7 +191,9 @@ func (e *healthExporter) export() error {
 	if e.options.config.OfflineMode {
 		return e.exportToFile(healthData)
 	} else {
-		return e.exportToHTTP(ctx, healthData)
+		exportCtx, cancelExport := context.WithTimeout(e.ctx, e.options.timeout)
+		defer cancelExport()
+		return e.exportToHTTP(exportCtx, healthData)
 	}
 }
 

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/exporter/collector"
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/exporter/writer"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
 )
 
@@ -56,6 +57,19 @@ func (m *MockCollector) Collect(ctx context.Context) (*collector.HealthData, err
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*collector.HealthData), args.Error(1)
+}
+
+type MockHTTPWriter struct {
+	mock.Mock
+}
+
+func (m *MockHTTPWriter) Send(ctx context.Context, data *collector.HealthData, metricsEndpoint string, logsEndpoint string, maxRetries int, authToken string) (string, error) {
+	args := m.Called(ctx, data, metricsEndpoint, logsEndpoint, maxRetries, authToken)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockHTTPWriter) SetJWTRefreshFunc(refreshFunc writer.JWTRefreshFunc) {
+	m.Called(refreshFunc)
 }
 
 // MockMetricsStore is a mock implementation of pkgmetrics.Store
@@ -1111,6 +1125,57 @@ func TestExportWithCollectorError(t *testing.T) {
 	assert.Contains(t, err.Error(), "collection failed")
 
 	// Cleanup
+	err = exporter.Stop()
+	require.NoError(t, err)
+}
+
+func TestExportUsesSeparateContextsForCollectionAndHTTP(t *testing.T) {
+	cfg := &config.HealthExporterConfig{
+		Interval:        metav1.Duration{Duration: 1 * time.Minute},
+		Timeout:         metav1.Duration{Duration: 50 * time.Millisecond},
+		MetricsEndpoint: "https://metrics.example.com",
+		LogsEndpoint:    "https://logs.example.com",
+		AuthToken:       "test-token",
+	}
+
+	ctx := context.Background()
+	exporter, err := New(ctx, WithConfig(cfg), WithMachineID("test-machine-id"))
+	require.NoError(t, err)
+	require.NotNil(t, exporter)
+
+	he := exporter.(*healthExporter)
+
+	mockCollector := &MockCollector{}
+	mockCollector.
+		On("Collect", mock.Anything).
+		Run(func(args mock.Arguments) {
+			time.Sleep(75 * time.Millisecond)
+		}).
+		Return(&collector.HealthData{
+			CollectionID: "collection-1",
+			MachineID:    "test-machine-id",
+			Timestamp:    time.Now().UTC(),
+		}, nil)
+
+	mockHTTPWriter := &MockHTTPWriter{}
+	mockHTTPWriter.
+		On("Send", mock.Anything, mock.Anything, cfg.MetricsEndpoint, cfg.LogsEndpoint, cfg.RetryMaxAttempts, cfg.AuthToken).
+		Run(func(args mock.Arguments) {
+			sendCtx, ok := args.Get(0).(context.Context)
+			require.True(t, ok)
+			assert.NoError(t, sendCtx.Err(), "export should receive a fresh context even if collection overran its deadline")
+		}).
+		Return("", nil)
+
+	he.collector = mockCollector
+	he.httpWriter = mockHTTPWriter
+
+	err = he.export()
+	require.NoError(t, err)
+
+	mockCollector.AssertExpectations(t)
+	mockHTTPWriter.AssertExpectations(t)
+
 	err = exporter.Stop()
 	require.NoError(t, err)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -211,7 +211,9 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 	}
 
 	// Initialize DCGM instance
-	dcgmInstance, err := nvidiadcgm.New()
+	dcgmInitCtx, dcgmInitCancel := context.WithTimeout(ctx, time.Minute)
+	dcgmInstance, err := nvidiadcgm.NewWithContext(dcgmInitCtx)
+	dcgmInitCancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DCGM instance: %w", err)
 	}

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -16,6 +16,7 @@
 package dcgm
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -117,8 +118,47 @@ type Instance interface {
 	Shutdown() error
 }
 
+var newInstanceFunc = newInitializedInstance
+
 // New creates a DCGM instance. Returns no-op instance if DCGM is unavailable.
 func New() (Instance, error) {
+	return newInitializedInstance()
+}
+
+// NewWithContext creates a DCGM instance with a bounded wait. If initialization
+// exceeds the context deadline, it returns a no-op instance so callers can
+// continue startup without blocking on slow DCGM device enumeration.
+func NewWithContext(ctx context.Context) (Instance, error) {
+	type result struct {
+		inst Instance
+		err  error
+	}
+
+	resultCh := make(chan result, 1)
+	abandonCh := make(chan struct{})
+
+	go func() {
+		inst, err := newInstanceFunc()
+		select {
+		case resultCh <- result{inst: inst, err: err}:
+		case <-abandonCh:
+			if err == nil && inst != nil {
+				_ = inst.Shutdown()
+			}
+		}
+	}()
+
+	select {
+	case res := <-resultCh:
+		return res.inst, res.err
+	case <-ctx.Done():
+		close(abandonCh)
+		log.Logger.Warnw("DCGM initialization timed out, returning no-op instance", "error", ctx.Err())
+		return NewNoOp(), nil
+	}
+}
+
+func newInitializedInstance() (Instance, error) {
 	initParams := resolveInitFromEnv()
 
 	cleanup, err := dcgm.Init(dcgm.Standalone, initParams.address, initParams.isUnixSocket)

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
@@ -16,8 +16,11 @@
 package dcgm
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
 )
@@ -123,6 +126,55 @@ func TestInstanceWhenDCGMNotAvailable(t *testing.T) {
 	// Should be safe to call methods on the instance
 	_ = inst.DCGMExists()
 	_ = inst.Shutdown()
+}
+
+func TestNewWithContextReturnsNoOpOnTimeout(t *testing.T) {
+	originalNewInstanceFunc := newInstanceFunc
+	defer func() {
+		newInstanceFunc = originalNewInstanceFunc
+	}()
+
+	blocker := make(chan struct{})
+	newInstanceFunc = func() (Instance, error) {
+		<-blocker
+		return &instance{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	inst, err := NewWithContext(ctx)
+	if err != nil {
+		t.Fatalf("NewWithContext() returned error: %v", err)
+	}
+	if inst == nil {
+		t.Fatal("instance should not be nil")
+	}
+	if inst.DCGMExists() {
+		t.Fatalf("expected no-op instance after timeout")
+	}
+
+	close(blocker)
+}
+
+func TestNewWithContextReturnsUnderlyingError(t *testing.T) {
+	originalNewInstanceFunc := newInstanceFunc
+	defer func() {
+		newInstanceFunc = originalNewInstanceFunc
+	}()
+
+	expectedErr := errors.New("boom")
+	newInstanceFunc = func() (Instance, error) {
+		return nil, expectedErr
+	}
+
+	inst, err := NewWithContext(context.Background())
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected error %v, got %v", expectedErr, err)
+	}
+	if inst != nil {
+		t.Fatalf("expected nil instance on error")
+	}
 }
 
 func TestAddHealthWatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- prewarm machine info and wait up to 5 seconds on the first export before falling back to cached or empty machine info
- move machine info refresh behind a single-flight cache so later exports never block on slow NVML/DCGM-backed machine info collection
- separate collection and HTTP export timeout contexts so slow collection does not consume the send budget
- bound DCGM initialization during server startup to 1 minute and fall back to a no-op DCGM instance when startup enumeration is too slow

## Behavior Notes
- first export now makes a best effort to include machine info without waiting indefinitely
- later exports reuse cached machine info and refresh it in the background only when stale
- the initial machine-info wait is a one-time gate and now honors collection context cancellation
- one export cycle can now take up to roughly collection timeout plus export timeout because those budgets are separated intentionally
- if DCGM startup takes more than 1 minute, the server continues startup with a no-op DCGM instance and skips DCGM-backed checks instead of hanging

## Testing
- `go test ./...`
- `go test -race ./internal/exporter/collector`
- `go test github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm ./internal/server ./internal/exporter`

Related ticket: GPUHEALTH-1735