### PR TITLE
feat: add flag to disable the local listener

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ This repository contains the `fleetint` host agent. The notes below are intended
 
 ### Key Security Assumptions
 
-- The local API listens on a Unix socket (`/run/fleetint/fleetint.sock`) by default, restricting access via filesystem permissions. TCP mode (`--listen-address=host:port`) is available but binds to localhost unless an operator explicitly changes it.
+- The local API listener is disabled by default. When enabled, the default bind target is Unix socket (`/run/fleetint/fleetint.sock`), restricting access via filesystem permissions. TCP mode (`--listen-address=host:port`) is available but binds to localhost unless an operator explicitly changes it.
 - The local HTTP API is mostly read-only and should not accept writable requests in normal operation; the fault-injection path is the exception, and it is disabled by default for test use only.
 - Backend communication is expected to use HTTPS endpoints.
 - The local state directory is trusted local storage and must remain readable only by the local service account or root.

--- a/cmd/fleetint/root.go
+++ b/cmd/fleetint/root.go
@@ -84,6 +84,10 @@ func App() *cli.App {
 					Usage: "set the listen address",
 					Value: config.DefaultListenAddress,
 				},
+				&cli.BoolFlag{
+					Name:  "disable-local-listener",
+					Usage: "disable local API listener startup (default: true; set --disable-local-listener=false to enable)",
+				},
 				&cli.DurationFlag{
 					Name:  "retention-period",
 					Usage: "set the time period to retain metrics for (once elapsed, old records are automatically purged)",

--- a/cmd/fleetint/run.go
+++ b/cmd/fleetint/run.go
@@ -254,6 +254,8 @@ func runCommand(cliContext *cli.Context) error {
 	}
 
 	listenAddress := cliContext.String("listen-address")
+	disableLocalListener := cliContext.Bool("disable-local-listener")
+	disableLocalListenerSet := cliContext.IsSet("disable-local-listener")
 	retentionPeriod := cliContext.Duration("retention-period")
 
 	ibClassRootDir := cliContext.String("infiniband-class-root-dir")
@@ -315,6 +317,9 @@ func runCommand(cliContext *cli.Context) error {
 	if listenAddress != "" {
 		cfg.Address = listenAddress
 	}
+	if disableLocalListenerSet {
+		cfg.DisableLocalListener = disableLocalListener
+	}
 
 	if retentionPeriod > 0 {
 		cfg.RetentionPeriod = metav1.Duration{Duration: retentionPeriod}
@@ -334,6 +339,11 @@ func runCommand(cliContext *cli.Context) error {
 		log.Logger.Infow("fault injection endpoint enabled for testing")
 	} else {
 		log.Logger.Infow("fault injection endpoint disabled")
+	}
+	if cfg.DisableLocalListener {
+		log.Logger.Infow("local API listener disabled")
+	} else {
+		log.Logger.Infow("local API listener enabled", "address", cfg.Address)
 	}
 
 	// Configure offline mode if enabled

--- a/deployments/helm/fleet-intelligence-agent/README.md
+++ b/deployments/helm/fleet-intelligence-agent/README.md
@@ -39,6 +39,7 @@ Common values (defaults from `values.yaml`):
 | `env.HTTPS_PROXY` | `""` | Optional HTTPS proxy for outbound requests. |
 | `logLevel` | `warn` | Log level. |
 | `listenAddress` | `0.0.0.0:15133` | Listen address. |
+| `disableLocalListener` | `true` | Disable local API listener startup entirely (no unix socket or TCP bind). |
 | `retentionPeriod` | `24h` | Retention period for stored metrics and events. |
 | `components` | `all` | Enabled components. |
 | `enroll.enabled` | `false` | Enable enrollment init container. |
@@ -75,6 +76,7 @@ See `docs/install-helm.md` for the enrollment flow and secret creation steps.
 - The chart assumes DCGM HostEngine is already running in the cluster (typically
   via NVIDIA GPU Operator). Set `env.DCGM_URL` to match your DCGM Service.
 - The DaemonSet uses `runtimeClassName: nvidia` by default.
+- The chart defaults to `disableLocalListener=true` (no local API socket/TCP listener).
 - **Node Labeling**: By default, the agent only deploys to nodes with GPUs (labeled `nvidia.com/gpu.present=true`).
   This label is automatically set by the NVIDIA GPU Operator or Device Plugin.
   To deploy to all nodes regardless of labels, override with `--set nodeSelector=null`.

--- a/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
+++ b/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
@@ -122,6 +122,7 @@ spec:
             - run
             - {{ printf "--log-level=%s" .Values.logLevel | quote }}
             - {{ printf "--listen-address=%s" .Values.listenAddress | quote }}
+            - {{ printf "--disable-local-listener=%t" .Values.disableLocalListener | quote }}
             - {{ printf "--retention-period=%s" .Values.retentionPeriod | quote }}
             - {{ printf "--components=%s" .Values.components | quote }}
           securityContext:
@@ -139,9 +140,11 @@ spec:
                   fieldPath: spec.nodeName
             - name: IS_RUNTIME_K8S
               value: "true"
+          {{- if not .Values.disableLocalListener }}
           ports:
             - name: http
               containerPort: {{ .Values.ports.http }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/deployments/helm/fleet-intelligence-agent/values.yaml
+++ b/deployments/helm/fleet-intelligence-agent/values.yaml
@@ -47,6 +47,7 @@ env:
 
 logLevel: warn
 listenAddress: 127.0.0.1:15133
+disableLocalListener: true
 retentionPeriod: 24h
 components: all
 

--- a/deployments/packages/systemd/fleetint.env
+++ b/deployments/packages/systemd/fleetint.env
@@ -1,5 +1,5 @@
 # Fleet Intelligence Agent environment configuration
-FLEETINT_FLAGS="--log-level=warn"
+FLEETINT_FLAGS="--log-level=warn --disable-local-listener"
 DCGM_URL="localhost"
 DCGM_URL_IS_UNIX_SOCKET="false"
 FLEETINT_COLLECT_INTERVAL="1m"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,15 +23,18 @@ sudo systemctl restart fleetintd
 
 - Set environment variables directly in `/etc/default/fleetint`
 - Set `fleetint run` flags through `FLEETINT_FLAGS="..."`
+- Package default includes `--disable-local-listener` in `FLEETINT_FLAGS` (matches runtime default)
 
 ### Kubernetes
 
 The Helm chart configures the container entrypoint as `fleetint run` and exposes:
 
 - environment variables under `env.*`
-- common `run` flags through dedicated chart values such as `logLevel`, `listenAddress`, and `components`
+- common `run` flags through dedicated chart values such as `logLevel`, `listenAddress`, `disableLocalListener`, and `components`
 
 Apply changes by updating `values.yaml` or using `helm upgrade --set ...`.
+
+Chart default sets `disableLocalListener: true`.
 
 ## Configurable Environment Variables
 
@@ -68,7 +71,7 @@ sudoedit /etc/default/fleetint
 ```
 
 ```bash
-FLEETINT_FLAGS="--log-level=info --components=all,-accelerator-nvidia-dcgm-prof"
+FLEETINT_FLAGS="--log-level=info --disable-local-listener --components=all,-accelerator-nvidia-dcgm-prof"
 DCGM_URL="localhost"
 DCGM_URL_IS_UNIX_SOCKET="false"
 FLEETINT_COLLECT_INTERVAL="2m"
@@ -86,6 +89,7 @@ sudo systemctl restart fleetintd
 ```yaml
 logLevel: info
 listenAddress: 0.0.0.0:15133
+disableLocalListener: false
 retentionPeriod: 24h
 components: all,-accelerator-nvidia-dcgm-prof
 
@@ -115,7 +119,8 @@ These are the `fleetint run` flags supported by the CLI.
 | --- | --- | --- | --- | --- |
 | `--log-level` | Log level: `debug`, `info`, `warn`, `error`. | unset by CLI; packaged bare-metal default is `warn` via `FLEETINT_FLAGS` | `FLEETINT_FLAGS="--log-level=..."` | `logLevel` |
 | `--log-file` | Log file path. Leave empty to log to stdout/stderr. | empty | `FLEETINT_FLAGS="--log-file=..."` | not exposed by chart by default |
-| `--listen-address` | Listen address for the agent API server. An absolute path creates a Unix socket; a `host:port` value opens a TCP listener. | `/run/fleetint/fleetint.sock` | `FLEETINT_FLAGS="--listen-address=..."` | `listenAddress` |
+| `--listen-address` | Listen address for the agent API server. An absolute path creates a Unix socket; a `host:port` value opens a TCP listener. This only takes effect when local listener startup is enabled. | `/run/fleetint/fleetint.sock` | `FLEETINT_FLAGS="--listen-address=..."` | `listenAddress` |
+| `--disable-local-listener` | Disable the local API listener entirely. When set, the agent does not bind either a Unix socket or TCP address. | `true` | `FLEETINT_FLAGS="--disable-local-listener"` | `disableLocalListener` (default `true`) |
 | `--retention-period` | Retention period for stored metrics and events. Minimum `1m`. | `24h` | `FLEETINT_FLAGS="--retention-period=..."` | `retentionPeriod` |
 | `--components` | Comma-separated component selection. Use `all`, `*`, explicit names, and `-name` exclusions. | empty flag value, which means enable all components by default | `FLEETINT_FLAGS="--components=..."` | `components` |
 | `--offline-mode` | Disable the HTTP API server and write telemetry to files instead. | `false` | `FLEETINT_FLAGS="--offline-mode ..."` | not exposed by chart by default |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,11 +18,14 @@ Performs a quick health scan of GPUs and system components. Returns immediately 
 sudo fleetint run
 ```
 
-Starts the API server. By default it listens on a Unix socket at `/run/fleetint/fleetint.sock` (access controlled by file permissions). Pass `--listen-address` to switch to TCP.
+Starts the agent runtime. By default, the local API listener is disabled.
+Use `--disable-local-listener=false` to enable local API serving.
+When enabled without overriding address, it listens on Unix socket `/run/fleetint/fleetint.sock` (access controlled by file permissions).
 
 **Options:**
 - `--log-level`: Set logging level (debug, info, warn, error)
-- `--listen-address`: Listen address. An absolute path (e.g. `/run/fleetint/fleetint.sock`) creates a Unix socket; a `host:port` value (e.g. `127.0.0.1:15133`) opens a TCP listener. Default: `/run/fleetint/fleetint.sock`. See [Exposing the Agent for External Monitoring](#exposing-the-agent-for-external-monitoring) for details on exposing to Prometheus and other tools.
+- `--listen-address`: Listen address. An absolute path (e.g. `/run/fleetint/fleetint.sock`) creates a Unix socket; a `host:port` value (e.g. `127.0.0.1:15133`) opens a TCP listener.
+- `--disable-local-listener`: Disable local API listener startup entirely (no unix socket or TCP bind). Runtime default is disabled.
 - `--components`: Enable/disable specific components
 
 ### Check Status
@@ -201,7 +204,9 @@ sudo journalctl -u fleetintd -f
 
 ## HTTP API
 
-The fleetint API server listens on a Unix socket (`/run/fleetint/fleetint.sock`) by default. When started with a TCP address (e.g. `--listen-address=127.0.0.1:15133`), the REST endpoints are also available over plain HTTP.
+By default, local API endpoints are not served.
+When started with `--disable-local-listener=false`, fleetint listens on Unix socket (`/run/fleetint/fleetint.sock`) unless `--listen-address` is set.
+When started with a TCP address (e.g. `--listen-address=127.0.0.1:15133`), the REST endpoints are also available over plain HTTP.
 
 **Using curl with the default Unix socket** (requires sudo since the socket is owner-only):
 
@@ -209,7 +214,7 @@ The fleetint API server listens on a Unix socket (`/run/fleetint/fleetint.sock`)
 sudo curl --unix-socket /run/fleetint/fleetint.sock http://localhost/healthz
 ```
 
-**Using curl with TCP** (requires `--listen-address=127.0.0.1:15133`):
+**Using curl with TCP** (requires `--disable-local-listener=false --listen-address=127.0.0.1:15133`):
 
 ```bash
 curl http://localhost:15133/healthz
@@ -303,14 +308,14 @@ Returns metrics in Prometheus exposition format for integration with monitoring 
 
 ## Exposing the Agent for External Monitoring
 
-By default, fleetint uses a Unix socket for security. To allow external monitoring tools like Prometheus to scrape metrics over the network, switch to a TCP listener with the `--listen-address` flag:
+By default, local API serving is disabled. To allow external monitoring tools like Prometheus to scrape metrics over the network, start with a TCP listener using `--listen-address`:
 
 ```bash
 # Expose on all interfaces
-sudo fleetint run --listen-address=0.0.0.0:15133
+sudo fleetint run --disable-local-listener=false --listen-address=0.0.0.0:15133
 
 # Or expose on a specific IP address
-sudo fleetint run --listen-address=192.168.1.100:15133
+sudo fleetint run --disable-local-listener=false --listen-address=192.168.1.100:15133
 ```
 
 ### Prometheus Configuration Example
@@ -352,7 +357,7 @@ scrape_configs:
 
 4. Check that the daemon is listening:
    ```bash
-   # Default (unix socket)
+   # Listener-enabled mode (unix socket)
    sudo ls -la /run/fleetint/fleetint.sock
 
    # TCP mode

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,11 @@ type Config struct {
 	// Address for the health server to listen on
 	Address string `json:"address"`
 
+	// DisableLocalListener disables the local API listener entirely.
+	// When true, the agent still performs data collection/export but does not
+	// bind either a unix socket or TCP port for local API access.
+	DisableLocalListener bool `json:"disable_local_listener"`
+
 	// State file that persists health status and metrics
 	// If empty, states are not persisted to file
 	State string `json:"state"`
@@ -139,9 +144,10 @@ type HealthExporterConfig struct {
 
 // Validate checks if the configuration is valid
 func (config *Config) Validate() error {
-	// In offline mode, address is not required
+	// In offline mode or when the local listener is explicitly disabled, an
+	// address is not required because no local API bind is attempted.
 	isOfflineMode := config.HealthExporter != nil && config.HealthExporter.OfflineMode
-	if !isOfflineMode {
+	if !isOfflineMode && !config.DisableLocalListener {
 		if config.Address == "" {
 			return errors.New("address is required")
 		}
@@ -246,6 +252,7 @@ func (config *Config) ToConfigEntries(allComponentNames []string) []ConfigEntry 
 	entries := []ConfigEntry{
 		{Key: "api_version", Value: config.APIVersion},
 		{Key: "address", Value: config.Address},
+		{Key: "disable_local_listener", Value: fmt.Sprintf("%t", config.DisableLocalListener)},
 		{Key: "state", Value: config.State},
 		{Key: "retention_period", Value: fmt.Sprintf("%d", int64(config.RetentionPeriod.Seconds()))},
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,6 +38,7 @@ func TestDefault(t *testing.T) {
 		// Check basic properties
 		assert.Equal(t, DefaultAPIVersion, cfg.APIVersion)
 		assert.Equal(t, DefaultListenAddress, cfg.Address)
+		assert.True(t, cfg.DisableLocalListener)
 		assert.Equal(t, DefaultRetentionPeriod, cfg.RetentionPeriod)
 
 		// State path should be set
@@ -73,6 +74,16 @@ func TestConfigValidation(t *testing.T) {
 		err := cfg.Validate()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "address is required")
+	})
+
+	t.Run("missing address allowed when local listener disabled", func(t *testing.T) {
+		cfg := &Config{
+			DisableLocalListener: true,
+			RetentionPeriod:      metav1.Duration{Duration: time.Hour},
+		}
+
+		err := cfg.Validate()
+		assert.NoError(t, err)
 	})
 
 	t.Run("retention period too short", func(t *testing.T) {
@@ -591,13 +602,15 @@ func TestToConfigEntries(t *testing.T) {
 		entries := cfg.ToConfigEntries(allComponents)
 
 		// Find specific entries
-		var apiVersion, address, state, retentionPeriod, enabledComponents, disabledComponents string
+		var apiVersion, address, disableLocalListener, state, retentionPeriod, enabledComponents, disabledComponents string
 		for _, entry := range entries {
 			switch entry.Key {
 			case "api_version":
 				apiVersion = entry.Value
 			case "address":
 				address = entry.Value
+			case "disable_local_listener":
+				disableLocalListener = entry.Value
 			case "state":
 				state = entry.Value
 			case "retention_period":
@@ -611,6 +624,7 @@ func TestToConfigEntries(t *testing.T) {
 
 		assert.Equal(t, "v1", apiVersion)
 		assert.Equal(t, "0.0.0.0:8080", address)
+		assert.Equal(t, "false", disableLocalListener)
 		assert.Equal(t, "/var/lib/fleetint", state)
 		assert.Equal(t, "86400", retentionPeriod)
 

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -73,6 +73,7 @@ func Default(ctx context.Context, opts ...OpOption) (*Config, error) {
 	cfg := &Config{
 		APIVersion:           DefaultAPIVersion,
 		Address:              DefaultListenAddress,
+		DisableLocalListener: true,
 		RetentionPeriod:      DefaultRetentionPeriod,
 		EnableFaultInjection: false, // Disabled by default for security
 		NvidiaToolOverwrites: nvidiacommon.ToolOverwrites{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,7 +84,12 @@ type Server struct {
 	// components, databases, and the health exporter would be closed twice.
 	stopOnce sync.Once
 
-	machineID string
+	nvmlInstance nvidianvml.Instance
+	machineID    string
+}
+
+func shouldStartLocalListener(cfg *config.Config) bool {
+	return cfg != nil && !cfg.DisableLocalListener
 }
 
 // initializeDatabases opens and initializes database connections
@@ -222,6 +227,7 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 	if err != nil {
 		return nil, fmt.Errorf("failed to create NVML instance: %w", err)
 	}
+	s.nvmlInstance = nvmlInstance
 
 	// Initialize DCGM instance
 	dcgmInitCtx, dcgmInitCancel := context.WithTimeout(ctx, time.Minute)
@@ -362,8 +368,12 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 		}
 	}
 
-	// Start the HTTP server
-	go s.startServer(ctx, nvmlInstance)
+	if shouldStartLocalListener(config) {
+		// Start the local API server.
+		go s.startServer(ctx)
+	} else {
+		log.Logger.Infow("local API listener disabled; skipping server startup")
+	}
 
 	return s, nil
 }
@@ -393,6 +403,11 @@ func (s *Server) Stop() {
 		if s.listener != nil {
 			// Go's UnixListener.Close() automatically unlinks the socket file.
 			_ = s.listener.Close()
+		}
+		if s.nvmlInstance != nil {
+			if err := s.nvmlInstance.Shutdown(); err != nil {
+				log.Logger.Warnw("failed to shutdown NVML instance", "error", err)
+			}
 		}
 
 		// Stop health exporter if running
@@ -459,16 +474,9 @@ func removeStaleSocket(path string) error {
 	return stdos.Remove(path)
 }
 
-// startServer creates and starts the HTTP server
-func (s *Server) startServer(ctx context.Context, nvmlInstance nvidianvml.Instance) {
-	defer func() {
-		if nvmlInstance != nil {
-			if err := nvmlInstance.Shutdown(); err != nil {
-				log.Logger.Warnw("failed to shutdown NVML instance", "error", err)
-			}
-		}
-		s.Stop()
-	}()
+// startServer creates and starts the local API server.
+func (s *Server) startServer(ctx context.Context) {
+	defer s.Stop()
 
 	// Create metrics store for health data
 	metricsSQLiteStore, err := pkgmetricsstore.NewSQLiteStore(ctx, s.dbRW, s.dbRO, pkgmetricsstore.DefaultTableName)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -79,6 +79,20 @@ func TestGetHealthCheckInterval(t *testing.T) {
 	}
 }
 
+func TestShouldStartLocalListener(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		assert.False(t, shouldStartLocalListener(nil))
+	})
+
+	t.Run("listener enabled by default", func(t *testing.T) {
+		assert.True(t, shouldStartLocalListener(&config.Config{}))
+	})
+
+	t.Run("listener disabled explicitly", func(t *testing.T) {
+		assert.False(t, shouldStartLocalListener(&config.Config{DisableLocalListener: true}))
+	})
+}
+
 // TestShouldEnableComponent tests the shouldEnableComponent function.
 func TestShouldEnableComponent(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--disable-local-listener` flag to control local API listener startup; disabled by default across all deployment methods.
  * Added Helm chart value `disableLocalListener` for Kubernetes deployments to manage listener behavior.

* **Documentation**
  * Updated security, configuration, and usage documentation to reflect that the local API listener is now disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->