### PR TITLE
feat: Add event_id(UUID) to events info in agent message to backend

### DIFF
--- a/internal/exporter/collector/collector.go
+++ b/internal/exporter/collector/collector.go
@@ -29,6 +29,7 @@ import (
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	pkgmetrics "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics"
 	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
+	"github.com/google/uuid"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/attestation"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
@@ -42,6 +43,11 @@ func GenerateCollectionID() string {
 	bytes := make([]byte, 16)
 	_, _ = rand.Read(bytes) // crypto/rand.Read never fails with a slice
 	return hex.EncodeToString(bytes)
+}
+
+// GenerateEventID generates a UUID for each exported event.
+func GenerateEventID() string {
+	return uuid.NewString()
 }
 
 // HealthData represents the collected health data
@@ -240,9 +246,14 @@ func (c *collector) collectEvents(ctx context.Context, data *HealthData) error {
 			if componentName == "" {
 				componentName = component.Name()
 			}
+			eventID := event.EventID
+			if eventID == "" {
+				eventID = GenerateEventID()
+			}
 
 			allEvents = append(allEvents, eventstore.Event{
 				Component: componentName,
+				EventID:   eventID,
 				Time:      event.Time.Time,
 				Name:      event.Name,
 				Type:      string(event.Type),

--- a/internal/exporter/collector/collector_test.go
+++ b/internal/exporter/collector/collector_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/eventstore"
 	pkgmetrics "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics"
 	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -358,6 +359,20 @@ func TestGenerateCollectionID(t *testing.T) {
 	// Verify IDs are 32 characters (16 bytes in hex)
 	assert.Len(t, id1, 32, "Collection ID should be 32 characters")
 	assert.Len(t, id2, 32, "Collection ID should be 32 characters")
+}
+
+func TestGenerateEventID(t *testing.T) {
+	id1 := GenerateEventID()
+	id2 := GenerateEventID()
+
+	assert.NotEmpty(t, id1)
+	assert.NotEmpty(t, id2)
+	assert.NotEqual(t, id1, id2, "Event IDs should be unique")
+
+	_, err1 := uuid.Parse(id1)
+	_, err2 := uuid.Parse(id2)
+	assert.NoError(t, err1, "ID1 should be a valid UUID")
+	assert.NoError(t, err2, "ID2 should be a valid UUID")
 }
 
 func TestNew(t *testing.T) {
@@ -771,6 +786,7 @@ func TestCollector_CollectEvents_WithComponents(t *testing.T) {
 		name: "test-component",
 		events: []apiv1.Event{
 			{
+				EventID:   "123e4567-e89b-12d3-a456-426614174000",
 				Time:      metav1.Time{Time: time.Now()},
 				Component: "test-component",
 				Name:      "test-event",
@@ -798,6 +814,9 @@ func TestCollector_CollectEvents_WithComponents(t *testing.T) {
 	assert.Equal(t, "test-component", data.Events[0].Component)
 	assert.Equal(t, "test-event", data.Events[0].Name)
 	assert.Equal(t, map[string]string{"xid_code": "79"}, data.Events[0].ExtraInfo)
+	assert.Equal(t, "123e4567-e89b-12d3-a456-426614174000", data.Events[0].EventID)
+	_, err = uuid.Parse(data.Events[0].EventID)
+	assert.NoError(t, err)
 }
 
 func TestCollector_CollectEvents_NoComponents(t *testing.T) {

--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -288,6 +288,12 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 					},
 				},
 				{
+					Key: "event_id",
+					Value: &commonv1.AnyValue{
+						Value: &commonv1.AnyValue_StringValue{StringValue: event.EventID},
+					},
+				},
+				{
 					Key: "event_name",
 					Value: &commonv1.AnyValue{
 						Value: &commonv1.AnyValue_StringValue{StringValue: event.Name},

--- a/internal/exporter/converter/otlp_test.go
+++ b/internal/exporter/converter/otlp_test.go
@@ -104,6 +104,7 @@ func TestOTLPConverter_Convert_WithEvents(t *testing.T) {
 		MachineID: "test-machine",
 		Events: eventstore.Events{
 			{
+				EventID:   "123e4567-e89b-12d3-a456-426614174000",
 				Time:      time.Date(2025, 11, 5, 12, 0, 0, 0, time.UTC),
 				Component: "gpu",
 				Name:      "temperature_warning",
@@ -134,6 +135,7 @@ func TestOTLPConverter_Convert_WithEvents(t *testing.T) {
 	logRecord := logs[0]
 	body := logRecord.Body.GetStringValue()
 	assert.Contains(t, body, "gpu")
+	assert.Equal(t, "123e4567-e89b-12d3-a456-426614174000", findAttribute(t, logs[0].Attributes, "event_id").GetStringValue())
 	// Body should contain either the event name or message
 	assert.True(t, contains(body, "temperature_warning") || contains(body, "GPU temperature high"),
 		"Log should contain event name or message")

--- a/third_party/fleet-intelligence-sdk/api/v1/types.go
+++ b/third_party/fleet-intelligence-sdk/api/v1/types.go
@@ -127,6 +127,9 @@ type Event struct {
 	// Component represents which component generated the event.
 	Component string `json:"component,omitempty"`
 
+	// EventID uniquely identifies the event.
+	EventID string `json:"event_id,omitempty"`
+
 	// Time represents when the event happened.
 	Time metav1.Time `json:"time"`
 

--- a/third_party/fleet-intelligence-sdk/pkg/eventstore/types.go
+++ b/third_party/fleet-intelligence-sdk/pkg/eventstore/types.go
@@ -27,6 +27,9 @@ type Event struct {
 	// Component represents which component generated the event.
 	Component string
 
+	// EventID uniquely identifies an event in the exported agent message.
+	EventID string
+
 	// Time represents when the event happened
 	Time time.Time
 
@@ -46,6 +49,7 @@ type Event struct {
 func (e *Event) ToEvent() apiv1.Event {
 	return apiv1.Event{
 		Component: e.Component,
+		EventID:   e.EventID,
 		Time:      metav1.Time{Time: e.Time},
 		Name:      e.Name,
 		Type:      apiv1.EventType(e.Type),

--- a/third_party/fleet-intelligence-sdk/pkg/eventstore/types_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/eventstore/types_test.go
@@ -1,0 +1,52 @@
+// Copyright 2024 Lepton AI Inc
+// Source: https://github.com/leptonai/gpud
+
+package eventstore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvent_ToEvent_PreservesEventID(t *testing.T) {
+	t.Parallel()
+
+	ev := Event{
+		Component: "component-a",
+		EventID:   "123e4567-e89b-12d3-a456-426614174000",
+		Time:      time.Unix(1710000000, 0).UTC(),
+		Name:      "event-a",
+		Type:      "Warning",
+		Message:   "hello",
+		ExtraInfo: map[string]string{
+			"key": "value",
+		},
+	}
+
+	apiEvent := ev.ToEvent()
+
+	assert.Equal(t, ev.EventID, apiEvent.EventID)
+	assert.Equal(t, "value", apiEvent.ExtraInfo["key"])
+}
+
+func TestEvent_ToEvent_EmptyEventID(t *testing.T) {
+	t.Parallel()
+
+	ev := Event{
+		Component: "component-a",
+		Time:      time.Unix(1710000000, 0).UTC(),
+		Name:      "event-a",
+		Type:      "Warning",
+		Message:   "hello",
+		ExtraInfo: map[string]string{
+			"key": "value",
+		},
+	}
+
+	apiEvent := ev.ToEvent()
+
+	assert.Empty(t, apiEvent.EventID)
+	assert.Equal(t, "value", apiEvent.ExtraInfo["key"])
+}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events now include a stable unique identifier; exported messages (including agent exports and OTLP logs) carry this identifier for better tracing and correlation.

* **Tests**
  * Added tests verifying identifier generation, format (UUID), preservation when provided, and presence in exported data formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->