### PR TITLE
fix: harden exporter JWT refresh handling

### DIFF
--- a/internal/exporter/options.go
+++ b/internal/exporter/options.go
@@ -197,6 +197,9 @@ func (c *exporterOptions) setDefaults() {
 	if c.httpClient == nil && c.timeout > 0 {
 		c.httpClient = &http.Client{
 			Timeout: c.timeout,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 		}
 	}
 }

--- a/internal/exporter/options_test.go
+++ b/internal/exporter/options_test.go
@@ -174,6 +174,19 @@ func TestWithTimeout(t *testing.T) {
 	}
 }
 
+func TestExporterOptions_setDefaults_DisablesRedirects(t *testing.T) {
+	opts := &exporterOptions{
+		timeout: 30 * time.Second,
+	}
+
+	opts.setDefaults()
+
+	require.NotNil(t, opts.httpClient)
+	assert.Equal(t, 30*time.Second, opts.httpClient.Timeout)
+	require.NotNil(t, opts.httpClient.CheckRedirect)
+	assert.Equal(t, http.ErrUseLastResponse, opts.httpClient.CheckRedirect(&http.Request{}, nil))
+}
+
 func TestWithDatabaseConnections(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/exporter/writer/http.go
+++ b/internal/exporter/writer/http.go
@@ -240,6 +240,18 @@ func (w *httpWriter) sendOTLPRequest(ctx context.Context, reqData []byte, dataTy
 	}
 	defer resp.Body.Close()
 
+	if resp.Request == nil || resp.Request.URL == nil || req.URL == nil {
+		return "", fmt.Errorf("failed to validate response origin")
+	}
+	if resp.Request.URL.Scheme != req.URL.Scheme || resp.Request.URL.Host != req.URL.Host {
+		log.Logger.Warnw("rejecting response from mismatched origin",
+			"configured_origin", req.URL.Scheme+"://"+req.URL.Host,
+			"response_origin", resp.Request.URL.Scheme+"://"+resp.Request.URL.Host,
+			"endpoint", endpoint,
+			"data_type", dataType)
+		return "", fmt.Errorf("response origin mismatch")
+	}
+
 	// Check response status
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", &HTTPError{
@@ -252,22 +264,11 @@ func (w *httpWriter) sendOTLPRequest(ctx context.Context, reqData []byte, dataTy
 	// Check for JWT token refresh in response headers
 	var newToken string
 	if headerToken := resp.Header.Get("jwt_assertion"); headerToken != "" {
-		if resp.Request == nil || resp.Request.URL == nil || req.URL == nil {
-			log.Logger.Warnw("ignoring refreshed JWT token because request URL context is unavailable",
-				"endpoint", endpoint,
-				"data_type", dataType)
-		} else if resp.Request.URL.Scheme != req.URL.Scheme || resp.Request.URL.Host != req.URL.Host {
-			log.Logger.Warnw("ignoring refreshed JWT token from mismatched response origin",
-				"configured_endpoint", req.URL.String(),
-				"response_url", resp.Request.URL.String(),
-				"data_type", dataType)
-		} else {
-			newToken = headerToken
-			log.Logger.Infow("Received refreshed JWT token from response header",
-				"endpoint", endpoint,
-				"data_type", dataType,
-				"token_length", len(newToken))
-		}
+		newToken = headerToken
+		log.Logger.Infow("Received refreshed JWT token from response header",
+			"endpoint", endpoint,
+			"data_type", dataType,
+			"token_length", len(newToken))
 	}
 
 	return newToken, nil

--- a/internal/exporter/writer/http.go
+++ b/internal/exporter/writer/http.go
@@ -252,11 +252,22 @@ func (w *httpWriter) sendOTLPRequest(ctx context.Context, reqData []byte, dataTy
 	// Check for JWT token refresh in response headers
 	var newToken string
 	if headerToken := resp.Header.Get("jwt_assertion"); headerToken != "" {
-		newToken = headerToken
-		log.Logger.Infow("Received refreshed JWT token from response header",
-			"endpoint", endpoint,
-			"data_type", dataType,
-			"token_length", len(newToken))
+		if resp.Request == nil || resp.Request.URL == nil || req.URL == nil {
+			log.Logger.Warnw("ignoring refreshed JWT token because request URL context is unavailable",
+				"endpoint", endpoint,
+				"data_type", dataType)
+		} else if resp.Request.URL.Scheme != req.URL.Scheme || resp.Request.URL.Host != req.URL.Host {
+			log.Logger.Warnw("ignoring refreshed JWT token from mismatched response origin",
+				"configured_endpoint", req.URL.String(),
+				"response_url", resp.Request.URL.String(),
+				"data_type", dataType)
+		} else {
+			newToken = headerToken
+			log.Logger.Infow("Received refreshed JWT token from response header",
+				"endpoint", endpoint,
+				"data_type", dataType,
+				"token_length", len(newToken))
+		}
 	}
 
 	return newToken, nil

--- a/internal/exporter/writer/http_test.go
+++ b/internal/exporter/writer/http_test.go
@@ -407,7 +407,7 @@ func TestHTTPWriter_sendOTLPRequest_DoesNotFollowRedirect(t *testing.T) {
 	assert.Contains(t, err.Error(), "HTTP 307")
 }
 
-func TestHTTPWriter_sendOTLPRequest_IgnoresJWTTokenFromRedirectedHost(t *testing.T) {
+func TestHTTPWriter_sendOTLPRequest_RejectsRedirectedHost(t *testing.T) {
 	newToken := "poisoned-jwt-token"
 
 	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -434,8 +434,9 @@ func TestHTTPWriter_sendOTLPRequest_IgnoresJWTTokenFromRedirectedHost(t *testing
 	ctx := context.Background()
 	token, err := writer.sendOTLPRequest(ctx, reqData, "metrics", "test-collection-id", "test-machine-id", server.URL, "test-token")
 
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Empty(t, token)
+	assert.Contains(t, err.Error(), "response origin mismatch")
 }
 
 func TestHTTPWriter_Send_ContextCancellation(t *testing.T) {

--- a/internal/exporter/writer/http_test.go
+++ b/internal/exporter/writer/http_test.go
@@ -374,6 +374,70 @@ func TestHTTPWriter_Send_JWTTokenRefreshFromHeader(t *testing.T) {
 	assert.Equal(t, newToken, returnedToken)
 }
 
+func TestHTTPWriter_sendOTLPRequest_DoesNotFollowRedirect(t *testing.T) {
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("unexpected redirect follow")
+	}))
+	defer redirectTarget.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	metricsData := &metricsv1.MetricsData{
+		ResourceMetrics: []*metricsv1.ResourceMetrics{},
+	}
+	reqData, err := proto.Marshal(metricsData)
+	require.NoError(t, err)
+
+	httpClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	otlpConverter := &mockOTLPConverter{}
+	writer := NewHTTPWriter(httpClient, otlpConverter).(*httpWriter)
+
+	ctx := context.Background()
+	returnedToken, err := writer.sendOTLPRequest(ctx, reqData, "metrics", "test-collection-id", "test-machine-id", server.URL, "test-token")
+
+	require.Error(t, err)
+	assert.Empty(t, returnedToken)
+	assert.Contains(t, err.Error(), "HTTP 307")
+}
+
+func TestHTTPWriter_sendOTLPRequest_IgnoresJWTTokenFromRedirectedHost(t *testing.T) {
+	newToken := "poisoned-jwt-token"
+
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("jwt_assertion", newToken)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer redirectTarget.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	metricsData := &metricsv1.MetricsData{
+		ResourceMetrics: []*metricsv1.ResourceMetrics{},
+	}
+	reqData, err := proto.Marshal(metricsData)
+	require.NoError(t, err)
+
+	httpClient := &http.Client{}
+	otlpConverter := &mockOTLPConverter{}
+	writer := NewHTTPWriter(httpClient, otlpConverter).(*httpWriter)
+
+	ctx := context.Background()
+	token, err := writer.sendOTLPRequest(ctx, reqData, "metrics", "test-collection-id", "test-machine-id", server.URL, "test-token")
+
+	require.NoError(t, err)
+	assert.Empty(t, token)
+}
+
 func TestHTTPWriter_Send_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(2 * time.Second)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default HTTP client no longer follows redirects automatically.
  * JWT assertion tokens are now accepted only from the configured origin; tokens from redirected hosts are rejected and trigger a warning.

* **Tests**
  * Added tests covering redirect handling and cross-origin JWT validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->