### PR TITLE
docs: add sudo to unix socket curl examples

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -203,10 +203,10 @@ sudo journalctl -u fleetintd -f
 
 The fleetint API server listens on a Unix socket (`/run/fleetint/fleetint.sock`) by default. When started with a TCP address (e.g. `--listen-address=127.0.0.1:15133`), the REST endpoints are also available over plain HTTP.
 
-**Using curl with the default Unix socket:**
+**Using curl with the default Unix socket** (requires sudo since the socket is owner-only):
 
 ```bash
-curl --unix-socket /run/fleetint/fleetint.sock http://localhost/healthz
+sudo curl --unix-socket /run/fleetint/fleetint.sock http://localhost/healthz
 ```
 
 **Using curl with TCP** (requires `--listen-address=127.0.0.1:15133`):
@@ -215,7 +215,7 @@ curl --unix-socket /run/fleetint/fleetint.sock http://localhost/healthz
 curl http://localhost:15133/healthz
 ```
 
-The examples below use the TCP form for brevity. Substitute `--unix-socket /run/fleetint/fleetint.sock http://localhost` for the hostname when using the default socket.
+The examples below use the TCP form for brevity. For the default socket, prefix with `sudo` and substitute `--unix-socket /run/fleetint/fleetint.sock http://localhost` for the hostname.
 
 ### Health Check
 


### PR DESCRIPTION
## Description
Update docs to include sudo for the curl command pointing to the UNIX socket since the socket is owned by root, commands like `fleetint status` and other already use sudo.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated HTTP API curl usage documentation for Unix socket requests to explicitly require `sudo` prefix when accessing the default Unix socket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->