### PR TITLE
fix: enforce token file size limit before read

### DIFF
--- a/cmd/fleetint/enroll.go
+++ b/cmd/fleetint/enroll.go
@@ -54,7 +54,19 @@ func resolveToken(cliContext *cli.Context) (string, error) {
 		if tokenFile == "-" {
 			raw, err = io.ReadAll(io.LimitReader(os.Stdin, maxTokenSize))
 		} else {
-			raw, err = os.ReadFile(tokenFile)
+			var file *os.File
+			file, err = os.Open(tokenFile)
+			if err == nil {
+				defer file.Close()
+				var info os.FileInfo
+				info, err = file.Stat()
+				if err == nil && info.Size() >= maxTokenSize {
+					return "", fmt.Errorf("token file %q exceeds maximum size of %d bytes", tokenFile, maxTokenSize)
+				}
+				if err == nil {
+					raw, err = io.ReadAll(io.LimitReader(file, maxTokenSize))
+				}
+			}
 		}
 		if err != nil {
 			return "", fmt.Errorf("failed to read token from %q: %w", tokenFile, err)

--- a/cmd/fleetint/security_test.go
+++ b/cmd/fleetint/security_test.go
@@ -134,6 +134,23 @@ func TestResolveToken_FromFile(t *testing.T) {
 	assert.NotContains(t, err.Error(), "mutually exclusive")
 }
 
+func TestResolveToken_RejectsOversizedTokenFile(t *testing.T) {
+	const maxTokenSize = 1 << 20
+
+	tmpFile := filepath.Join(t.TempDir(), "token")
+	file, err := os.Create(tmpFile)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	require.NoError(t, os.Truncate(tmpFile, maxTokenSize))
+
+	app := App()
+	app.Writer = &bytes.Buffer{}
+
+	err = app.Run([]string{"fleetint", "enroll", "--endpoint", "https://example.com", "--token-file", tmpFile})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+}
+
 // TestResolveToken_RequiresOne verifies that omitting both flags is an error.
 func TestResolveToken_RequiresOne(t *testing.T) {
 	app := App()


### PR DESCRIPTION
Reject oversized token files before reading regular files into memory so a misconfigured --token-file cannot bypass the 1 MiB guard and trigger excessive allocation.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced token file validation during enrollment to check file size upfront and reject files exceeding the maximum allowed size (1 MiB) with a clear error message.

* **Tests**
  * Added test coverage for oversized token file validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->