### PR TITLE
fix: detect gpu hardware before driver checks

### DIFF
--- a/internal/precheck/precheck.go
+++ b/internal/precheck/precheck.go
@@ -140,7 +140,7 @@ func Evaluate(input *Input) Result {
 		evaluateArchitecture(input),
 		evaluateDriver(input),
 		evaluateNVAttest(input.NVAttestPresent),
-		evaluateDCGM(*input),
+		evaluateDCGM(input),
 	}
 
 	return Result{Checks: checks}
@@ -301,7 +301,15 @@ func evaluateNVAttest(present *bool) Check {
 	}
 }
 
-func evaluateDCGM(input Input) Check {
+func evaluateDCGM(input *Input) Check {
+	if input == nil {
+		return Check{
+			Name:    "dcgm",
+			Passed:  true,
+			Message: "DCGM checks skipped",
+		}
+	}
+
 	if input.DCGMReachable == nil {
 		return Check{
 			Name:    "dcgm",

--- a/internal/precheck/precheck.go
+++ b/internal/precheck/precheck.go
@@ -50,6 +50,7 @@ type nvmlInstance = nvidianvml.Instance
 
 type Input struct {
 	GPUHardwarePresent bool
+	GPUHardwareErr     error
 	GPUInfo            *apiv1.MachineGPUInfo
 	GPUInfoErr         error
 	GPUDriverVersion   string
@@ -121,7 +122,7 @@ func CollectInput() (Input, error) {
 	}
 
 	if !input.GPUHardwarePresent {
-		input.GPUHardwarePresent = detectGPUHardware()
+		input.GPUHardwarePresent, input.GPUHardwareErr = detectGPUHardware()
 	}
 
 	nvattestPresent := detectNVAttest()
@@ -135,6 +136,10 @@ func CollectInput() (Input, error) {
 }
 
 func Evaluate(input *Input) Result {
+	if input == nil {
+		input = &Input{}
+	}
+
 	checks := []Check{
 		evaluateGPUPresence(input),
 		evaluateArchitecture(input),
@@ -147,6 +152,13 @@ func Evaluate(input *Input) Result {
 }
 
 func evaluateGPUPresence(input *Input) Check {
+	if input != nil && input.GPUHardwareErr != nil {
+		return Check{
+			Name:    "gpu-present",
+			Message: "Unable to determine NVIDIA GPU presence; verify lspci is installed and accessible, then retry",
+		}
+	}
+
 	if !gpuHardwareDetected(input) {
 		return Check{
 			Name:    "gpu-present",
@@ -263,16 +275,16 @@ func hasDetectedGPUInfo(info *apiv1.MachineGPUInfo) bool {
 	return info != nil && len(info.GPUs) > 0
 }
 
-func detectGPUHardware() bool {
+func detectGPUHardware() (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	devs, err := listPCIGPUs(ctx)
 	if err != nil {
-		return false
+		return false, err
 	}
 
-	return len(devs) > 0
+	return len(devs) > 0, nil
 }
 
 // evaluateNVAttest checks whether nvattest is present in PATH.

--- a/internal/precheck/precheck.go
+++ b/internal/precheck/precheck.go
@@ -17,13 +17,16 @@
 package precheck
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
+	nvidiapci "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia/pci"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/dcgmversion"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
@@ -39,15 +42,17 @@ var (
 	getMachineInfo    = machineinfo.GetMachineInfo
 	lookPath          = exec.LookPath
 	detectDCGMVersion = dcgmversion.DetectHostengineVersion
+	listPCIGPUs       = nvidiapci.ListPCIGPUs
 )
 
 type nvmlInstance = nvidianvml.Instance
 
 type Input struct {
-	MachineInfo     *machineinfo.MachineInfo
-	NVAttestPresent *bool
-	DCGMReachable   *bool
-	DCGMVersion     string
+	GPUHardwarePresent bool
+	MachineInfo        *machineinfo.MachineInfo
+	NVAttestPresent    *bool
+	DCGMReachable      *bool
+	DCGMVersion        string
 }
 
 type Check struct {
@@ -104,7 +109,12 @@ func CollectInput() (Input, error) {
 		info, machineInfoErr := getMachineInfo(nvmlInstance)
 		if machineInfoErr == nil {
 			input.MachineInfo = info
+			input.GPUHardwarePresent = hasDetectedGPU(info)
 		}
+	}
+
+	if !input.GPUHardwarePresent {
+		input.GPUHardwarePresent = detectGPUHardware()
 	}
 
 	nvattestPresent := detectNVAttest()
@@ -119,9 +129,9 @@ func CollectInput() (Input, error) {
 
 func Evaluate(input Input) Result {
 	checks := []Check{
-		evaluateGPUPresence(input.MachineInfo),
-		evaluateArchitecture(input.MachineInfo),
-		evaluateDriver(input.MachineInfo),
+		evaluateGPUPresence(input),
+		evaluateArchitecture(input),
+		evaluateDriver(input),
 		evaluateNVAttest(input.NVAttestPresent),
 		evaluateDCGM(input),
 	}
@@ -129,8 +139,8 @@ func Evaluate(input Input) Result {
 	return Result{Checks: checks}
 }
 
-func evaluateGPUPresence(info *machineinfo.MachineInfo) Check {
-	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
+func evaluateGPUPresence(input Input) Check {
+	if !gpuHardwareDetected(input) {
 		return Check{
 			Name:    "gpu-present",
 			Message: "no NVIDIA GPU detected",
@@ -144,12 +154,21 @@ func evaluateGPUPresence(info *machineinfo.MachineInfo) Check {
 	}
 }
 
-func evaluateArchitecture(info *machineinfo.MachineInfo) Check {
-	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
+func evaluateArchitecture(input Input) Check {
+	if !gpuHardwareDetected(input) {
 		return Check{
 			Name:    "gpu-architecture",
 			Passed:  true,
 			Message: "GPU architecture check skipped because no GPU was detected",
+		}
+	}
+
+	info := input.MachineInfo
+	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
+		return Check{
+			Name:    "gpu-architecture",
+			Passed:  true,
+			Message: "GPU architecture check skipped because NVIDIA driver is not detected",
 		}
 	}
 
@@ -176,12 +195,20 @@ func evaluateArchitecture(info *machineinfo.MachineInfo) Check {
 	}
 }
 
-func evaluateDriver(info *machineinfo.MachineInfo) Check {
-	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
+func evaluateDriver(input Input) Check {
+	if !gpuHardwareDetected(input) {
 		return Check{
 			Name:    "gpu-driver",
 			Passed:  true,
 			Message: "driver check skipped because no GPU was detected",
+		}
+	}
+
+	info := input.MachineInfo
+	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
+		return Check{
+			Name:    "gpu-driver",
+			Message: "NVIDIA driver not detected",
 		}
 	}
 
@@ -212,6 +239,30 @@ func evaluateDriver(info *machineinfo.MachineInfo) Check {
 		Passed:  true,
 		Message: "NVIDIA driver detected: " + info.GPUDriverVersion,
 	}
+}
+
+func gpuHardwareDetected(input Input) bool {
+	if input.GPUHardwarePresent {
+		return true
+	}
+
+	return hasDetectedGPU(input.MachineInfo)
+}
+
+func hasDetectedGPU(info *machineinfo.MachineInfo) bool {
+	return info != nil && info.GPUInfo != nil && len(info.GPUInfo.GPUs) > 0
+}
+
+func detectGPUHardware() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	devs, err := listPCIGPUs(ctx)
+	if err != nil {
+		return false
+	}
+
+	return len(devs) > 0
 }
 
 // evaluateNVAttest checks whether nvattest is present in PATH.

--- a/internal/precheck/precheck.go
+++ b/internal/precheck/precheck.go
@@ -143,7 +143,7 @@ func evaluateGPUPresence(input Input) Check {
 	if !gpuHardwareDetected(input) {
 		return Check{
 			Name:    "gpu-present",
-			Message: "no NVIDIA GPU detected",
+			Message: "No NVIDIA GPU detected; verify the node has an NVIDIA GPU installed and visible to the OS",
 		}
 	}
 
@@ -159,7 +159,7 @@ func evaluateArchitecture(input Input) Check {
 		return Check{
 			Name:    "gpu-architecture",
 			Passed:  true,
-			Message: "GPU architecture check skipped because no GPU was detected",
+			Message: "GPU architecture check skipped because no NVIDIA GPU was detected",
 		}
 	}
 
@@ -168,14 +168,14 @@ func evaluateArchitecture(input Input) Check {
 		return Check{
 			Name:    "gpu-architecture",
 			Passed:  true,
-			Message: "GPU architecture check skipped because NVIDIA driver is not detected",
+			Message: "GPU architecture check skipped because the NVIDIA driver is not available",
 		}
 	}
 
 	if info.GPUInfo.Architecture == "" {
 		return Check{
 			Name:    "gpu-architecture",
-			Message: "GPU architecture is unknown",
+			Message: "GPU detected, but its architecture could not be determined; verify the NVIDIA driver is installed and loaded",
 		}
 	}
 
@@ -184,7 +184,7 @@ func evaluateArchitecture(input Input) Check {
 	}) {
 		return Check{
 			Name:    "gpu-architecture",
-			Message: "unsupported GPU architecture: " + info.GPUInfo.Architecture,
+			Message: "Unsupported GPU architecture: " + info.GPUInfo.Architecture + "; supported architectures are Hopper, Blackwell, and Rubin",
 		}
 	}
 
@@ -200,7 +200,7 @@ func evaluateDriver(input Input) Check {
 		return Check{
 			Name:    "gpu-driver",
 			Passed:  true,
-			Message: "driver check skipped because no GPU was detected",
+			Message: "NVIDIA driver check skipped because no NVIDIA GPU was detected",
 		}
 	}
 
@@ -208,14 +208,14 @@ func evaluateDriver(input Input) Check {
 	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
 		return Check{
 			Name:    "gpu-driver",
-			Message: "NVIDIA driver not detected",
+			Message: "NVIDIA GPU detected via PCI, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry",
 		}
 	}
 
 	if info.GPUDriverVersion == "" {
 		return Check{
 			Name:    "gpu-driver",
-			Message: "NVIDIA driver not detected",
+			Message: "NVIDIA GPU hardware is present, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry",
 		}
 	}
 
@@ -230,7 +230,7 @@ func evaluateDriver(input Input) Check {
 	if driverMajor < minimumDriverMajorVersion {
 		return Check{
 			Name:    "gpu-driver",
-			Message: fmt.Sprintf("NVIDIA driver major version %d is below required minimum %d", driverMajor, minimumDriverMajorVersion),
+			Message: fmt.Sprintf("NVIDIA driver version %s is below the required minimum %d; upgrade the driver and retry", info.GPUDriverVersion, minimumDriverMajorVersion),
 		}
 	}
 
@@ -280,7 +280,7 @@ func evaluateNVAttest(present *bool) Check {
 	if !*present {
 		return Check{
 			Name:    "nvattest",
-			Message: "nvattest not found in PATH",
+			Message: "nvattest was not found in PATH; install nvattest and ensure it is available in PATH",
 		}
 	}
 
@@ -303,14 +303,14 @@ func evaluateDCGM(input Input) Check {
 	if !*input.DCGMReachable {
 		return Check{
 			Name:    "dcgm",
-			Message: "DCGM HostEngine is not reachable",
+			Message: "DCGM HostEngine is not reachable; verify DCGM is running and DCGM_URL is configured correctly",
 		}
 	}
 
 	if input.DCGMVersion == "" {
 		return Check{
 			Name:    "dcgm",
-			Message: "DCGM HostEngine version could not be determined",
+			Message: "DCGM HostEngine is reachable, but its version could not be determined; verify the DCGM installation",
 		}
 	}
 
@@ -325,7 +325,7 @@ func evaluateDCGM(input Input) Check {
 	if !versionOK {
 		return Check{
 			Name:    "dcgm",
-			Message: "DCGM HostEngine version " + input.DCGMVersion + " is below required minimum " + minimumDCGMVersion,
+			Message: "DCGM HostEngine version " + input.DCGMVersion + " is below the required minimum " + minimumDCGMVersion + "; upgrade DCGM and retry",
 		}
 	}
 

--- a/internal/precheck/precheck.go
+++ b/internal/precheck/precheck.go
@@ -25,11 +25,12 @@ import (
 	"strings"
 	"time"
 
+	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
+	pkgmachineinfo "github.com/NVIDIA/fleet-intelligence-sdk/pkg/machine-info"
 	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
 	nvidiapci "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia/pci"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/dcgmversion"
-	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
 )
 
 var supportedArchitectures = []string{"Hopper", "Blackwell", "Rubin"}
@@ -39,7 +40,7 @@ const minimumDriverMajorVersion = 510
 
 var (
 	newNVML           = nvidianvml.New
-	getMachineInfo    = machineinfo.GetMachineInfo
+	getMachineGPUInfo = pkgmachineinfo.GetMachineGPUInfo
 	lookPath          = exec.LookPath
 	detectDCGMVersion = dcgmversion.DetectHostengineVersion
 	listPCIGPUs       = nvidiapci.ListPCIGPUs
@@ -49,7 +50,9 @@ type nvmlInstance = nvidianvml.Instance
 
 type Input struct {
 	GPUHardwarePresent bool
-	MachineInfo        *machineinfo.MachineInfo
+	GPUInfo            *apiv1.MachineGPUInfo
+	GPUInfoErr         error
+	GPUDriverVersion   string
 	NVAttestPresent    *bool
 	DCGMReachable      *bool
 	DCGMVersion        string
@@ -106,10 +109,14 @@ func CollectInput() (Input, error) {
 	if err == nil {
 		defer func() { _ = nvmlInstance.Shutdown() }()
 
-		info, machineInfoErr := getMachineInfo(nvmlInstance)
-		if machineInfoErr == nil {
-			input.MachineInfo = info
-			input.GPUHardwarePresent = hasDetectedGPU(info)
+		input.GPUDriverVersion = nvmlInstance.DriverVersion()
+
+		gpuInfo, gpuInfoErr := getMachineGPUInfo(nvmlInstance)
+		if gpuInfoErr == nil {
+			input.GPUInfo = gpuInfo
+			input.GPUHardwarePresent = hasDetectedGPUInfo(gpuInfo)
+		} else {
+			input.GPUInfoErr = gpuInfoErr
 		}
 	}
 
@@ -163,8 +170,7 @@ func evaluateArchitecture(input Input) Check {
 		}
 	}
 
-	info := input.MachineInfo
-	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
+	if input.GPUDriverVersion == "" {
 		return Check{
 			Name:    "gpu-architecture",
 			Passed:  true,
@@ -172,7 +178,15 @@ func evaluateArchitecture(input Input) Check {
 		}
 	}
 
-	if info.GPUInfo.Architecture == "" {
+	if input.GPUInfo == nil || len(input.GPUInfo.GPUs) == 0 {
+		return Check{
+			Name:    "gpu-architecture",
+			Passed:  true,
+			Message: "GPU architecture check skipped because GPU details could not be collected; check agent logs and retry",
+		}
+	}
+
+	if input.GPUInfo.Architecture == "" {
 		return Check{
 			Name:    "gpu-architecture",
 			Message: "GPU detected, but its architecture could not be determined; verify the NVIDIA driver is installed and loaded",
@@ -180,18 +194,18 @@ func evaluateArchitecture(input Input) Check {
 	}
 
 	if !slices.ContainsFunc(supportedArchitectures, func(s string) bool {
-		return strings.EqualFold(s, info.GPUInfo.Architecture)
+		return strings.EqualFold(s, input.GPUInfo.Architecture)
 	}) {
 		return Check{
 			Name:    "gpu-architecture",
-			Message: "Unsupported GPU architecture: " + info.GPUInfo.Architecture + "; supported architectures are Hopper, Blackwell, and Rubin",
+			Message: "Unsupported GPU architecture: " + input.GPUInfo.Architecture + "; supported architectures are Hopper, Blackwell, and Rubin",
 		}
 	}
 
 	return Check{
 		Name:    "gpu-architecture",
 		Passed:  true,
-		Message: "supported GPU architecture detected: " + info.GPUInfo.Architecture,
+		Message: "supported GPU architecture detected: " + input.GPUInfo.Architecture,
 	}
 }
 
@@ -204,22 +218,14 @@ func evaluateDriver(input Input) Check {
 		}
 	}
 
-	info := input.MachineInfo
-	if info == nil || info.GPUInfo == nil || len(info.GPUInfo.GPUs) == 0 {
-		return Check{
-			Name:    "gpu-driver",
-			Message: "NVIDIA GPU detected via PCI, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry",
-		}
-	}
-
-	if info.GPUDriverVersion == "" {
+	if input.GPUDriverVersion == "" {
 		return Check{
 			Name:    "gpu-driver",
 			Message: "NVIDIA GPU hardware is present, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry",
 		}
 	}
 
-	driverMajor, _, _, err := nvidianvml.ParseDriverVersion(info.GPUDriverVersion)
+	driverMajor, _, _, err := nvidianvml.ParseDriverVersion(input.GPUDriverVersion)
 	if err != nil {
 		return Check{
 			Name:    "gpu-driver",
@@ -230,14 +236,14 @@ func evaluateDriver(input Input) Check {
 	if driverMajor < minimumDriverMajorVersion {
 		return Check{
 			Name:    "gpu-driver",
-			Message: fmt.Sprintf("NVIDIA driver version %s is below the required minimum %d; upgrade the driver and retry", info.GPUDriverVersion, minimumDriverMajorVersion),
+			Message: fmt.Sprintf("NVIDIA driver version %s is below the required minimum %d; upgrade the driver and retry", input.GPUDriverVersion, minimumDriverMajorVersion),
 		}
 	}
 
 	return Check{
 		Name:    "gpu-driver",
 		Passed:  true,
-		Message: "NVIDIA driver detected: " + info.GPUDriverVersion,
+		Message: "NVIDIA driver detected: " + input.GPUDriverVersion,
 	}
 }
 
@@ -246,11 +252,11 @@ func gpuHardwareDetected(input Input) bool {
 		return true
 	}
 
-	return hasDetectedGPU(input.MachineInfo)
+	return hasDetectedGPUInfo(input.GPUInfo)
 }
 
-func hasDetectedGPU(info *machineinfo.MachineInfo) bool {
-	return info != nil && info.GPUInfo != nil && len(info.GPUInfo.GPUs) > 0
+func hasDetectedGPUInfo(info *apiv1.MachineGPUInfo) bool {
+	return info != nil && len(info.GPUs) > 0
 }
 
 func detectGPUHardware() bool {

--- a/internal/precheck/precheck.go
+++ b/internal/precheck/precheck.go
@@ -99,7 +99,7 @@ func Run() (Result, error) {
 		return Result{}, err
 	}
 
-	return Evaluate(input), nil
+	return Evaluate(&input), nil
 }
 
 func CollectInput() (Input, error) {
@@ -134,19 +134,19 @@ func CollectInput() (Input, error) {
 	return input, nil
 }
 
-func Evaluate(input Input) Result {
+func Evaluate(input *Input) Result {
 	checks := []Check{
 		evaluateGPUPresence(input),
 		evaluateArchitecture(input),
 		evaluateDriver(input),
 		evaluateNVAttest(input.NVAttestPresent),
-		evaluateDCGM(input),
+		evaluateDCGM(*input),
 	}
 
 	return Result{Checks: checks}
 }
 
-func evaluateGPUPresence(input Input) Check {
+func evaluateGPUPresence(input *Input) Check {
 	if !gpuHardwareDetected(input) {
 		return Check{
 			Name:    "gpu-present",
@@ -161,7 +161,7 @@ func evaluateGPUPresence(input Input) Check {
 	}
 }
 
-func evaluateArchitecture(input Input) Check {
+func evaluateArchitecture(input *Input) Check {
 	if !gpuHardwareDetected(input) {
 		return Check{
 			Name:    "gpu-architecture",
@@ -170,7 +170,7 @@ func evaluateArchitecture(input Input) Check {
 		}
 	}
 
-	if input.GPUDriverVersion == "" {
+	if input == nil || input.GPUDriverVersion == "" {
 		return Check{
 			Name:    "gpu-architecture",
 			Passed:  true,
@@ -209,7 +209,7 @@ func evaluateArchitecture(input Input) Check {
 	}
 }
 
-func evaluateDriver(input Input) Check {
+func evaluateDriver(input *Input) Check {
 	if !gpuHardwareDetected(input) {
 		return Check{
 			Name:    "gpu-driver",
@@ -218,7 +218,7 @@ func evaluateDriver(input Input) Check {
 		}
 	}
 
-	if input.GPUDriverVersion == "" {
+	if input == nil || input.GPUDriverVersion == "" {
 		return Check{
 			Name:    "gpu-driver",
 			Message: "NVIDIA GPU hardware is present, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry",
@@ -247,7 +247,11 @@ func evaluateDriver(input Input) Check {
 	}
 }
 
-func gpuHardwareDetected(input Input) bool {
+func gpuHardwareDetected(input *Input) bool {
+	if input == nil {
+		return false
+	}
+
 	if input.GPUHardwarePresent {
 		return true
 	}

--- a/internal/precheck/precheck_test.go
+++ b/internal/precheck/precheck_test.go
@@ -105,7 +105,7 @@ func TestEvaluateArchitecture(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := Evaluate(tt.input)
+			result := Evaluate(&tt.input)
 
 			assert.Equal(t, tt.wantPassed, result.Passed())
 			for _, wantMessage := range tt.wantMessages {
@@ -203,7 +203,7 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := Evaluate(tt.input)
+			result := Evaluate(&tt.input)
 
 			assert.Equal(t, tt.wantPassed, result.Passed())
 			for _, wantMessage := range tt.wantMessages {
@@ -216,7 +216,7 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 func TestEvaluateDetectsHardwareWithoutDriver(t *testing.T) {
 	t.Parallel()
 
-	result := Evaluate(Input{
+	result := Evaluate(&Input{
 		GPUHardwarePresent: true,
 		NVAttestPresent:    boolPtr(true),
 	})
@@ -230,7 +230,7 @@ func TestEvaluateDetectsHardwareWithoutDriver(t *testing.T) {
 func TestEvaluateSkipsArchitectureWhenGPUDetailsFail(t *testing.T) {
 	t.Parallel()
 
-	result := Evaluate(Input{
+	result := Evaluate(&Input{
 		GPUHardwarePresent: true,
 		GPUDriverVersion:   "575.57.08",
 		GPUInfoErr:         fmt.Errorf("gpu info failed"),
@@ -245,7 +245,7 @@ func TestEvaluateSkipsArchitectureWhenGPUDetailsFail(t *testing.T) {
 func TestEvaluateAggregatesFailures(t *testing.T) {
 	t.Parallel()
 
-	result := Evaluate(Input{
+	result := Evaluate(&Input{
 		GPUInfo:          gpuInfo("Ampere"),
 		GPUDriverVersion: "",
 		NVAttestPresent:  boolPtr(false),
@@ -322,7 +322,7 @@ func TestEvaluateDCGM(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := Evaluate(tt.input)
+			result := Evaluate(&tt.input)
 
 			assert.Equal(t, tt.wantPassed, result.Passed())
 			for _, wantMessage := range tt.wantMessages {
@@ -335,7 +335,7 @@ func TestEvaluateDCGM(t *testing.T) {
 func TestEvaluateDCGMSkipsWhenReachabilityUnset(t *testing.T) {
 	t.Parallel()
 
-	result := Evaluate(Input{
+	result := Evaluate(&Input{
 		GPUInfo:          gpuInfo("Hopper"),
 		GPUDriverVersion: "575.57.08",
 		NVAttestPresent:  boolPtr(true),

--- a/internal/precheck/precheck_test.go
+++ b/internal/precheck/precheck_test.go
@@ -227,6 +227,17 @@ func TestEvaluateDetectsHardwareWithoutDriver(t *testing.T) {
 	assert.Contains(t, checkMessages(result.Checks), "NVIDIA GPU hardware is present, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry")
 }
 
+func TestEvaluateNilInput(t *testing.T) {
+	t.Parallel()
+
+	result := Evaluate(nil)
+
+	assert.False(t, result.Passed())
+	assert.Contains(t, checkMessages(result.Checks), "No NVIDIA GPU detected; verify the node has an NVIDIA GPU installed and visible to the OS")
+	assert.Contains(t, checkMessages(result.Checks), "nvattest check skipped")
+	assert.Contains(t, checkMessages(result.Checks), "DCGM checks skipped")
+}
+
 func TestEvaluateSkipsArchitectureWhenGPUDetailsFail(t *testing.T) {
 	t.Parallel()
 
@@ -240,6 +251,19 @@ func TestEvaluateSkipsArchitectureWhenGPUDetailsFail(t *testing.T) {
 	assert.True(t, findCheck(t, result.Checks, "gpu-present").Passed)
 	assert.True(t, findCheck(t, result.Checks, "gpu-driver").Passed)
 	assert.Contains(t, checkMessages(result.Checks), "GPU architecture check skipped because GPU details could not be collected; check agent logs and retry")
+}
+
+func TestEvaluateReportsGPUProbeFailure(t *testing.T) {
+	t.Parallel()
+
+	result := Evaluate(&Input{
+		GPUHardwareErr:  fmt.Errorf("lspci unavailable"),
+		NVAttestPresent: boolPtr(true),
+	})
+
+	assert.False(t, result.Passed())
+	assert.Contains(t, checkMessages(result.Checks), "Unable to determine NVIDIA GPU presence; verify lspci is installed and accessible, then retry")
+	assert.Contains(t, checkMessages(result.Checks), "NVIDIA driver check skipped because no NVIDIA GPU was detected")
 }
 
 func TestEvaluateAggregatesFailures(t *testing.T) {
@@ -384,6 +408,41 @@ func TestCollectInputCallsDCGMInit(t *testing.T) {
 	assert.True(t, *input.DCGMReachable)
 	assert.Equal(t, "4.2.3", input.DCGMVersion)
 	assert.True(t, detectDCGMCalled)
+}
+
+func TestCollectInputPreservesGPUProbeError(t *testing.T) {
+	t.Parallel()
+
+	originalNewNVML := newNVML
+	originalLookPath := lookPath
+	originalDetectDCGMVersion := detectDCGMVersion
+	originalListPCIGPUs := listPCIGPUs
+	t.Cleanup(func() {
+		newNVML = originalNewNVML
+		lookPath = originalLookPath
+		detectDCGMVersion = originalDetectDCGMVersion
+		listPCIGPUs = originalListPCIGPUs
+	})
+
+	newNVML = func() (nvmlInstance, error) {
+		return nil, fmt.Errorf("skip nvml in test")
+	}
+	lookPath = func(file string) (string, error) {
+		return "/usr/bin/" + file, nil
+	}
+	detectDCGMVersion = func() (string, error) {
+		return "4.2.3", nil
+	}
+	listPCIGPUs = func(_ context.Context) ([]string, error) {
+		return nil, fmt.Errorf("lspci unavailable")
+	}
+
+	input, err := CollectInput()
+
+	require.NoError(t, err)
+	assert.False(t, input.GPUHardwarePresent)
+	require.Error(t, input.GPUHardwareErr)
+	assert.Contains(t, input.GPUHardwareErr.Error(), "lspci unavailable")
 }
 
 func gpuInfo(architecture string) *apiv1.MachineGPUInfo {

--- a/internal/precheck/precheck_test.go
+++ b/internal/precheck/precheck_test.go
@@ -16,6 +16,7 @@
 package precheck
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -202,6 +203,20 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 	}
 }
 
+func TestEvaluateDetectsHardwareWithoutDriver(t *testing.T) {
+	t.Parallel()
+
+	result := Evaluate(Input{
+		GPUHardwarePresent: true,
+		NVAttestPresent:    boolPtr(true),
+	})
+
+	assert.False(t, result.Passed())
+	assert.Contains(t, checkMessages(result.Checks), "NVIDIA GPU detected")
+	assert.Contains(t, checkMessages(result.Checks), "GPU architecture check skipped because NVIDIA driver is not detected")
+	assert.Contains(t, checkMessages(result.Checks), "NVIDIA driver not detected")
+}
+
 func TestEvaluateAggregatesFailures(t *testing.T) {
 	t.Parallel()
 
@@ -305,10 +320,12 @@ func TestCollectInputCallsDCGMInit(t *testing.T) {
 	originalNewNVML := newNVML
 	originalLookPath := lookPath
 	originalDetectDCGMVersion := detectDCGMVersion
+	originalListPCIGPUs := listPCIGPUs
 	t.Cleanup(func() {
 		newNVML = originalNewNVML
 		lookPath = originalLookPath
 		detectDCGMVersion = originalDetectDCGMVersion
+		listPCIGPUs = originalListPCIGPUs
 	})
 
 	newNVML = func() (nvmlInstance, error) {
@@ -324,9 +341,14 @@ func TestCollectInputCallsDCGMInit(t *testing.T) {
 		return "4.2.3", nil
 	}
 
+	listPCIGPUs = func(_ context.Context) ([]string, error) {
+		return []string{"0000:00:00.0 3D controller: NVIDIA Corporation Test GPU [10de:ffff]"}, nil
+	}
+
 	input, err := CollectInput()
 
 	require.NoError(t, err)
+	assert.True(t, input.GPUHardwarePresent)
 	require.NotNil(t, input.DCGMReachable)
 	assert.True(t, *input.DCGMReachable)
 	assert.Equal(t, "4.2.3", input.DCGMVersion)

--- a/internal/precheck/precheck_test.go
+++ b/internal/precheck/precheck_test.go
@@ -23,8 +23,6 @@ import (
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
 )
 
 func TestEvaluateArchitecture(t *testing.T) {
@@ -39,28 +37,31 @@ func TestEvaluateArchitecture(t *testing.T) {
 		{
 			name: "passes for hopper",
 			input: Input{
-				MachineInfo: machineInfoWithGPU("Hopper", "575.57.08"),
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "575.57.08",
 			},
 			wantPassed: true,
 		},
 		{
 			name: "passes for blackwell",
 			input: Input{
-				MachineInfo: machineInfoWithGPU("Blackwell", "575.57.08"),
+				GPUInfo:          gpuInfo("Blackwell"),
+				GPUDriverVersion: "575.57.08",
 			},
 			wantPassed: true,
 		},
 		{
 			name: "passes for rubin",
 			input: Input{
-				MachineInfo: machineInfoWithGPU("Rubin", "575.57.08"),
+				GPUInfo:          gpuInfo("Rubin"),
+				GPUDriverVersion: "575.57.08",
 			},
 			wantPassed: true,
 		},
 		{
 			name: "fails for missing gpu",
 			input: Input{
-				MachineInfo: &machineinfo.MachineInfo{},
+				GPUInfo: &apiv1.MachineGPUInfo{},
 			},
 			wantPassed: false,
 			wantMessages: []string{
@@ -70,14 +71,16 @@ func TestEvaluateArchitecture(t *testing.T) {
 		{
 			name: "passes for hopper lowercase",
 			input: Input{
-				MachineInfo: machineInfoWithGPU("hopper", "575.57.08"),
+				GPUInfo:          gpuInfo("hopper"),
+				GPUDriverVersion: "575.57.08",
 			},
 			wantPassed: true,
 		},
 		{
 			name: "fails for unsupported architecture",
 			input: Input{
-				MachineInfo: machineInfoWithGPU("Ampere", "575.57.08"),
+				GPUInfo:          gpuInfo("Ampere"),
+				GPUDriverVersion: "575.57.08",
 			},
 			wantPassed: false,
 			wantMessages: []string{
@@ -87,7 +90,8 @@ func TestEvaluateArchitecture(t *testing.T) {
 		{
 			name: "fails for empty architecture",
 			input: Input{
-				MachineInfo: machineInfoWithGPU("", "575.57.08"),
+				GPUInfo:          gpuInfo(""),
+				GPUDriverVersion: "575.57.08",
 			},
 			wantPassed: false,
 			wantMessages: []string{
@@ -129,8 +133,9 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 		{
 			name: "fails for missing driver",
 			input: Input{
-				MachineInfo:     machineInfoWithGPU("Hopper", ""),
-				NVAttestPresent: boolPtr(true),
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "",
+				NVAttestPresent:  boolPtr(true),
 			},
 			wantPassed: false,
 			wantMessages: []string{
@@ -140,8 +145,9 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 		{
 			name: "fails for malformed driver version",
 			input: Input{
-				MachineInfo:     machineInfoWithGPU("Hopper", "not-a-version"),
-				NVAttestPresent: boolPtr(true),
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "not-a-version",
+				NVAttestPresent:  boolPtr(true),
 			},
 			wantPassed: false,
 			wantMessages: []string{
@@ -151,8 +157,9 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 		{
 			name: "fails for driver below minimum major version",
 			input: Input{
-				MachineInfo:     machineInfoWithGPU("Hopper", "509.12.01"),
-				NVAttestPresent: boolPtr(true),
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "509.12.01",
+				NVAttestPresent:  boolPtr(true),
 			},
 			wantPassed: false,
 			wantMessages: []string{
@@ -162,8 +169,9 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 		{
 			name: "fails for missing nvattest",
 			input: Input{
-				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
-				NVAttestPresent: boolPtr(false),
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "575.57.08",
+				NVAttestPresent:  boolPtr(false),
 			},
 			wantPassed: false,
 			wantMessages: []string{
@@ -173,16 +181,18 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 		{
 			name: "passes when driver major is at minimum and nvattest is present",
 			input: Input{
-				MachineInfo:     machineInfoWithGPU("Hopper", "510.47.03"),
-				NVAttestPresent: boolPtr(true),
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "510.47.03",
+				NVAttestPresent:  boolPtr(true),
 			},
 			wantPassed: true,
 		},
 		{
 			name: "passes when newer driver and nvattest are present",
 			input: Input{
-				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
-				NVAttestPresent: boolPtr(true),
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "575.57.08",
+				NVAttestPresent:  boolPtr(true),
 			},
 			wantPassed: true,
 		},
@@ -214,19 +224,35 @@ func TestEvaluateDetectsHardwareWithoutDriver(t *testing.T) {
 	assert.False(t, result.Passed())
 	assert.Contains(t, checkMessages(result.Checks), "NVIDIA GPU detected")
 	assert.Contains(t, checkMessages(result.Checks), "GPU architecture check skipped because the NVIDIA driver is not available")
-	assert.Contains(t, checkMessages(result.Checks), "NVIDIA GPU detected via PCI, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry")
+	assert.Contains(t, checkMessages(result.Checks), "NVIDIA GPU hardware is present, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry")
+}
+
+func TestEvaluateSkipsArchitectureWhenGPUDetailsFail(t *testing.T) {
+	t.Parallel()
+
+	result := Evaluate(Input{
+		GPUHardwarePresent: true,
+		GPUDriverVersion:   "575.57.08",
+		GPUInfoErr:         fmt.Errorf("gpu info failed"),
+		NVAttestPresent:    boolPtr(true),
+	})
+
+	assert.True(t, findCheck(t, result.Checks, "gpu-present").Passed)
+	assert.True(t, findCheck(t, result.Checks, "gpu-driver").Passed)
+	assert.Contains(t, checkMessages(result.Checks), "GPU architecture check skipped because GPU details could not be collected; check agent logs and retry")
 }
 
 func TestEvaluateAggregatesFailures(t *testing.T) {
 	t.Parallel()
 
 	result := Evaluate(Input{
-		MachineInfo:     machineInfoWithGPU("Ampere", ""),
-		NVAttestPresent: boolPtr(false),
+		GPUInfo:          gpuInfo("Ampere"),
+		GPUDriverVersion: "",
+		NVAttestPresent:  boolPtr(false),
 	})
 
 	assert.False(t, result.Passed())
-	assert.Contains(t, checkMessages(result.Checks), "Unsupported GPU architecture: Ampere; supported architectures are Hopper, Blackwell, and Rubin")
+	assert.Contains(t, checkMessages(result.Checks), "GPU architecture check skipped because the NVIDIA driver is not available")
 	assert.Contains(t, checkMessages(result.Checks), "NVIDIA GPU hardware is present, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry")
 	assert.Contains(t, checkMessages(result.Checks), "nvattest was not found in PATH; install nvattest and ensure it is available in PATH")
 }
@@ -243,9 +269,10 @@ func TestEvaluateDCGM(t *testing.T) {
 		{
 			name: "fails when dcgm is unreachable",
 			input: Input{
-				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
-				NVAttestPresent: boolPtr(true),
-				DCGMReachable:   boolPtr(false),
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "575.57.08",
+				NVAttestPresent:  boolPtr(true),
+				DCGMReachable:    boolPtr(false),
 			},
 			wantPassed: false,
 			wantMessages: []string{
@@ -255,10 +282,11 @@ func TestEvaluateDCGM(t *testing.T) {
 		{
 			name: "fails when dcgm version is too old",
 			input: Input{
-				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
-				NVAttestPresent: boolPtr(true),
-				DCGMReachable:   boolPtr(true),
-				DCGMVersion:     "4.2.2",
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "575.57.08",
+				NVAttestPresent:  boolPtr(true),
+				DCGMReachable:    boolPtr(true),
+				DCGMVersion:      "4.2.2",
 			},
 			wantPassed: false,
 			wantMessages: []string{
@@ -268,20 +296,22 @@ func TestEvaluateDCGM(t *testing.T) {
 		{
 			name: "passes for minimum supported dcgm version",
 			input: Input{
-				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
-				NVAttestPresent: boolPtr(true),
-				DCGMReachable:   boolPtr(true),
-				DCGMVersion:     "4.2.3",
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "575.57.08",
+				NVAttestPresent:  boolPtr(true),
+				DCGMReachable:    boolPtr(true),
+				DCGMVersion:      "4.2.3",
 			},
 			wantPassed: true,
 		},
 		{
 			name: "passes for newer dcgm version",
 			input: Input{
-				MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
-				NVAttestPresent: boolPtr(true),
-				DCGMReachable:   boolPtr(true),
-				DCGMVersion:     "4.3.0",
+				GPUInfo:          gpuInfo("Hopper"),
+				GPUDriverVersion: "575.57.08",
+				NVAttestPresent:  boolPtr(true),
+				DCGMReachable:    boolPtr(true),
+				DCGMVersion:      "4.3.0",
 			},
 			wantPassed: true,
 		},
@@ -306,8 +336,9 @@ func TestEvaluateDCGMSkipsWhenReachabilityUnset(t *testing.T) {
 	t.Parallel()
 
 	result := Evaluate(Input{
-		MachineInfo:     machineInfoWithGPU("Hopper", "575.57.08"),
-		NVAttestPresent: boolPtr(true),
+		GPUInfo:          gpuInfo("Hopper"),
+		GPUDriverVersion: "575.57.08",
+		NVAttestPresent:  boolPtr(true),
 	})
 
 	assert.True(t, result.Passed())
@@ -355,17 +386,27 @@ func TestCollectInputCallsDCGMInit(t *testing.T) {
 	assert.True(t, detectDCGMCalled)
 }
 
-func machineInfoWithGPU(architecture, driverVersion string) *machineinfo.MachineInfo {
-	return &machineinfo.MachineInfo{
-		GPUDriverVersion: driverVersion,
-		GPUInfo: &apiv1.MachineGPUInfo{
-			Architecture: architecture,
-			Product:      "test-gpu",
-			GPUs: []apiv1.MachineGPUInstance{
-				{UUID: "GPU-1"},
-			},
+func gpuInfo(architecture string) *apiv1.MachineGPUInfo {
+	return &apiv1.MachineGPUInfo{
+		Architecture: architecture,
+		Product:      "test-gpu",
+		GPUs: []apiv1.MachineGPUInstance{
+			{UUID: "GPU-1"},
 		},
 	}
+}
+
+func findCheck(t *testing.T, checks []Check, name string) Check {
+	t.Helper()
+
+	for _, check := range checks {
+		if check.Name == name {
+			return check
+		}
+	}
+
+	t.Fatalf("check %q not found", name)
+	return Check{}
 }
 
 func checkMessages(checks []Check) []string {

--- a/internal/precheck/precheck_test.go
+++ b/internal/precheck/precheck_test.go
@@ -64,7 +64,7 @@ func TestEvaluateArchitecture(t *testing.T) {
 			},
 			wantPassed: false,
 			wantMessages: []string{
-				"no NVIDIA GPU detected",
+				"No NVIDIA GPU detected; verify the node has an NVIDIA GPU installed and visible to the OS",
 			},
 		},
 		{
@@ -81,7 +81,7 @@ func TestEvaluateArchitecture(t *testing.T) {
 			},
 			wantPassed: false,
 			wantMessages: []string{
-				"unsupported GPU architecture: Ampere",
+				"Unsupported GPU architecture: Ampere; supported architectures are Hopper, Blackwell, and Rubin",
 			},
 		},
 		{
@@ -91,7 +91,7 @@ func TestEvaluateArchitecture(t *testing.T) {
 			},
 			wantPassed: false,
 			wantMessages: []string{
-				"GPU architecture is unknown",
+				"GPU detected, but its architecture could not be determined; verify the NVIDIA driver is installed and loaded",
 			},
 		},
 	}
@@ -134,7 +134,7 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 			},
 			wantPassed: false,
 			wantMessages: []string{
-				"NVIDIA driver not detected",
+				"NVIDIA GPU hardware is present, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry",
 			},
 		},
 		{
@@ -156,7 +156,7 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 			},
 			wantPassed: false,
 			wantMessages: []string{
-				"NVIDIA driver major version 509 is below required minimum 510",
+				"NVIDIA driver version 509.12.01 is below the required minimum 510; upgrade the driver and retry",
 			},
 		},
 		{
@@ -167,7 +167,7 @@ func TestEvaluateDriverAndNVAT(t *testing.T) {
 			},
 			wantPassed: false,
 			wantMessages: []string{
-				"nvattest not found in PATH",
+				"nvattest was not found in PATH; install nvattest and ensure it is available in PATH",
 			},
 		},
 		{
@@ -213,8 +213,8 @@ func TestEvaluateDetectsHardwareWithoutDriver(t *testing.T) {
 
 	assert.False(t, result.Passed())
 	assert.Contains(t, checkMessages(result.Checks), "NVIDIA GPU detected")
-	assert.Contains(t, checkMessages(result.Checks), "GPU architecture check skipped because NVIDIA driver is not detected")
-	assert.Contains(t, checkMessages(result.Checks), "NVIDIA driver not detected")
+	assert.Contains(t, checkMessages(result.Checks), "GPU architecture check skipped because the NVIDIA driver is not available")
+	assert.Contains(t, checkMessages(result.Checks), "NVIDIA GPU detected via PCI, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry")
 }
 
 func TestEvaluateAggregatesFailures(t *testing.T) {
@@ -226,9 +226,9 @@ func TestEvaluateAggregatesFailures(t *testing.T) {
 	})
 
 	assert.False(t, result.Passed())
-	assert.Contains(t, checkMessages(result.Checks), "unsupported GPU architecture: Ampere")
-	assert.Contains(t, checkMessages(result.Checks), "NVIDIA driver not detected")
-	assert.Contains(t, checkMessages(result.Checks), "nvattest not found in PATH")
+	assert.Contains(t, checkMessages(result.Checks), "Unsupported GPU architecture: Ampere; supported architectures are Hopper, Blackwell, and Rubin")
+	assert.Contains(t, checkMessages(result.Checks), "NVIDIA GPU hardware is present, but the NVIDIA driver was not detected; install or load the NVIDIA driver and retry")
+	assert.Contains(t, checkMessages(result.Checks), "nvattest was not found in PATH; install nvattest and ensure it is available in PATH")
 }
 
 func TestEvaluateDCGM(t *testing.T) {
@@ -249,7 +249,7 @@ func TestEvaluateDCGM(t *testing.T) {
 			},
 			wantPassed: false,
 			wantMessages: []string{
-				"DCGM HostEngine is not reachable",
+				"DCGM HostEngine is not reachable; verify DCGM is running and DCGM_URL is configured correctly",
 			},
 		},
 		{
@@ -262,7 +262,7 @@ func TestEvaluateDCGM(t *testing.T) {
 			},
 			wantPassed: false,
 			wantMessages: []string{
-				"DCGM HostEngine version 4.2.2 is below required minimum 4.2.3",
+				"DCGM HostEngine version 4.2.2 is below the required minimum 4.2.3; upgrade DCGM and retry",
 			},
 		},
 		{

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia/pci/detect_lspci.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia/pci/detect_lspci.go
@@ -24,15 +24,17 @@ func ListPCIGPUs(ctx context.Context) ([]string, error) {
 	return listPCIs(ctx, "lspci -nn", isNVIDIAGPUPCI)
 }
 
-// 3D controller represents the GPU device itself
+// 3D controller and VGA compatible controller represent GPU devices,
 // whereas PCI Bridge refers to the PCIe switch/bridge component
 // that connects the GPU to the system's PCIe infrastructure
 //
 // e.g.,
 // 000a:00:00.0 Bridge: NVIDIA Corporation Device 1af1 (rev a1)
 // 000b:00:00.0 3D controller: NVIDIA Corporation GA100 [A100 SXM4 80GB] (rev a1)
+// 0001:00:00.0 VGA compatible controller: NVIDIA Corporation Device 2c33 (rev a1)
 func isNVIDIAGPUPCI(line string) bool {
-	return strings.Contains(line, "NVIDIA") && strings.Contains(line, "3D controller")
+	return strings.Contains(line, "NVIDIA") &&
+		(strings.Contains(line, "3D controller") || strings.Contains(line, "VGA compatible controller"))
 }
 
 func listPCIs(ctx context.Context, command string, matchFunc func(line string) bool) ([]string, error) {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia/pci/detect_lspci_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia/pci/detect_lspci_test.go
@@ -26,6 +26,11 @@ func Test_isNVIDIAGPUPCI(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "NVIDIA VGA compatible controller",
+			line:     "01:00.0 VGA compatible controller: NVIDIA Corporation Device 2c33 (rev a1)",
+			expected: true,
+		},
+		{
 			name:     "uppercase 3D CONTROLLER",
 			line:     "000b:00:00.0 3D CONTROLLER: NVIDIA Corporation GA100 [A100 SXM4 80GB] (rev a1)",
 			expected: false, // function checks for exact case "3D controller"


### PR DESCRIPTION
## Summary
- detect NVIDIA GPU hardware via PCI fallback when NVML cannot provide machine info
- report a driver-specific precheck failure when GPU hardware is present but the NVIDIA driver is missing
- add regression coverage for the hardware-present, driver-missing precheck path

## Testing
- `go test ./internal/precheck ./cmd/fleetint`

## Related
- Jira: GPUHEALTH-1724
- https://jirasw.nvidia.com/browse/GPUHEALTH-1724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GPU pre-checks more reliably detect GPU hardware (including PCI fallback) and now skip or fail checks with clearer, actionable guidance for driver, architecture, NVAttest/DCGM issues.
* **New Features**
  * Broader PCI GPU detection to include additional controller types; driver-version is collected and surfaced to checks and messages.
* **Tests**
  * Added/updated tests for driver-missing, GPU detail collection failures, architecture-skip behavior, and expanded PCI detection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->