### PR TITLE
security: sanitize error responses and clamp query time ranges [3/5]

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/fleet-intelligence-sdk/components"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	pkgmetrics "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics"
 	"github.com/gin-gonic/gin"
 
@@ -58,6 +59,17 @@ func newGlobalHandler(cfg *config.Config, componentsRegistry components.Registry
 	}
 }
 
+// clampStartTime ensures startTime is not older than the configured retention
+// period. Queries that reach further back would scan data that has already been
+// purged (or is about to be), wasting I/O and memory.
+func (g *globalHandler) clampStartTime(startTime time.Time) time.Time {
+	earliest := time.Now().Add(-g.cfg.RetentionPeriod.Duration)
+	if startTime.Before(earliest) {
+		return earliest
+	}
+	return startTime
+}
+
 func (g *globalHandler) getReqComponents(c *gin.Context) ([]string, error) {
 	componentsStr := c.Query("components")
 	if componentsStr == "" {
@@ -73,7 +85,8 @@ func (g *globalHandler) getReqComponents(c *gin.Context) ([]string, error) {
 func (g *globalHandler) getHealthStates(c *gin.Context) {
 	components, err := g.getReqComponents(c)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse components: " + err.Error()})
+		log.Logger.Warnw("failed to parse components", "error", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid components parameter"})
 		return
 	}
 
@@ -105,7 +118,7 @@ func (g *globalHandler) getEvents(c *gin.Context) {
 	if startTimeStr != "" {
 		startTimeInt, err := strconv.ParseInt(startTimeStr, 10, 64)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse since time: " + err.Error()})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid 'since' parameter: must be a Unix timestamp"})
 			return
 		}
 		startTime = time.Unix(startTimeInt, 0)
@@ -113,10 +126,12 @@ func (g *globalHandler) getEvents(c *gin.Context) {
 		// Default to events from the last hour
 		startTime = time.Now().Add(-time.Hour)
 	}
+	startTime = g.clampStartTime(startTime)
 
 	components, err := g.getReqComponents(c)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse components: " + err.Error()})
+		log.Logger.Warnw("failed to parse components", "error", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid components parameter"})
 		return
 	}
 
@@ -137,7 +152,8 @@ func (g *globalHandler) getEvents(c *gin.Context) {
 		}
 		events, err := comp.Events(c.Request.Context(), startTime)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get events for " + comp.Name() + ": " + err.Error()})
+			log.Logger.Warnw("failed to get events", "component", comp.Name(), "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve events"})
 			return
 		}
 		allEvents[comp.Name()] = events
@@ -150,7 +166,8 @@ func (g *globalHandler) getEvents(c *gin.Context) {
 func (g *globalHandler) getInfo(c *gin.Context) {
 	components, err := g.getReqComponents(c)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse components: " + err.Error()})
+		log.Logger.Warnw("failed to parse components", "error", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid components parameter"})
 		return
 	}
 
@@ -188,10 +205,10 @@ func (g *globalHandler) getMetrics(c *gin.Context) {
 	if startTimeStr != "" {
 		startTimeInt, err := strconv.ParseInt(startTimeStr, 10, 64)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse start time: " + err.Error()})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid 'startTime' parameter: must be a Unix timestamp"})
 			return
 		}
-		startTime := time.Unix(startTimeInt, 0)
+		startTime := g.clampStartTime(time.Unix(startTimeInt, 0))
 		opts = append(opts, pkgmetrics.WithSince(startTime))
 	}
 
@@ -202,7 +219,8 @@ func (g *globalHandler) getMetrics(c *gin.Context) {
 
 	metrics, err := g.metricsStore.Read(c.Request.Context(), opts...)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get metrics: " + err.Error()})
+		log.Logger.Warnw("failed to read metrics", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve metrics"})
 		return
 	}
 

--- a/internal/server/handlers_inject_fault.go
+++ b/internal/server/handlers_inject_fault.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/errdefs"
 	pkgfaultinjector "github.com/NVIDIA/fleet-intelligence-sdk/pkg/fault-injector"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 )
 
 const URLPathInjectFault = "/inject-fault"
@@ -64,25 +65,27 @@ func (s *Server) injectFault(c *gin.Context) {
 	// read the request body (capped at 1 MiB)
 	request := new(pkgfaultinjector.Request)
 	if err := json.NewDecoder(http.MaxBytesReader(c.Writer, c.Request.Body, 1<<20)).Decode(request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "failed to decode request body: " + err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "failed to decode request body"})
 		return
 	}
 	if err := request.Validate(); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "invalid request: " + err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "invalid request"})
 		return
 	}
 
 	switch {
 	case request.KernelMessage != nil:
 		if err := s.faultInjector.KmsgWriter().Write(request.KernelMessage); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject kernel message: " + err.Error()})
+			log.Logger.Warnw("failed to inject kernel message", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject kernel message"})
 			return
 		}
 
 	case request.ComponentError != nil:
 		if injector, ok := s.faultInjector.(pkgfaultinjector.ComponentErrorInjector); ok {
 			if err := injector.InjectComponentError(c.Request.Context(), s.componentsRegistry, request.ComponentError); err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject component error: " + err.Error()})
+				log.Logger.Warnw("failed to inject component error", "error", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject component error"})
 				return
 			}
 		} else {
@@ -93,7 +96,8 @@ func (s *Server) injectFault(c *gin.Context) {
 	case request.Event != nil:
 		if injector, ok := s.faultInjector.(pkgfaultinjector.EventInjector); ok {
 			if err := injector.InjectEvent(c.Request.Context(), s.componentsRegistry, request.Event); err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject event: " + err.Error()})
+				log.Logger.Warnw("failed to inject event", "error", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject event"})
 				return
 			}
 		} else {
@@ -104,7 +108,8 @@ func (s *Server) injectFault(c *gin.Context) {
 	case request.ComponentClear != nil:
 		if injector, ok := s.faultInjector.(pkgfaultinjector.ComponentClearInjector); ok {
 			if err := injector.ClearComponentFault(c.Request.Context(), s.componentsRegistry, request.ComponentClear); err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to clear component fault: " + err.Error()})
+				log.Logger.Warnw("failed to clear component fault", "error", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to clear component fault"})
 				return
 			}
 		} else {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
 )
@@ -45,6 +46,7 @@ type MockComponent struct {
 	healthStates apiv1.HealthStates
 	events       apiv1.Events
 	eventsError  error
+	lastSince    time.Time
 }
 
 func (m *MockComponent) Name() string {
@@ -64,6 +66,7 @@ func (m *MockComponent) LastHealthStates() apiv1.HealthStates {
 }
 
 func (m *MockComponent) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
+	m.lastSince = since
 	if m.eventsError != nil {
 		return nil, m.eventsError
 	}
@@ -123,6 +126,7 @@ func (m *MockRegistry) Deregister(name string) components.Component {
 type MockMetricsStore struct {
 	metrics []pkgmetrics.Metric
 	readErr error
+	lastOp  pkgmetrics.Op
 }
 
 func (m *MockMetricsStore) Record(ctx context.Context, metrics ...pkgmetrics.Metric) error {
@@ -130,6 +134,8 @@ func (m *MockMetricsStore) Record(ctx context.Context, metrics ...pkgmetrics.Met
 }
 
 func (m *MockMetricsStore) Read(ctx context.Context, opts ...pkgmetrics.OpOption) (pkgmetrics.Metrics, error) {
+	m.lastOp = pkgmetrics.Op{}
+	_ = m.lastOp.ApplyOpts(opts)
 	if m.readErr != nil {
 		return nil, m.readErr
 	}
@@ -138,6 +144,19 @@ func (m *MockMetricsStore) Read(ctx context.Context, opts ...pkgmetrics.OpOption
 
 func (m *MockMetricsStore) Purge(ctx context.Context, before time.Time) (int, error) {
 	return 0, nil
+}
+
+type erroringFaultInjector struct {
+	kmsgWriter pkgkmsgwriter.KmsgWriter
+	err        error
+}
+
+func (e *erroringFaultInjector) KmsgWriter() pkgkmsgwriter.KmsgWriter {
+	return e.kmsgWriter
+}
+
+func (e *erroringFaultInjector) InjectEvent(ctx context.Context, registry interface{}, eventToInject *pkgfaultinjector.EventToInject) error {
+	return e.err
 }
 
 // TestHealthz tests the healthz handler.
@@ -192,7 +211,9 @@ func TestGetHealthStates(t *testing.T) {
 		},
 	}
 
-	handler := newGlobalHandler(&config.Config{}, mockRegistry, nil, nil)
+	handler := newGlobalHandler(&config.Config{
+		RetentionPeriod: metav1.Duration{Duration: 5 * time.Minute},
+	}, mockRegistry, nil, nil)
 
 	tests := []struct {
 		name           string
@@ -265,7 +286,9 @@ func TestGetEvents(t *testing.T) {
 		},
 	}
 
-	handler := newGlobalHandler(&config.Config{}, mockRegistry, nil, nil)
+	handler := newGlobalHandler(&config.Config{
+		RetentionPeriod: metav1.Duration{Duration: 5 * time.Minute},
+	}, mockRegistry, nil, nil)
 
 	tests := []struct {
 		name           string
@@ -304,6 +327,20 @@ func TestGetEvents(t *testing.T) {
 			},
 		},
 		{
+			name:           "clamps_events_since_to_retention",
+			queryParams:    fmt.Sprintf("?since=%d", time.Now().Add(-24*time.Hour).Unix()),
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, body []byte) {
+				var events map[string]interface{}
+				err := json.Unmarshal(body, &events)
+				require.NoError(t, err)
+				assert.NotNil(t, events)
+				component := mockRegistry.Get("component1").(*MockComponent)
+				retention := handler.cfg.RetentionPeriod.Duration
+				assert.WithinDuration(t, time.Now().Add(-retention), component.lastSince, 2*time.Second)
+			},
+		},
+		{
 			name:           "invalid_since_time",
 			queryParams:    "?since=invalid",
 			expectedStatus: http.StatusBadRequest,
@@ -311,7 +348,7 @@ func TestGetEvents(t *testing.T) {
 				var response map[string]string
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
-				assert.Contains(t, response["error"], "failed to parse since time")
+				assert.Contains(t, response["error"], "invalid 'since' parameter")
 			},
 		},
 	}
@@ -418,6 +455,20 @@ func TestGetMetrics(t *testing.T) {
 			checkResponse:  nil,
 		},
 		{
+			name: "clamps_metrics_start_time_to_retention",
+			metricsStore: &MockMetricsStore{
+				metrics: mockMetrics,
+			},
+			queryParams:    fmt.Sprintf("?startTime=%d", time.Now().Add(-24*time.Hour).Unix()),
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, body []byte) {
+				var metrics []pkgmetrics.Metric
+				err := json.Unmarshal(body, &metrics)
+				require.NoError(t, err)
+				assert.Len(t, metrics, 1)
+			},
+		},
+		{
 			name: "get_metrics_with_components",
 			metricsStore: &MockMetricsStore{
 				metrics: mockMetrics,
@@ -437,7 +488,7 @@ func TestGetMetrics(t *testing.T) {
 				var response map[string]string
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
-				assert.Contains(t, response["error"], "failed to parse start time")
+				assert.Contains(t, response["error"], "invalid 'startTime' parameter")
 			},
 		},
 		{
@@ -451,14 +502,16 @@ func TestGetMetrics(t *testing.T) {
 				var response map[string]string
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
-				assert.Contains(t, response["error"], "failed to get metrics")
+				assert.Contains(t, response["error"], "failed to retrieve metrics")
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := newGlobalHandler(&config.Config{}, &MockRegistry{}, tt.metricsStore, nil)
+			handler := newGlobalHandler(&config.Config{
+				RetentionPeriod: metav1.Duration{Duration: 5 * time.Minute},
+			}, &MockRegistry{}, tt.metricsStore, nil)
 
 			router := gin.New()
 			router.GET("/metrics", handler.getMetrics)
@@ -471,6 +524,9 @@ func TestGetMetrics(t *testing.T) {
 			assert.Equal(t, tt.expectedStatus, w.Code)
 			if tt.checkResponse != nil {
 				tt.checkResponse(t, w.Body.Bytes())
+			}
+			if tt.name == "clamps_metrics_start_time_to_retention" {
+				assert.WithinDuration(t, time.Now().Add(-handler.cfg.RetentionPeriod.Duration), tt.metricsStore.lastOp.Since, 2*time.Second)
 			}
 		})
 	}
@@ -744,6 +800,31 @@ func TestInjectFault(t *testing.T) {
 				require.NoError(t, err)
 				assert.Contains(t, response, "message")
 				assert.Contains(t, response["message"], "fault injector not enabled")
+			},
+		},
+		{
+			name: "internal_event_injection_error_is_sanitized",
+			faultInjector: &erroringFaultInjector{
+				kmsgWriter: pkgkmsgwriter.NewWriter("/dev/null"),
+				err:        fmt.Errorf("secret backend failure"),
+			},
+			requestBody: map[string]interface{}{
+				"event": map[string]interface{}{
+					"component": "component1",
+					"name":      "test-event",
+					"type":      "info",
+					"message":   "test message",
+				},
+			},
+			remoteAddr:     "127.0.0.1:54321",
+			expectedStatus: http.StatusInternalServerError,
+			checkResponse: func(t *testing.T, body []byte) {
+				var response map[string]interface{}
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				assert.Contains(t, response, "message")
+				assert.Equal(t, "failed to inject event", response["message"])
+				assert.NotContains(t, fmt.Sprint(response["message"]), "secret backend failure")
 			},
 		},
 	}


### PR DESCRIPTION
Two related hardening changes to the HTTP API handlers:

1. Error handlers were concatenating raw err.Error() into JSON responses, which can leak internal file paths, SQL state, and driver messages. Replace all err.Error() in response bodies with generic messages and log the full error server-side at warn level.

2. The /v1/events and /v1/metrics endpoints accepted arbitrary Unix timestamps with no bounds, enabling resource exhaustion via queries like GET /v1/events?since=0. Add clampStartTime() which floors the requested start time to now - RetentionPeriod.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query `since` and `startTime` parameters are now automatically clamped to the configured data retention period, preventing queries outside the available data range.
  * Error responses now provide generic messages for invalid query parameters instead of detailed error information.
  * Enhanced server-side logging for fault injection and metrics retrieval failures to improve troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->