### PR TITLE
security: harden output file creation with symlink checks and 0600 mode [5/5]

### DIFF
--- a/internal/exporter/converter/csv.go
+++ b/internal/exporter/converter/csv.go
@@ -18,6 +18,7 @@ package converter
 import (
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
+	"golang.org/x/sys/unix"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/exporter/collector"
@@ -95,10 +97,27 @@ func (c *csvConverter) Convert(data *collector.HealthData, outputDir, timestamp 
 	return files, nil
 }
 
+// safeCreateFile creates a new file at path with mode 0600, refusing to follow
+// symlinks. If the path already exists as a symlink, an error is returned.
+func safeCreateFile(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, fmt.Errorf("refusing to write through symlink: %s", path)
+		}
+		return nil, err
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("failed to secure file %s: %w", path, err)
+	}
+	return file, nil
+}
+
 // writeMetricsCSV writes metrics data to CSV format
 func (c *csvConverter) writeMetricsCSV(outputDir, filename string, data *collector.HealthData) error {
 	fullPath := filepath.Join(outputDir, filename)
-	file, err := os.Create(fullPath)
+	file, err := safeCreateFile(fullPath)
 	if err != nil {
 		return fmt.Errorf("failed to create file %s: %w", fullPath, err)
 	}
@@ -145,7 +164,7 @@ func (c *csvConverter) writeMetricsCSV(outputDir, filename string, data *collect
 // writeEventsCSV writes events data to CSV format
 func (c *csvConverter) writeEventsCSV(outputDir, filename string, data *collector.HealthData) error {
 	fullPath := filepath.Join(outputDir, filename)
-	file, err := os.Create(fullPath)
+	file, err := safeCreateFile(fullPath)
 	if err != nil {
 		return fmt.Errorf("failed to create file %s: %w", fullPath, err)
 	}
@@ -184,7 +203,7 @@ func (c *csvConverter) writeEventsCSV(outputDir, filename string, data *collecto
 // writeComponentHealthCSV writes component health data to CSV format
 func (c *csvConverter) writeComponentHealthCSV(outputDir, filename string, data *collector.HealthData) error {
 	fullPath := filepath.Join(outputDir, filename)
-	file, err := os.Create(fullPath)
+	file, err := safeCreateFile(fullPath)
 	if err != nil {
 		return fmt.Errorf("failed to create file %s: %w", fullPath, err)
 	}
@@ -261,7 +280,7 @@ func (c *csvConverter) writeComponentHealthCSV(outputDir, filename string, data 
 // writeMachineInfoCSV writes machine info to CSV format using the same structure as RenderTable
 func (c *csvConverter) writeMachineInfoCSV(outputDir, filename string, data *collector.HealthData) error {
 	fullPath := filepath.Join(outputDir, filename)
-	file, err := os.Create(fullPath)
+	file, err := safeCreateFile(fullPath)
 	if err != nil {
 		return fmt.Errorf("failed to create file %s: %w", fullPath, err)
 	}

--- a/internal/exporter/converter/csv_test.go
+++ b/internal/exporter/converter/csv_test.go
@@ -227,6 +227,35 @@ func TestCSVConverter_Convert_MachineInfo(t *testing.T) {
 	assert.Contains(t, records, []string{"DCGM Version", "4.2.3"})
 }
 
+func TestSafeCreateFile_RejectsSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "target.csv")
+	link := filepath.Join(tmpDir, "link.csv")
+
+	require.NoError(t, os.WriteFile(target, []byte("data"), 0o600))
+	require.NoError(t, os.Symlink(target, link))
+
+	file, err := safeCreateFile(link)
+	require.Error(t, err)
+	assert.Nil(t, file)
+	assert.Contains(t, err.Error(), "refusing to write through symlink")
+}
+
+func TestSafeCreateFile_TightensExistingPermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "metrics.csv")
+
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+
+	file, err := safeCreateFile(path)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
 func TestCSVConverter_Convert_EmptyData(t *testing.T) {
 	tmpDir := t.TempDir()
 	timestamp := "20251105_120000"

--- a/internal/exporter/writer/file.go
+++ b/internal/exporter/writer/file.go
@@ -17,11 +17,13 @@
 package writer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
+	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -92,6 +94,23 @@ func (w *fileWriter) WriteCSV(data *collector.HealthData, outputPath string) err
 	return nil
 }
 
+// safeCreateFile creates a new file at path with mode 0600, refusing to follow
+// symlinks. If the path already exists as a symlink, an error is returned.
+func safeCreateFile(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, fmt.Errorf("refusing to write through symlink: %s", path)
+		}
+		return nil, err
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("failed to secure file %s: %w", path, err)
+	}
+	return file, nil
+}
+
 // writeOTLPJSONFile writes protobuf message as standard OTLP JSON format
 func (w *fileWriter) writeOTLPJSONFile(filename string, message proto.Message) error {
 	// Use protojson to ensure proper OTLP field naming and format
@@ -107,7 +126,7 @@ func (w *fileWriter) writeOTLPJSONFile(filename string, message proto.Message) e
 		return fmt.Errorf("failed to marshal OTLP message to JSON: %w", err)
 	}
 
-	file, err := os.Create(filename)
+	file, err := safeCreateFile(filename)
 	if err != nil {
 		return fmt.Errorf("failed to create file %s: %w", filename, err)
 	}

--- a/internal/exporter/writer/file_test.go
+++ b/internal/exporter/writer/file_test.go
@@ -338,6 +338,35 @@ func TestFileWriter_WriteOTLPJSONFile_InvalidPath(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to create file")
 }
 
+func TestSafeCreateFile_RejectsSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "target.json")
+	link := filepath.Join(tmpDir, "link.json")
+
+	require.NoError(t, os.WriteFile(target, []byte("{}"), 0o600))
+	require.NoError(t, os.Symlink(target, link))
+
+	file, err := safeCreateFile(link)
+	require.Error(t, err)
+	assert.Nil(t, file)
+	assert.Contains(t, err.Error(), "refusing to write through symlink")
+}
+
+func TestSafeCreateFile_TightensExistingPermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	filename := filepath.Join(tmpDir, "test.json")
+
+	require.NoError(t, os.WriteFile(filename, []byte("{}"), 0o644))
+
+	file, err := safeCreateFile(filename)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	info, err := os.Stat(filename)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
 func TestFileWriter_TimestampFormatting(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/third_party/fleet-intelligence-sdk/pkg/log/audit.go
+++ b/third_party/fleet-intelligence-sdk/pkg/log/audit.go
@@ -4,10 +4,13 @@
 package log
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -93,13 +96,17 @@ func NewNopAuditLogger() AuditLogger {
 func NewAuditLogger(logFile string) AuditLogger {
 	var w zapcore.WriteSyncer
 	if logFile != "" {
-		w = zapcore.AddSync(&lumberjack.Logger{
-			Filename:   logFile,
-			MaxSize:    128, // megabytes
-			MaxBackups: 5,
-			MaxAge:     3,    // days
-			Compress:   true, // compress the rotated files
-		})
+		if err := prepareAuditLogFile(logFile); err != nil {
+			w = zapcore.AddSync(os.Stdout)
+		} else {
+			w = zapcore.AddSync(&lumberjack.Logger{
+				Filename:   logFile,
+				MaxSize:    128, // megabytes
+				MaxBackups: 5,
+				MaxAge:     3,    // days
+				Compress:   true, // compress the rotated files
+			})
+		}
 	} else {
 		w = zapcore.AddSync(os.Stdout)
 	}
@@ -118,6 +125,21 @@ func NewAuditLogger(logFile string) AuditLogger {
 	logger := zap.New(core)
 
 	return &auditLogger{logger: logger}
+}
+
+func prepareAuditLogFile(logFile string) error {
+	file, err := os.OpenFile(logFile, os.O_CREATE|os.O_APPEND|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return fmt.Errorf("refusing to write audit log through symlink: %s", logFile)
+		}
+		return err
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
 }
 
 type auditLogger struct {

--- a/third_party/fleet-intelligence-sdk/pkg/log/audit_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/log/audit_test.go
@@ -206,6 +206,9 @@ func TestNewAuditLogger(t *testing.T) {
 		// Verify file was created and contains expected content
 		content, err := os.ReadFile(logFile)
 		require.NoError(t, err)
+		info, err := os.Stat(logFile)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 
 		// Parse the JSON log entry
 		var logEntry map[string]interface{}


### PR DESCRIPTION
When the agent runs as root, output files were created via os.Create which uses the process umask (typically 0022), producing world-readable files. Additionally, a local attacker could place a symlink at an expected output path to redirect writes to a sensitive system file.

Add safeCreateFile() in both the file writer and CSV converter that:
- Checks for symlinks via os.Lstat before opening (rejects symlinks)
- Creates files with explicit 0600 mode (owner read/write only)

Also chmod the audit log file to 0600 after lumberjack creates it.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Enhanced file security**: Output files (CSV exports, JSON exports, and audit logs) are now created with restricted permissions (0600) to prevent unauthorized access.
* **Symlink protection**: Added safeguards to prevent writing through symbolic links, protecting against symlink-based attacks on exported data and logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->