### PR TITLE
security: parameterize metrics component filter to prevent SQL injection

### DIFF
--- a/third_party/fleet-intelligence-sdk/pkg/metrics/store/sqlite.go
+++ b/third_party/fleet-intelligence-sdk/pkg/metrics/store/sqlite.go
@@ -193,13 +193,13 @@ func read(ctx context.Context, dbRO *sql.DB, table string, opts ...pkgmetrics.Op
 		if whereStatement != "" {
 			whereStatement += " AND "
 		}
-		whereStatement += fmt.Sprintf("%s IN (", columnComponentName)
 
-		components := make([]string, 0, len(op.SelectedComponents))
+		placeholders := make([]string, 0, len(op.SelectedComponents))
 		for component := range op.SelectedComponents {
-			components = append(components, "'"+component+"'")
+			placeholders = append(placeholders, "?")
+			params = append(params, component)
 		}
-		whereStatement += strings.Join(components, ", ") + ")"
+		whereStatement += fmt.Sprintf("%s IN (%s)", columnComponentName, strings.Join(placeholders, ", "))
 	}
 	if whereStatement != "" {
 		whereStatement = fmt.Sprintf("WHERE %s", whereStatement)

--- a/third_party/fleet-intelligence-sdk/pkg/metrics/store/sqlite_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/metrics/store/sqlite_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	pkgmetadata "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metadata"
 	pkgmetrics "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics"
 	pkgsqlite "github.com/NVIDIA/fleet-intelligence-sdk/pkg/sqlite"
 )
@@ -1059,4 +1060,42 @@ func TestSQLiteReadScanHandling(t *testing.T) {
 	assert.Equal(t, nullMetric.Component, results[0].Component)
 	assert.Equal(t, nullMetric.Name, results[0].Name)
 	assert.Empty(t, results[0].Labels)
+}
+
+func TestSQLiteReadWithComponentsTreatsSQLMetacharactersAsData(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	tableName := "test_read_sql_metacharacters"
+	err := CreateTable(ctx, dbRW, tableName)
+	require.NoError(t, err)
+
+	err = pkgmetadata.CreateTableMetadata(ctx, dbRW)
+	require.NoError(t, err)
+	err = pkgmetadata.SetMetadata(ctx, dbRW, "sak_token", "top-secret")
+	require.NoError(t, err)
+
+	payload := "x') UNION ALL SELECT 0,key,value,NULL,0 FROM gpud_metadata--"
+	expected := pkgmetrics.Metric{
+		UnixMilliseconds: time.Now().UnixMilli(),
+		Component:        payload,
+		Name:             "metric1",
+		Value:            42.0,
+	}
+
+	err = insert(ctx, dbRW, tableName, expected)
+	require.NoError(t, err)
+
+	results, err := read(ctx, dbRO, tableName, pkgmetrics.WithComponents(payload))
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, expected.UnixMilliseconds, results[0].UnixMilliseconds)
+	assert.Equal(t, expected.Component, results[0].Component)
+	assert.Equal(t, expected.Name, results[0].Name)
+	assert.Equal(t, expected.Value, results[0].Value)
 }


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
read() in pkg/metrics/store/sqlite built the WHERE ... IN (...) clause by quoting and concatenating component names directly into the SQL string. A caller able to control a component name could break out of the quoted literal and append arbitrary SQL, including UNION queries against other tables such as gpud_metadata.

Bind component names as query parameters instead. Add a regression test that inserts and reads back a metric whose Component field is a UNION payload targeting gpud_metadata, verifying the input is treated as data rather than SQL.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL injection vulnerability in metric component filtering.
  * Component names containing special characters are now properly treated as literal data rather than SQL syntax.
  * Updated query construction to use parameterized SQL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->