### PR TITLE
security: add security response headers to HTTP API [4/5]

### DIFF
--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -636,6 +636,9 @@ func TestInstallMiddlewares(t *testing.T) {
 				assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
 				assert.Empty(t, w.Header().Get("Access-Control-Allow-Methods"))
 				assert.Empty(t, w.Header().Get("Access-Control-Allow-Headers"))
+				assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+				assert.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
+				assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
 			},
 			expectedStatus: http.StatusOK,
 		},

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -562,6 +562,17 @@ func (s *Server) startServer(ctx context.Context, nvmlInstance nvidianvml.Instan
 // installMiddlewares installs basic middleware for the router
 func (s *Server) installMiddlewares(router *gin.Engine) {
 	router.Use(gin.Recovery())
+	router.Use(securityHeaders())
+}
+
+// securityHeaders returns middleware that sets standard security response headers.
+func securityHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("X-Frame-Options", "DENY")
+		c.Header("Cache-Control", "no-store")
+		c.Next()
+	}
 }
 
 // healthz returns a simple health check handler


### PR DESCRIPTION
Add a middleware that sets standard security headers on every response:
- X-Content-Type-Options: nosniff (prevents MIME-sniffing attacks)
- X-Frame-Options: DENY (prevents clickjacking via iframes)
- Cache-Control: no-store (prevents proxy/browser caching of health data)

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced application security by implementing security headers in all HTTP responses to protect against common web vulnerabilities.

* **Tests**
  * Added comprehensive test coverage validating the implementation of security headers in application responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->