### PR TITLE
security: use absolute paths for exec to prevent PATH poisoning [2/5]

### DIFF
--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	pkgfile "github.com/NVIDIA/fleet-intelligence-sdk/pkg/file"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	pkgmetadata "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metadata"
 	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
@@ -505,33 +506,35 @@ func (m *Manager) getEvidences(nonce string) (*AttestationSDKResponse, error) {
 	ctx, cancel := context.WithTimeout(m.ctx, 60*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "nvattest", "collect-evidence", "--gpu-evidence-source=corelib", "--nonce", nonce, "--gpu-architecture", "blackwell", "--format", "json")
+	nvattestPath, err := pkgfile.LocateExecutable("nvattest")
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate attestation CLI: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, nvattestPath, "collect-evidence", "--gpu-evidence-source=corelib", "--nonce", nonce, "--gpu-architecture", "blackwell", "--format", "json")
 
 	// Capture stdout (JSON) and stderr (logs) separately
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	runErr := cmd.Run()
 
-	log.Logger.Debugw("Attestation CLI completed", "exit_error", err, "stdout", stdout.String(), "stderr", stderr.String())
+	log.Logger.Debugw("Attestation CLI completed", "exit_error", runErr, "stdout", stdout.String(), "stderr", stderr.String())
 
-	if err != nil {
+	if runErr != nil {
 		// If stdout is empty, it means the command failed completely (e.g. command not found)
 		if stdout.Len() == 0 {
-			// SDKResponse is nil
-			return nil, fmt.Errorf("attestation CLI execution failed: %w (stderr: %s)", err, stderr.String())
+			return nil, fmt.Errorf("attestation CLI execution failed: %w (stderr: %s)", runErr, stderr.String())
 		}
 		// If stdout has content, we continue to try parsing the JSON response
-		log.Logger.Warnw("Attestation CLI returned error exit code but has output, attempting to parse", "error", err)
+		log.Logger.Warnw("Attestation CLI returned error exit code but has output, attempting to parse", "error", runErr)
 	}
 
 	// Parse the JSON response from stdout (clean JSON without log messages)
 	var response AttestationSDKResponse
 	if parseErr := json.Unmarshal(stdout.Bytes(), &response); parseErr != nil {
 		log.Logger.Debugw("Failed to parse attestation CLI JSON response", "parse_error", parseErr)
-		// SDKResponse is nil
-		return nil, fmt.Errorf("failed to parse CLI response: %w (stderr: %s), stdout: %s, error: %s", parseErr, stderr.String(), stdout.String(), err.Error())
+		return nil, fmt.Errorf("failed to parse CLI response: %w (stderr: %s, stdout: %s, exec: %v)", parseErr, stderr.String(), stdout.String(), runErr)
 	}
 
 	log.Logger.Infow("Successfully called attestation SDK",

--- a/internal/attestation/attestation_test.go
+++ b/internal/attestation/attestation_test.go
@@ -376,7 +376,7 @@ func TestManager_GetEvidences(t *testing.T) {
 	// In CI environment, the nvattest binary might not exist or directory might not exist
 	if err != nil {
 		// If binary is missing, this is expected in CI
-		if strings.Contains(err.Error(), "executable file not found") || strings.Contains(err.Error(), "no such file or directory") || strings.Contains(err.Error(), "The following arguments were not expected") {
+		if strings.Contains(err.Error(), "executable file not found") || strings.Contains(err.Error(), "no such file or directory") || strings.Contains(err.Error(), "not found in PATH") || strings.Contains(err.Error(), "The following arguments were not expected") {
 			t.Log("Attestation CLI binary or directory not found (expected in CI)")
 			return
 		}

--- a/third_party/fleet-intelligence-sdk/pkg/file/file.go
+++ b/third_party/fleet-intelligence-sdk/pkg/file/file.go
@@ -8,14 +8,24 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
+// LocateExecutable finds bin in PATH and returns its absolute path.
+// It rejects relative results to prevent PATH-poisoning attacks when the
+// agent runs as root.
 func LocateExecutable(bin string) (string, error) {
 	execPath, err := exec.LookPath(bin)
-	if err == nil {
-		return execPath, CheckExecutable(execPath)
+	if err != nil {
+		return "", fmt.Errorf("executable %q not found in PATH: %w", bin, err)
 	}
-	return "", fmt.Errorf("executable %q not found in PATH: %w", bin, err)
+	// exec.LookPath may return a relative path on older Go versions or when
+	// "." or an empty element is present in PATH. Reject those results rather
+	// than resolving them against the current working directory.
+	if !filepath.IsAbs(execPath) {
+		return "", fmt.Errorf("executable %q resolved to non-absolute path %q", bin, execPath)
+	}
+	return execPath, CheckExecutable(execPath)
 }
 
 func CheckExecutable(file string) error {

--- a/third_party/fleet-intelligence-sdk/pkg/file/file_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/file/file_test.go
@@ -4,6 +4,8 @@
 package file
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,4 +17,22 @@ func TestLocateExecutable(t *testing.T) {
 	require.NoError(t, err, "LocateExecutable() should not fail")
 	assert.NotEmpty(t, execPath, "executable path should not be empty")
 	t.Logf("found executable %q", execPath)
+}
+
+func TestLocateExecutableRejectsRelativePathResult(t *testing.T) {
+	tmpDir := t.TempDir()
+	execPath := filepath.Join(tmpDir, "fakebin")
+	require.NoError(t, os.WriteFile(execPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() {
+		_ = os.Chdir(origWD)
+	})
+
+	t.Setenv("PATH", "."+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err = LocateExecutable("fakebin")
+	require.Error(t, err, "LocateExecutable must reject binaries found via '.' in PATH")
 }

--- a/third_party/fleet-intelligence-sdk/pkg/host/virtualization_environment.go
+++ b/third_party/fleet-intelligence-sdk/pkg/host/virtualization_environment.go
@@ -97,7 +97,7 @@ func GetSystemManufacturer(ctx context.Context) (string, error) {
 		return "", nil
 	}
 
-	output, err := exec.CommandContext(ctx, "sudo", dmidecodePath, "-s", "system-manufacturer").CombinedOutput()
+	output, err := exec.CommandContext(ctx, dmidecodePath, "-s", "system-manufacturer").CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to read dmidecode for system manufacturer: %w\n\noutput:\n%s", err, strings.TrimSpace(string(output)))
 	}

--- a/third_party/fleet-intelligence-sdk/pkg/process/options.go
+++ b/third_party/fleet-intelligence-sdk/pkg/process/options.go
@@ -7,9 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/file"
 )
 
 type OpOption func(*Op)
@@ -198,9 +199,6 @@ func WithRestartConfig(config RestartConfig) OpOption {
 }
 
 func commandExists(name string) bool {
-	p, err := exec.LookPath(name)
-	if err != nil {
-		return false
-	}
-	return p != ""
+	_, err := file.LocateExecutable(name)
+	return err == nil
 }

--- a/third_party/fleet-intelligence-sdk/pkg/process/pids.go
+++ b/third_party/fleet-intelligence-sdk/pkg/process/pids.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/file"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 
 	procs "github.com/shirou/gopsutil/v4/process"
@@ -15,7 +16,10 @@ import (
 
 func CheckRunningByPid(ctx context.Context, processName string) bool {
 	log.Logger.Debugw("checking if process is running", "processName", processName)
-	err := exec.CommandContext(ctx, "pidof", processName).Run()
+	pidofPath, err := file.LocateExecutable("pidof")
+	if err == nil {
+		err = exec.CommandContext(ctx, pidofPath, processName).Run()
+	}
 	if err != nil {
 		log.Logger.Debugw("failed to check -- assuming process is not running", "error", err)
 	}

--- a/third_party/fleet-intelligence-sdk/pkg/systemd/systemd.go
+++ b/third_party/fleet-intelligence-sdk/pkg/systemd/systemd.go
@@ -17,23 +17,17 @@ import (
 )
 
 func SystemdExists() bool {
-	p, err := exec.LookPath("systemd")
-	if err != nil {
-		return false
-	}
-	return p != ""
+	_, err := file.LocateExecutable("systemd")
+	return err == nil
 }
 
 func SystemctlExists() bool {
-	p, err := exec.LookPath("systemctl")
-	if err != nil {
-		return false
-	}
-	return p != ""
+	_, err := file.LocateExecutable("systemctl")
+	return err == nil
 }
 
 func DaemonReload(ctx context.Context) ([]byte, error) {
-	cmdPath, err := exec.LookPath("systemctl")
+	cmdPath, err := file.LocateExecutable("systemctl")
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +80,7 @@ func parseVersion(version string) (string, []string) {
 // IsActive returns true if the systemd service is active.
 // TODO: deprecate this
 func IsActive(service string) (bool, error) {
-	p, err := exec.LookPath("systemctl")
+	p, err := file.LocateExecutable("systemctl")
 	if err != nil {
 		return false, fmt.Errorf("systemd active check requires systemctl (%w)", err)
 	}
@@ -110,7 +104,7 @@ const uptimeTimeLayout = "Mon 2006-01-02 15:04:05 MST"
 // Returns nil if the service is not found (thus uptime is not applicable, "n/a").
 // ref. https://github.com/kubernetes/node-problem-detector/blob/c4e5400ed6d7ca30d3a803248ae5b55c53557e59/pkg/healthchecker/health_checker_linux.go
 func GetUptime(service string) (*time.Duration, error) {
-	p, err := exec.LookPath("systemctl")
+	p, err := file.LocateExecutable("systemctl")
 	if err != nil {
 		return nil, fmt.Errorf("systemd uptime check requires systemctl (%w)", err)
 	}


### PR DESCRIPTION
LocateExecutable relied on exec.LookPath which could return a relative path if "." is in PATH. When the agent runs as root, a local attacker who places a malicious binary in the working directory could hijack execution.

Harden LocateExecutable to resolve the result to an absolute path via filepath.Abs before returning it. Also resolve "sudo" through LocateExecutable in GetSystemManufacturer instead of using a bare command name, so the same absolute-path guarantee applies.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fail early with clearer errors when required system binaries cannot be located.
  * Reject non-absolute (relative) resolved executable paths to avoid running unintended commands.
  * Use resolved absolute executable paths for system and privilege-helper invocations rather than relying on ambiguous fallbacks.

* **Tests**
  * Added a unit test validating rejection of relative executable path results.
  * Broadened CI test tolerance for additional "not found" messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->