### PR TITLE
feat: add loop and retry for dcgm detection

### DIFF
--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/clock/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/clock/component.go
@@ -73,7 +73,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	}
 
 	// Register clock fields with DCGM instance for centralized watching
-	if c.dcgmInstance != nil && c.dcgmInstance.DCGMExists() {
+	if c.dcgmInstance != nil {
 		if err := c.dcgmInstance.AddFieldsToWatch(clockFields); err != nil {
 			log.Logger.Warnw("failed to register clock fields", "error", err)
 		} else {

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/inforom/component.go
@@ -78,7 +78,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	}
 
 	// Register this component's health watch system with DCGM
-	if c.dcgmInstance != nil && c.dcgmInstance.DCGMExists() {
+	if c.dcgmInstance != nil {
 		if err := c.dcgmInstance.AddHealthWatch(dcgm.DCGM_HEALTH_WATCH_INFOROM); err != nil {
 			log.Logger.Warnw("failed to add inforom health watch", "error", err)
 		} else {

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/mem/component.go
@@ -78,7 +78,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	}
 
 	// Only initialize if DCGM is available
-	if c.dcgmInstance != nil && c.dcgmInstance.DCGMExists() {
+	if c.dcgmInstance != nil {
 		// Register this component's health watch system with DCGM
 		if err := c.dcgmInstance.AddHealthWatch(dcgm.DCGM_HEALTH_WATCH_MEM); err != nil {
 			log.Logger.Warnw("failed to add memory health watch", "error", err)
@@ -446,4 +446,3 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 
 	return apiv1.HealthStates{state}
 }
-

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvlink/component.go
@@ -78,7 +78,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	}
 
 	// Only initialize if DCGM is available
-	if c.dcgmInstance != nil && c.dcgmInstance.DCGMExists() {
+	if c.dcgmInstance != nil {
 		// Register this component's health watch system with DCGM
 		if err := c.dcgmInstance.AddHealthWatch(dcgm.DCGM_HEALTH_WATCH_NVLINK); err != nil {
 			log.Logger.Warnw("failed to add NVLink health watch", "error", err)

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/nvswitch/component.go
@@ -51,6 +51,8 @@ type component struct {
 	healthCheckInterval time.Duration
 	dcgmInstance        nvidiadcgm.Instance
 	dcgmHealthCache     *nvidiadcgm.HealthCache
+	switchMu            sync.Mutex
+	registeredSwitches  map[uint]struct{}
 
 	eventBucket eventstore.Bucket
 
@@ -72,42 +74,32 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		healthCheckInterval: healthCheckInterval,
 		dcgmInstance:        gpudInstance.DCGMInstance,
 		dcgmHealthCache:     gpudInstance.DCGMHealthCache,
+		registeredSwitches:  make(map[uint]struct{}),
 	}
 
-	// Add NVSwitch entities to DCGM group and register health watches
-	// This component takes ownership of managing NVSwitch entities in DCGM
+	if c.dcgmInstance != nil {
+		// Register health watch systems even if DCGM is not connected yet.
+		// A reconnecting DCGM instance will replay this registration later.
+		healthSystems := dcgm.DCGM_HEALTH_WATCH_NVSWITCH_FATAL | dcgm.DCGM_HEALTH_WATCH_NVSWITCH_NONFATAL
+		if err := c.dcgmInstance.AddHealthWatch(healthSystems); err != nil {
+			log.Logger.Warnw("failed to add NVSwitch health watch", "error", err)
+		} else {
+			log.Logger.Infow("registered DCGM NVSwitch health watch (fatal and non-fatal)")
+		}
+	}
+
+	// Add NVSwitch entities to DCGM group when DCGM is already connected.
 	if c.dcgmInstance != nil && c.dcgmInstance.DCGMExists() {
 		// Query for NVSwitch entities in the system
 		switchEntities, err := dcgm.GetEntityGroupEntities(dcgm.FE_SWITCH)
 		if err != nil {
 			log.Logger.Warnw("failed to get NVSwitch entities", "error", err)
 		} else if len(switchEntities) > 0 {
-			// Add NVSwitch entities to the DCGM group
-			addedCount := 0
-			failedCount := 0
-			for _, switchID := range switchEntities {
-				if err := c.dcgmInstance.AddEntityToGroup(switchID); err != nil {
-					log.Logger.Warnw("failed to add NVSwitch to DCGM group", "switchID", switchID, "error", err)
-					failedCount++
-				} else {
-					addedCount++
-				}
+			if err := c.ensureSwitchEntitiesRegistered(switchEntities); err != nil {
+				log.Logger.Warnw("failed to add NVSwitch entities to DCGM group", "error", err)
 			}
-			log.Logger.Infow("added NVSwitch entities to DCGM group",
-				"totalCount", len(switchEntities),
-				"addedCount", addedCount,
-				"failedCount", failedCount)
 		} else {
 			log.Logger.Debugw("no NVSwitch entities found in system")
-		}
-
-		// Register health watch systems (both fatal and non-fatal)
-		// This registers with DCGM, and the health cache will automatically poll these systems
-		healthSystems := dcgm.DCGM_HEALTH_WATCH_NVSWITCH_FATAL | dcgm.DCGM_HEALTH_WATCH_NVSWITCH_NONFATAL
-		if err := c.dcgmInstance.AddHealthWatch(healthSystems); err != nil {
-			log.Logger.Warnw("failed to add NVSwitch health watch", "error", err)
-		} else {
-			log.Logger.Infow("registered DCGM NVSwitch health watch (fatal and non-fatal)")
 		}
 	}
 
@@ -246,6 +238,9 @@ func (c *component) Check() components.CheckResult {
 	}
 
 	log.Logger.Debugw("found NVSwitch entities", "count", len(switchEntities))
+	if err := c.ensureSwitchEntitiesRegistered(switchEntities); err != nil {
+		log.Logger.Warnw("failed to ensure NVSwitch entities are in DCGM group", "error", err)
+	}
 
 	// Get cached DCGM NVSwitch health check results (both fatal and non-fatal) from shared cache
 	// Check fatal errors
@@ -310,6 +305,39 @@ func (c *component) Check() components.CheckResult {
 	dcgmcommon.EmitNewIncidentEvents(c.ctx, cr.ts, Name, EventNameIncident, c.eventBucket, prevIncidents, cr.incidents)
 
 	return cr
+}
+
+func (c *component) ensureSwitchEntitiesRegistered(switchEntities []uint) error {
+	c.switchMu.Lock()
+	defer c.switchMu.Unlock()
+
+	addedCount := 0
+	failedCount := 0
+
+	for _, switchID := range switchEntities {
+		if _, exists := c.registeredSwitches[switchID]; exists {
+			continue
+		}
+		if err := c.dcgmInstance.AddEntityToGroup(switchID); err != nil {
+			log.Logger.Warnw("failed to add NVSwitch to DCGM group", "switchID", switchID, "error", err)
+			failedCount++
+			continue
+		}
+		c.registeredSwitches[switchID] = struct{}{}
+		addedCount++
+	}
+
+	if addedCount > 0 || failedCount > 0 {
+		log.Logger.Infow("processed NVSwitch entity registration",
+			"totalCount", len(switchEntities),
+			"addedCount", addedCount,
+			"failedCount", failedCount)
+	}
+
+	if failedCount > 0 {
+		return fmt.Errorf("failed to register %d NVSwitch entities", failedCount)
+	}
+	return nil
 }
 
 var _ components.CheckResult = &checkResult{}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/pcie/component.go
@@ -78,7 +78,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	}
 
 	// Only initialize if DCGM is available
-	if c.dcgmInstance != nil && c.dcgmInstance.DCGMExists() {
+	if c.dcgmInstance != nil {
 		// Register this component's health watch system with DCGM
 		if err := c.dcgmInstance.AddHealthWatch(dcgm.DCGM_HEALTH_WATCH_PCIE); err != nil {
 			log.Logger.Warnw("failed to add PCIe health watch", "error", err)
@@ -361,4 +361,3 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 
 	return apiv1.HealthStates{state}
 }
-

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/power/component.go
@@ -80,7 +80,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	}
 
 	// Only initialize if DCGM is available
-	if c.dcgmInstance != nil && c.dcgmInstance.DCGMExists() {
+	if c.dcgmInstance != nil {
 		// Register this component's health watch system with DCGM
 		if err := c.dcgmInstance.AddHealthWatch(dcgm.DCGM_HEALTH_WATCH_POWER); err != nil {
 			log.Logger.Warnw("failed to add power health watch", "error", err)
@@ -387,4 +387,3 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 
 	return apiv1.HealthStates{state}
 }
-

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/thermal/component.go
@@ -80,7 +80,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	}
 
 	// Only initialize if DCGM is available
-	if c.dcgmInstance != nil && c.dcgmInstance.DCGMExists() {
+	if c.dcgmInstance != nil {
 		// Register this component's health watch system with DCGM
 		if err := c.dcgmInstance.AddHealthWatch(dcgm.DCGM_HEALTH_WATCH_THERMAL); err != nil {
 			log.Logger.Warnw("failed to add thermal health watch", "error", err)

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/utilization/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/utilization/component.go
@@ -73,7 +73,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	}
 
 	// Register utilization fields with DCGM instance for centralized watching
-	if c.dcgmInstance != nil && c.dcgmInstance.DCGMExists() {
+	if c.dcgmInstance != nil {
 		if err := c.dcgmInstance.AddFieldsToWatch(utilizationFields); err != nil {
 			log.Logger.Warnw("failed to register utilization fields", "error", err)
 		} else {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/field_cache.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/field_cache.go
@@ -51,7 +51,7 @@ type FieldValueCache struct {
 func NewFieldValueCache(ctx context.Context, instance Instance, pollInterval time.Duration) *FieldValueCache {
 	cctx, ccancel := context.WithCancel(ctx)
 
-	return &FieldValueCache{
+	fc := &FieldValueCache{
 		ctx:            cctx,
 		cancel:         ccancel,
 		instance:       instance,
@@ -59,6 +59,12 @@ func NewFieldValueCache(ctx context.Context, instance Instance, pollInterval tim
 		fieldGroupName: "gpud-gpu-fields",
 		pollInterval:   pollInterval,
 	}
+
+	if registrar, ok := instance.(reconnectCallbackRegistrar); ok {
+		registrar.RegisterReconnectCallback(fc.resetAfterReconnect)
+	}
+
+	return fc
 }
 
 // SetupFieldWatching creates the field group and starts DCGM watching for all registered fields.
@@ -159,11 +165,28 @@ func (fc *FieldValueCache) Start() error {
 func (fc *FieldValueCache) Stop() {
 	fc.cancel()
 
-	if fc.instance != nil && fc.instance.DCGMExists() && fc.fieldGroupID.GetHandle() != 0 {
-		if err := dcgm.FieldGroupDestroy(fc.fieldGroupID); err != nil {
+	fc.registrationMu.Lock()
+	fieldGroupID := fc.fieldGroupID
+	fc.fieldGroupID = dcgm.FieldHandle{}
+	fc.registrationMu.Unlock()
+
+	if fc.instance != nil && fc.instance.DCGMExists() && fieldGroupID.GetHandle() != 0 {
+		if err := dcgm.FieldGroupDestroy(fieldGroupID); err != nil {
 			log.Logger.Warnw("failed to destroy field group", "error", err)
 		}
 	}
+}
+
+func (fc *FieldValueCache) resetAfterReconnect() {
+	fc.registrationMu.Lock()
+	fc.fieldGroupID = dcgm.FieldHandle{}
+	fc.registrationMu.Unlock()
+
+	fc.mu.Lock()
+	fc.values = make(map[uint]map[dcgm.Short]dcgm.FieldValue_v1)
+	fc.lastError = nil
+	fc.lastUpdate = time.Time{}
+	fc.mu.Unlock()
 }
 
 func (fc *FieldValueCache) pollLoop() {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/field_cache.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/field_cache.go
@@ -40,6 +40,7 @@ type FieldValueCache struct {
 	lastError  error
 
 	fieldGroupID   dcgm.FieldHandle
+	fieldGroupName string
 	pollInterval   time.Duration
 	started        bool
 	startOnce      sync.Once
@@ -51,25 +52,38 @@ func NewFieldValueCache(ctx context.Context, instance Instance, pollInterval tim
 	cctx, ccancel := context.WithCancel(ctx)
 
 	return &FieldValueCache{
-		ctx:          cctx,
-		cancel:       ccancel,
-		instance:     instance,
-		values:       make(map[uint]map[dcgm.Short]dcgm.FieldValue_v1),
-		pollInterval: pollInterval,
+		ctx:            cctx,
+		cancel:         ccancel,
+		instance:       instance,
+		values:         make(map[uint]map[dcgm.Short]dcgm.FieldValue_v1),
+		fieldGroupName: "gpud-gpu-fields",
+		pollInterval:   pollInterval,
 	}
 }
 
 // SetupFieldWatching creates the field group and starts DCGM watching for all registered fields.
 // For tests, use SetupFieldWatchingWithName to provide a unique name.
 func (fc *FieldValueCache) SetupFieldWatching() error {
-	return fc.SetupFieldWatchingWithName("gpud-gpu-fields")
+	return fc.SetupFieldWatchingWithName(fc.fieldGroupName)
 }
 
 // SetupFieldWatchingWithName creates the field group with a custom name.
 // This is useful for tests to avoid naming conflicts when running in parallel.
 func (fc *FieldValueCache) SetupFieldWatchingWithName(fieldGroupName string) error {
+	fc.mu.Lock()
+	fc.fieldGroupName = fieldGroupName
+	fc.mu.Unlock()
+
+	return fc.ensureFieldWatchingSetup()
+}
+
+func (fc *FieldValueCache) ensureFieldWatchingSetup() error {
 	fc.registrationMu.Lock()
 	defer fc.registrationMu.Unlock()
+
+	if fc.fieldGroupID.GetHandle() != 0 {
+		return nil
+	}
 
 	if fc.instance == nil || !fc.instance.DCGMExists() {
 		log.Logger.Debugw("DCGM not available, skipping field watching setup")
@@ -81,6 +95,10 @@ func (fc *FieldValueCache) SetupFieldWatchingWithName(fieldGroupName string) err
 		log.Logger.Debugw("no fields registered, skipping field watching setup")
 		return nil
 	}
+
+	fc.mu.RLock()
+	fieldGroupName := fc.fieldGroupName
+	fc.mu.RUnlock()
 
 	fieldGroupID, err := dcgm.FieldGroupCreate(fieldGroupName, watchedFields)
 	if err != nil {
@@ -122,22 +140,8 @@ func (fc *FieldValueCache) Start() error {
 	var startErr error
 	fc.startOnce.Do(func() {
 		fc.registrationMu.Lock()
-		defer fc.registrationMu.Unlock()
-
-		if fc.instance == nil || !fc.instance.DCGMExists() {
-			log.Logger.Debugw("no fields or DCGM unavailable, skipping polling")
-			fc.started = true
-			return
-		}
-
-		watchedFields := fc.instance.GetWatchedFields()
-		if len(watchedFields) == 0 {
-			log.Logger.Debugw("no fields or DCGM unavailable, skipping polling")
-			fc.started = true
-			return
-		}
-
 		fc.started = true
+		fc.registrationMu.Unlock()
 
 		if err := fc.Poll(); err != nil {
 			log.Logger.Warnw("initial poll failed", "error", err)
@@ -145,7 +149,7 @@ func (fc *FieldValueCache) Start() error {
 
 		go fc.pollLoop()
 
-		log.Logger.Infow("field cache polling started", "interval", fc.pollInterval, "fields", len(watchedFields))
+		log.Logger.Infow("field cache polling started", "interval", fc.pollInterval)
 	})
 
 	return startErr
@@ -185,12 +189,19 @@ func (fc *FieldValueCache) Poll() error {
 	}
 
 	if !fc.instance.DCGMExists() {
-		return fmt.Errorf("DCGM library not loaded")
+		// DCGM may become available after startup; keep polling until it is ready.
+		log.Logger.Debugw("DCGM not available yet, skipping field poll")
+		return nil
+	}
+
+	if err := fc.ensureFieldWatchingSetup(); err != nil {
+		return err
 	}
 
 	watchedFields := fc.instance.GetWatchedFields()
 	if len(watchedFields) == 0 {
-		return fmt.Errorf("no fields to watch")
+		log.Logger.Debugw("no fields registered with DCGM, skipping field poll")
+		return nil
 	}
 
 	devices := fc.instance.GetDevices()

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/field_cache_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/field_cache_test.go
@@ -87,6 +87,30 @@ func TestFieldValueCache_SetupWithNoFields(t *testing.T) {
 	assert.NoError(t, err, "setup with no fields should return nil")
 }
 
+func TestFieldValueCache_ResetAfterReconnectCallback(t *testing.T) {
+	ctx := context.Background()
+	mockInstance := &mockReconnectRegistrarInstance{
+		mockDCGMInstance: mockDCGMInstance{dcgmExists: true},
+	}
+
+	fc := NewFieldValueCache(ctx, mockInstance, time.Second)
+	assert.NotNil(t, mockInstance.callback, "reconnect callback should be registered")
+
+	fc.mu.Lock()
+	fc.lastError = assert.AnError
+	fc.lastUpdate = time.Now()
+	fc.values[1] = map[dcgm.Short]dcgm.FieldValue_v1{}
+	fc.mu.Unlock()
+
+	mockInstance.callback()
+
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	assert.Nil(t, fc.lastError, "callback should clear cached errors")
+	assert.True(t, fc.lastUpdate.IsZero(), "callback should reset last update timestamp")
+	assert.Empty(t, fc.values, "callback should clear cached values")
+}
+
 // mockDCGMInstance is a minimal mock for testing field cache behavior
 type mockDCGMInstance struct {
 	dcgmExists bool
@@ -139,4 +163,13 @@ func (m *mockDCGMInstance) GetDevices() []DeviceInfo {
 
 func (m *mockDCGMInstance) Shutdown() error {
 	return nil
+}
+
+type mockReconnectRegistrarInstance struct {
+	mockDCGMInstance
+	callback func()
+}
+
+func (m *mockReconnectRegistrarInstance) RegisterReconnectCallback(callback func()) {
+	m.callback = callback
 }

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/health_cache.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/health_cache.go
@@ -17,6 +17,7 @@ package dcgm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -26,6 +27,8 @@ import (
 
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 )
+
+var errTransientGroupNotReady = errors.New("dcgm group handle not ready")
 
 // HealthCache manages a shared cache of DCGM health check results.
 // It polls DCGM health status in the background and provides cached results
@@ -135,7 +138,7 @@ func (hc *HealthCache) Poll() error {
 		}
 
 		// Check if this is a transient error (benign, don't store)
-		if IsTransientError(err) {
+		if errors.Is(err, errTransientGroupNotReady) || IsTransientError(err) {
 			log.Logger.Infow("DCGM transient error, will retry",
 				"component", "health_cache",
 				"error", err)
@@ -258,7 +261,7 @@ func (hc *HealthCache) GetLastUpdateTime() time.Time {
 func healthCheckDirect(inst Instance) (*dcgm.HealthResponse, error) {
 	groupHandle := inst.GetGroupHandle()
 	if groupHandle.GetHandle() == 0 {
-		return nil, fmt.Errorf("DCGM group handle is not initialized")
+		return nil, fmt.Errorf("%w: DCGM group handle is not initialized", errTransientGroupNotReady)
 	}
 
 	// Call DCGM health check directly on the group

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/health_cache.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/health_cache.go
@@ -113,7 +113,10 @@ func (hc *HealthCache) Poll() error {
 	}
 
 	if !hc.instance.DCGMExists() {
-		return fmt.Errorf("DCGM library not loaded")
+		// DCGM may become available after startup (e.g., hostengine warmup).
+		// Keep polling so the cache can recover automatically.
+		log.Logger.Debugw("DCGM not available yet, skipping health check poll")
+		return nil
 	}
 
 	// Perform health check on the group
@@ -253,14 +256,13 @@ func (hc *HealthCache) GetLastUpdateTime() time.Time {
 // This is a helper to access the underlying DCGM API without going through
 // the instance's own caching layer.
 func healthCheckDirect(inst Instance) (*dcgm.HealthResponse, error) {
-	// Type assert to get access to the internal instance
-	internalInst, ok := inst.(*instance)
-	if !ok {
-		return nil, fmt.Errorf("instance is not a *instance type")
+	groupHandle := inst.GetGroupHandle()
+	if groupHandle.GetHandle() == 0 {
+		return nil, fmt.Errorf("DCGM group handle is not initialized")
 	}
 
 	// Call DCGM health check directly on the group
-	healthResp, err := dcgm.HealthCheck(internalInst.groupHandle)
+	healthResp, err := dcgm.HealthCheck(groupHandle)
 	if err != nil {
 		return nil, fmt.Errorf("failed to perform DCGM health check: %w", err)
 	}

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/health_cache_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/health_cache_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dcgm
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+)
+
+func TestHealthCheckDirectGroupHandleNotReadyIsTransient(t *testing.T) {
+	inst := &healthCacheMockInstance{
+		dcgmExists:   true,
+		groupHandle:  dcgm.GroupHandle{},
+		watchedField: []dcgm.Short{},
+	}
+
+	_, err := healthCheckDirect(inst)
+	if err == nil {
+		t.Fatalf("expected error for uninitialized group handle")
+	}
+	if !errors.Is(err, errTransientGroupNotReady) {
+		t.Fatalf("expected transient group-not-ready error, got: %v", err)
+	}
+}
+
+func TestHealthCachePollSkipsUninitializedGroupHandle(t *testing.T) {
+	hc := NewHealthCache(
+		context.Background(),
+		&healthCacheMockInstance{
+			dcgmExists:   true,
+			groupHandle:  dcgm.GroupHandle{},
+			watchedField: []dcgm.Short{},
+		},
+		time.Second,
+	)
+
+	if err := hc.Poll(); err != nil {
+		t.Fatalf("Poll() should treat uninitialized group handle as transient, got: %v", err)
+	}
+
+	_, _, err := hc.GetResult(dcgm.DCGM_HEALTH_WATCH_PCIE)
+	if err != nil {
+		t.Fatalf("GetResult() should not expose transient group-not-ready as lastError, got: %v", err)
+	}
+}
+
+type healthCacheMockInstance struct {
+	dcgmExists   bool
+	groupHandle  dcgm.GroupHandle
+	watchedField []dcgm.Short
+}
+
+func (m *healthCacheMockInstance) DCGMExists() bool { return m.dcgmExists }
+
+func (m *healthCacheMockInstance) AddEntityToGroup(entityID uint) error { return nil }
+
+func (m *healthCacheMockInstance) AddHealthWatch(system dcgm.HealthSystem) error { return nil }
+
+func (m *healthCacheMockInstance) RemoveHealthWatch(system dcgm.HealthSystem) error { return nil }
+
+func (m *healthCacheMockInstance) HealthCheck(system dcgm.HealthSystem) (dcgm.HealthResult, []dcgm.Incident, error) {
+	return dcgm.DCGM_HEALTH_RESULT_PASS, nil, nil
+}
+
+func (m *healthCacheMockInstance) AddFieldsToWatch(fields []dcgm.Short) error {
+	m.watchedField = append(m.watchedField, fields...)
+	return nil
+}
+
+func (m *healthCacheMockInstance) GetWatchedFields() []dcgm.Short {
+	fieldsCopy := make([]dcgm.Short, len(m.watchedField))
+	copy(fieldsCopy, m.watchedField)
+	return fieldsCopy
+}
+
+func (m *healthCacheMockInstance) RemoveFieldsFromWatch(fields []dcgm.Short) error { return nil }
+
+func (m *healthCacheMockInstance) GetLatestValuesForFields(deviceID uint, fields []dcgm.Short) ([]dcgm.FieldValue_v1, error) {
+	return nil, nil
+}
+
+func (m *healthCacheMockInstance) GetGroupHandle() dcgm.GroupHandle { return m.groupHandle }
+
+func (m *healthCacheMockInstance) GetDevices() []DeviceInfo { return nil }
+
+func (m *healthCacheMockInstance) Shutdown() error { return nil }

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -159,6 +159,10 @@ type Instance interface {
 	Shutdown() error
 }
 
+type reconnectCallbackRegistrar interface {
+	RegisterReconnectCallback(callback func())
+}
+
 var newInstanceFunc = newInitializedInstance
 
 // New creates a DCGM instance. Returns no-op instance if DCGM is unavailable.
@@ -466,12 +470,14 @@ func (inst *instance) Shutdown() error {
 var _ Instance = &reconnectingInstance{}
 
 type reconnectingInstance struct {
-	mu sync.RWMutex
+	stateMu   sync.RWMutex
+	currentMu sync.RWMutex
 
 	current        Instance
 	watchedSystems dcgm.HealthSystem
 	watchedFields  map[dcgm.Short]struct{}
 	groupEntities  map[uint]struct{}
+	callbacks      []func()
 
 	reconnectInterval time.Duration
 	stopCh            chan struct{}
@@ -539,10 +545,12 @@ func (inst *reconnectingInstance) reconnectNow() error {
 		return err
 	}
 
-	inst.mu.Lock()
+	inst.currentMu.Lock()
 	previousInst := inst.current
 	inst.current = connectedInst
-	inst.mu.Unlock()
+	inst.currentMu.Unlock()
+
+	inst.runReconnectCallbacks()
 
 	if previousInst != nil {
 		_ = previousInst.Shutdown()
@@ -553,7 +561,7 @@ func (inst *reconnectingInstance) reconnectNow() error {
 }
 
 func (inst *reconnectingInstance) replayState(connectedInst Instance) error {
-	inst.mu.RLock()
+	inst.stateMu.RLock()
 	groupEntities := make([]uint, 0, len(inst.groupEntities))
 	for entityID := range inst.groupEntities {
 		groupEntities = append(groupEntities, entityID)
@@ -565,7 +573,7 @@ func (inst *reconnectingInstance) replayState(connectedInst Instance) error {
 	for fieldID := range inst.watchedFields {
 		watchedFields = append(watchedFields, fieldID)
 	}
-	inst.mu.RUnlock()
+	inst.stateMu.RUnlock()
 
 	for _, entityID := range groupEntities {
 		if err := connectedInst.AddEntityToGroup(entityID); err != nil {
@@ -588,14 +596,30 @@ func (inst *reconnectingInstance) replayState(connectedInst Instance) error {
 	return nil
 }
 
-func (inst *reconnectingInstance) getCurrent() Instance {
-	inst.mu.RLock()
-	defer inst.mu.RUnlock()
-	return inst.current
+func (inst *reconnectingInstance) RegisterReconnectCallback(callback func()) {
+	if callback == nil {
+		return
+	}
+	inst.stateMu.Lock()
+	inst.callbacks = append(inst.callbacks, callback)
+	inst.stateMu.Unlock()
+}
+
+func (inst *reconnectingInstance) runReconnectCallbacks() {
+	inst.stateMu.RLock()
+	callbacks := make([]func(), len(inst.callbacks))
+	copy(callbacks, inst.callbacks)
+	inst.stateMu.RUnlock()
+
+	for _, callback := range callbacks {
+		callback()
+	}
 }
 
 func (inst *reconnectingInstance) DCGMExists() bool {
-	currentInst := inst.getCurrent()
+	inst.currentMu.RLock()
+	currentInst := inst.current
+	defer inst.currentMu.RUnlock()
 	if currentInst == nil {
 		return false
 	}
@@ -603,11 +627,13 @@ func (inst *reconnectingInstance) DCGMExists() bool {
 }
 
 func (inst *reconnectingInstance) AddEntityToGroup(entityID uint) error {
-	inst.mu.Lock()
+	inst.stateMu.Lock()
 	inst.groupEntities[entityID] = struct{}{}
-	currentInst := inst.current
-	inst.mu.Unlock()
+	inst.stateMu.Unlock()
 
+	inst.currentMu.RLock()
+	currentInst := inst.current
+	defer inst.currentMu.RUnlock()
 	if currentInst != nil && currentInst.DCGMExists() {
 		return currentInst.AddEntityToGroup(entityID)
 	}
@@ -615,11 +641,13 @@ func (inst *reconnectingInstance) AddEntityToGroup(entityID uint) error {
 }
 
 func (inst *reconnectingInstance) AddHealthWatch(system dcgm.HealthSystem) error {
-	inst.mu.Lock()
+	inst.stateMu.Lock()
 	inst.watchedSystems |= system
-	currentInst := inst.current
-	inst.mu.Unlock()
+	inst.stateMu.Unlock()
 
+	inst.currentMu.RLock()
+	currentInst := inst.current
+	defer inst.currentMu.RUnlock()
 	if currentInst != nil && currentInst.DCGMExists() {
 		return currentInst.AddHealthWatch(system)
 	}
@@ -627,11 +655,13 @@ func (inst *reconnectingInstance) AddHealthWatch(system dcgm.HealthSystem) error
 }
 
 func (inst *reconnectingInstance) RemoveHealthWatch(system dcgm.HealthSystem) error {
-	inst.mu.Lock()
+	inst.stateMu.Lock()
 	inst.watchedSystems &^= system
-	currentInst := inst.current
-	inst.mu.Unlock()
+	inst.stateMu.Unlock()
 
+	inst.currentMu.RLock()
+	currentInst := inst.current
+	defer inst.currentMu.RUnlock()
 	if currentInst != nil && currentInst.DCGMExists() {
 		return currentInst.RemoveHealthWatch(system)
 	}
@@ -639,7 +669,9 @@ func (inst *reconnectingInstance) RemoveHealthWatch(system dcgm.HealthSystem) er
 }
 
 func (inst *reconnectingInstance) HealthCheck(system dcgm.HealthSystem) (dcgm.HealthResult, []dcgm.Incident, error) {
-	currentInst := inst.getCurrent()
+	inst.currentMu.RLock()
+	currentInst := inst.current
+	defer inst.currentMu.RUnlock()
 	if currentInst == nil {
 		return dcgm.DCGM_HEALTH_RESULT_PASS, nil, nil
 	}
@@ -647,13 +679,15 @@ func (inst *reconnectingInstance) HealthCheck(system dcgm.HealthSystem) (dcgm.He
 }
 
 func (inst *reconnectingInstance) AddFieldsToWatch(fields []dcgm.Short) error {
-	inst.mu.Lock()
+	inst.stateMu.Lock()
 	for _, field := range fields {
 		inst.watchedFields[field] = struct{}{}
 	}
-	currentInst := inst.current
-	inst.mu.Unlock()
+	inst.stateMu.Unlock()
 
+	inst.currentMu.RLock()
+	currentInst := inst.current
+	defer inst.currentMu.RUnlock()
 	if currentInst != nil && currentInst.DCGMExists() {
 		return currentInst.AddFieldsToWatch(fields)
 	}
@@ -661,8 +695,8 @@ func (inst *reconnectingInstance) AddFieldsToWatch(fields []dcgm.Short) error {
 }
 
 func (inst *reconnectingInstance) GetWatchedFields() []dcgm.Short {
-	inst.mu.RLock()
-	defer inst.mu.RUnlock()
+	inst.stateMu.RLock()
+	defer inst.stateMu.RUnlock()
 
 	fields := make([]dcgm.Short, 0, len(inst.watchedFields))
 	for fieldID := range inst.watchedFields {
@@ -673,13 +707,15 @@ func (inst *reconnectingInstance) GetWatchedFields() []dcgm.Short {
 }
 
 func (inst *reconnectingInstance) RemoveFieldsFromWatch(fields []dcgm.Short) error {
-	inst.mu.Lock()
+	inst.stateMu.Lock()
 	for _, field := range fields {
 		delete(inst.watchedFields, field)
 	}
-	currentInst := inst.current
-	inst.mu.Unlock()
+	inst.stateMu.Unlock()
 
+	inst.currentMu.RLock()
+	currentInst := inst.current
+	defer inst.currentMu.RUnlock()
 	if currentInst != nil && currentInst.DCGMExists() {
 		return currentInst.RemoveFieldsFromWatch(fields)
 	}
@@ -687,7 +723,9 @@ func (inst *reconnectingInstance) RemoveFieldsFromWatch(fields []dcgm.Short) err
 }
 
 func (inst *reconnectingInstance) GetLatestValuesForFields(deviceID uint, fields []dcgm.Short) ([]dcgm.FieldValue_v1, error) {
-	currentInst := inst.getCurrent()
+	inst.currentMu.RLock()
+	currentInst := inst.current
+	defer inst.currentMu.RUnlock()
 	if currentInst == nil {
 		return nil, fmt.Errorf("DCGM is not available")
 	}
@@ -695,7 +733,9 @@ func (inst *reconnectingInstance) GetLatestValuesForFields(deviceID uint, fields
 }
 
 func (inst *reconnectingInstance) GetGroupHandle() dcgm.GroupHandle {
-	currentInst := inst.getCurrent()
+	inst.currentMu.RLock()
+	currentInst := inst.current
+	defer inst.currentMu.RUnlock()
 	if currentInst == nil {
 		return dcgm.GroupHandle{}
 	}
@@ -703,7 +743,9 @@ func (inst *reconnectingInstance) GetGroupHandle() dcgm.GroupHandle {
 }
 
 func (inst *reconnectingInstance) GetDevices() []DeviceInfo {
-	currentInst := inst.getCurrent()
+	inst.currentMu.RLock()
+	currentInst := inst.current
+	defer inst.currentMu.RUnlock()
 	if currentInst == nil {
 		return nil
 	}
@@ -715,7 +757,11 @@ func (inst *reconnectingInstance) Shutdown() error {
 	inst.shutdownOnce.Do(func() {
 		close(inst.stopCh)
 
-		currentInst := inst.getCurrent()
+		inst.currentMu.Lock()
+		currentInst := inst.current
+		inst.current = nil
+		inst.currentMu.Unlock()
+
 		if currentInst != nil {
 			shutdownErr = currentInst.Shutdown()
 		}

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -17,6 +17,7 @@ package dcgm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -34,6 +35,7 @@ var _ Instance = &instance{}
 const defaultDCGMReconnectInterval = 30 * time.Second
 
 var dcgmReconnectInterval = defaultDCGMReconnectInterval
+var errReconnectAborted = errors.New("dcgm reconnect aborted")
 
 // dcgmInitParams defines how we initialize the go-dcgm client.
 type dcgmInitParams struct {
@@ -199,10 +201,20 @@ func NewWithContext(ctx context.Context) (Instance, error) {
 		if res.err != nil {
 			return nil, res.err
 		}
+		if res.inst == nil || !res.inst.DCGMExists() {
+			log.Logger.Warnw(
+				"DCGM not available at startup; continuing with no-op instance and retrying in background until DCGM is up",
+				"retryInterval", dcgmReconnectInterval.String(),
+			)
+		}
 		return newReconnectingInstance(res.inst, dcgmReconnectInterval), nil
 	case <-ctx.Done():
 		close(abandonCh)
-		log.Logger.Warnw("DCGM initialization timed out, returning no-op instance", "error", ctx.Err())
+		log.Logger.Warnw(
+			"DCGM initialization timed out; continuing with no-op instance and retrying in background until DCGM is up",
+			"error", ctx.Err(),
+			"retryInterval", dcgmReconnectInterval.String(),
+		)
 		return newReconnectingInstance(NewNoOp(), dcgmReconnectInterval), nil
 	}
 }
@@ -472,16 +484,27 @@ var _ Instance = &reconnectingInstance{}
 type reconnectingInstance struct {
 	stateMu   sync.RWMutex
 	currentMu sync.RWMutex
+	// reconnectMu serializes reconnect and shutdown transitions.
+	// Long-running connect operations happen outside this lock.
+	reconnectMu sync.Mutex
 
 	current        Instance
 	watchedSystems dcgm.HealthSystem
 	watchedFields  map[dcgm.Short]struct{}
 	groupEntities  map[uint]struct{}
 	callbacks      []func()
+	shuttingDown   bool
+	generation     uint64
 
 	reconnectInterval time.Duration
 	stopCh            chan struct{}
 	shutdownOnce      sync.Once
+}
+
+type reconnectStateSnapshot struct {
+	groupEntities  []uint
+	watchedSystems dcgm.HealthSystem
+	watchedFields  []dcgm.Short
 }
 
 func newReconnectingInstance(initial Instance, reconnectInterval time.Duration) Instance {
@@ -510,9 +533,21 @@ func newReconnectingInstance(initial Instance, reconnectInterval time.Duration) 
 }
 
 func (inst *reconnectingInstance) reconnectLoop() {
+	retryAttempt := 0
+
 	if !inst.DCGMExists() {
+		log.Logger.Infow("DCGM unavailable, starting background reconnect loop", "retryInterval", inst.reconnectInterval.String())
 		if err := inst.reconnectNow(); err != nil {
-			log.Logger.Debugw("initial DCGM reconnect attempt failed", "error", err)
+			if errors.Is(err, errReconnectAborted) {
+				return
+			}
+			retryAttempt++
+			log.Logger.Infow(
+				"DCGM reconnect attempt failed, will retry",
+				"attempt", retryAttempt,
+				"retryInterval", inst.reconnectInterval.String(),
+				"error", err,
+			)
 		}
 	}
 
@@ -528,19 +563,50 @@ func (inst *reconnectingInstance) reconnectLoop() {
 				continue
 			}
 			if err := inst.reconnectNow(); err != nil {
-				log.Logger.Debugw("DCGM reconnect attempt failed", "error", err)
+				if errors.Is(err, errReconnectAborted) {
+					return
+				}
+				retryAttempt++
+				log.Logger.Infow(
+					"DCGM reconnect attempt failed, will retry",
+					"attempt", retryAttempt,
+					"retryInterval", inst.reconnectInterval.String(),
+					"error", err,
+				)
+				continue
 			}
+			retryAttempt = 0
 		}
 	}
 }
 
 func (inst *reconnectingInstance) reconnectNow() error {
+	inst.reconnectMu.Lock()
+	if inst.shuttingDown {
+		inst.reconnectMu.Unlock()
+		return errReconnectAborted
+	}
+	expectedGeneration := inst.generation
+	inst.reconnectMu.Unlock()
+
 	connectedInst, err := newConnectedInstanceFunc()
 	if err != nil {
 		return err
 	}
 
-	if err := inst.replayState(connectedInst); err != nil {
+	inst.reconnectMu.Lock()
+	defer inst.reconnectMu.Unlock()
+	if inst.shuttingDown || inst.generation != expectedGeneration {
+		_ = connectedInst.Shutdown()
+		return errReconnectAborted
+	}
+
+	// Hold stateMu through replay + current swap so newly-registered watches/fields/entities
+	// cannot slip in between snapshot and swap and get lost on the newly connected instance.
+	inst.stateMu.Lock()
+	snapshot := inst.snapshotStateLocked()
+	if err := inst.replayState(connectedInst, snapshot); err != nil {
+		inst.stateMu.Unlock()
 		_ = connectedInst.Shutdown()
 		return err
 	}
@@ -549,6 +615,7 @@ func (inst *reconnectingInstance) reconnectNow() error {
 	previousInst := inst.current
 	inst.current = connectedInst
 	inst.currentMu.Unlock()
+	inst.stateMu.Unlock()
 
 	inst.runReconnectCallbacks()
 
@@ -560,8 +627,7 @@ func (inst *reconnectingInstance) reconnectNow() error {
 	return nil
 }
 
-func (inst *reconnectingInstance) replayState(connectedInst Instance) error {
-	inst.stateMu.RLock()
+func (inst *reconnectingInstance) snapshotStateLocked() reconnectStateSnapshot {
 	groupEntities := make([]uint, 0, len(inst.groupEntities))
 	for entityID := range inst.groupEntities {
 		groupEntities = append(groupEntities, entityID)
@@ -573,7 +639,18 @@ func (inst *reconnectingInstance) replayState(connectedInst Instance) error {
 	for fieldID := range inst.watchedFields {
 		watchedFields = append(watchedFields, fieldID)
 	}
-	inst.stateMu.RUnlock()
+
+	return reconnectStateSnapshot{
+		groupEntities:  groupEntities,
+		watchedSystems: watchedSystems,
+		watchedFields:  watchedFields,
+	}
+}
+
+func (inst *reconnectingInstance) replayState(connectedInst Instance, snapshot reconnectStateSnapshot) error {
+	groupEntities := snapshot.groupEntities
+	watchedSystems := snapshot.watchedSystems
+	watchedFields := snapshot.watchedFields
 
 	for _, entityID := range groupEntities {
 		if err := connectedInst.AddEntityToGroup(entityID); err != nil {
@@ -755,6 +832,9 @@ func (inst *reconnectingInstance) GetDevices() []DeviceInfo {
 func (inst *reconnectingInstance) Shutdown() error {
 	var shutdownErr error
 	inst.shutdownOnce.Do(func() {
+		inst.reconnectMu.Lock()
+		inst.shuttingDown = true
+		inst.generation++
 		close(inst.stopCh)
 
 		inst.currentMu.Lock()
@@ -765,6 +845,7 @@ func (inst *reconnectingInstance) Shutdown() error {
 		if currentInst != nil {
 			shutdownErr = currentInst.Shutdown()
 		}
+		inst.reconnectMu.Unlock()
 	})
 	return shutdownErr
 }

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
 
@@ -29,6 +30,10 @@ import (
 )
 
 var _ Instance = &instance{}
+
+const defaultDCGMReconnectInterval = 30 * time.Second
+
+var dcgmReconnectInterval = defaultDCGMReconnectInterval
 
 // dcgmInitParams defines how we initialize the go-dcgm client.
 type dcgmInitParams struct {
@@ -187,21 +192,36 @@ func NewWithContext(ctx context.Context) (Instance, error) {
 
 	select {
 	case res := <-resultCh:
-		return res.inst, res.err
+		if res.err != nil {
+			return nil, res.err
+		}
+		return newReconnectingInstance(res.inst, dcgmReconnectInterval), nil
 	case <-ctx.Done():
 		close(abandonCh)
 		log.Logger.Warnw("DCGM initialization timed out, returning no-op instance", "error", ctx.Err())
-		return NewNoOp(), nil
+		return newReconnectingInstance(NewNoOp(), dcgmReconnectInterval), nil
 	}
 }
 
+var newConnectedInstanceFunc = func() (Instance, error) {
+	return newConnectedInstance()
+}
+
 func newInitializedInstance() (Instance, error) {
+	connectedInst, err := newConnectedInstanceFunc()
+	if err != nil {
+		log.Logger.Warnw("DCGM initialization failed, returning no-op instance", "error", err)
+		return NewNoOp(), nil
+	}
+	return connectedInst, nil
+}
+
+func newConnectedInstance() (Instance, error) {
 	initParams := resolveInitFromEnv()
 
 	cleanup, err := dcgm.Init(dcgm.Standalone, initParams.address, initParams.isUnixSocket)
 	if err != nil {
-		log.Logger.Warnw("DCGM initialization failed, returning no-op instance", "error", err)
-		return NewNoOp(), nil
+		return nil, err
 	}
 
 	log.Logger.Debugw("DCGM initialized successfully")
@@ -238,14 +258,14 @@ func newInitializedInstance() (Instance, error) {
 		log.Logger.Infow("cached device information", "numDevices", len(devices))
 	}
 
-	inst := &instance{
+	connectedInst := &instance{
 		dcgmExists:  true,
 		groupHandle: groupHandle,
 		cleanup:     cleanup,
 		devices:     devices,
 	}
 
-	return inst, nil
+	return connectedInst, nil
 }
 
 var _ Instance = &instance{}
@@ -441,6 +461,266 @@ func (inst *instance) Shutdown() error {
 		inst.cleanup()
 	}
 	return nil
+}
+
+var _ Instance = &reconnectingInstance{}
+
+type reconnectingInstance struct {
+	mu sync.RWMutex
+
+	current        Instance
+	watchedSystems dcgm.HealthSystem
+	watchedFields  map[dcgm.Short]struct{}
+	groupEntities  map[uint]struct{}
+
+	reconnectInterval time.Duration
+	stopCh            chan struct{}
+	shutdownOnce      sync.Once
+}
+
+func newReconnectingInstance(initial Instance, reconnectInterval time.Duration) Instance {
+	if initial == nil {
+		initial = NewNoOp()
+	}
+	if reconnectInterval <= 0 {
+		reconnectInterval = defaultDCGMReconnectInterval
+	}
+
+	inst := &reconnectingInstance{
+		current:           initial,
+		watchedFields:     make(map[dcgm.Short]struct{}),
+		groupEntities:     make(map[uint]struct{}),
+		reconnectInterval: reconnectInterval,
+		stopCh:            make(chan struct{}),
+	}
+
+	for _, field := range initial.GetWatchedFields() {
+		inst.watchedFields[field] = struct{}{}
+	}
+
+	go inst.reconnectLoop()
+
+	return inst
+}
+
+func (inst *reconnectingInstance) reconnectLoop() {
+	if !inst.DCGMExists() {
+		if err := inst.reconnectNow(); err != nil {
+			log.Logger.Debugw("initial DCGM reconnect attempt failed", "error", err)
+		}
+	}
+
+	ticker := time.NewTicker(inst.reconnectInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-inst.stopCh:
+			return
+		case <-ticker.C:
+			if inst.DCGMExists() {
+				continue
+			}
+			if err := inst.reconnectNow(); err != nil {
+				log.Logger.Debugw("DCGM reconnect attempt failed", "error", err)
+			}
+		}
+	}
+}
+
+func (inst *reconnectingInstance) reconnectNow() error {
+	connectedInst, err := newConnectedInstanceFunc()
+	if err != nil {
+		return err
+	}
+
+	if err := inst.replayState(connectedInst); err != nil {
+		_ = connectedInst.Shutdown()
+		return err
+	}
+
+	inst.mu.Lock()
+	previousInst := inst.current
+	inst.current = connectedInst
+	inst.mu.Unlock()
+
+	if previousInst != nil {
+		_ = previousInst.Shutdown()
+	}
+
+	log.Logger.Infow("DCGM reconnected successfully")
+	return nil
+}
+
+func (inst *reconnectingInstance) replayState(connectedInst Instance) error {
+	inst.mu.RLock()
+	groupEntities := make([]uint, 0, len(inst.groupEntities))
+	for entityID := range inst.groupEntities {
+		groupEntities = append(groupEntities, entityID)
+	}
+
+	watchedSystems := inst.watchedSystems
+
+	watchedFields := make([]dcgm.Short, 0, len(inst.watchedFields))
+	for fieldID := range inst.watchedFields {
+		watchedFields = append(watchedFields, fieldID)
+	}
+	inst.mu.RUnlock()
+
+	for _, entityID := range groupEntities {
+		if err := connectedInst.AddEntityToGroup(entityID); err != nil {
+			return fmt.Errorf("failed to replay DCGM entity group state for entity %d: %w", entityID, err)
+		}
+	}
+
+	if watchedSystems != 0 {
+		if err := connectedInst.AddHealthWatch(watchedSystems); err != nil {
+			return fmt.Errorf("failed to replay DCGM health watch state: %w", err)
+		}
+	}
+
+	if len(watchedFields) > 0 {
+		if err := connectedInst.AddFieldsToWatch(watchedFields); err != nil {
+			return fmt.Errorf("failed to replay DCGM watched fields state: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (inst *reconnectingInstance) getCurrent() Instance {
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	return inst.current
+}
+
+func (inst *reconnectingInstance) DCGMExists() bool {
+	currentInst := inst.getCurrent()
+	if currentInst == nil {
+		return false
+	}
+	return currentInst.DCGMExists()
+}
+
+func (inst *reconnectingInstance) AddEntityToGroup(entityID uint) error {
+	inst.mu.Lock()
+	inst.groupEntities[entityID] = struct{}{}
+	currentInst := inst.current
+	inst.mu.Unlock()
+
+	if currentInst != nil && currentInst.DCGMExists() {
+		return currentInst.AddEntityToGroup(entityID)
+	}
+	return nil
+}
+
+func (inst *reconnectingInstance) AddHealthWatch(system dcgm.HealthSystem) error {
+	inst.mu.Lock()
+	inst.watchedSystems |= system
+	currentInst := inst.current
+	inst.mu.Unlock()
+
+	if currentInst != nil && currentInst.DCGMExists() {
+		return currentInst.AddHealthWatch(system)
+	}
+	return nil
+}
+
+func (inst *reconnectingInstance) RemoveHealthWatch(system dcgm.HealthSystem) error {
+	inst.mu.Lock()
+	inst.watchedSystems &^= system
+	currentInst := inst.current
+	inst.mu.Unlock()
+
+	if currentInst != nil && currentInst.DCGMExists() {
+		return currentInst.RemoveHealthWatch(system)
+	}
+	return nil
+}
+
+func (inst *reconnectingInstance) HealthCheck(system dcgm.HealthSystem) (dcgm.HealthResult, []dcgm.Incident, error) {
+	currentInst := inst.getCurrent()
+	if currentInst == nil {
+		return dcgm.DCGM_HEALTH_RESULT_PASS, nil, nil
+	}
+	return currentInst.HealthCheck(system)
+}
+
+func (inst *reconnectingInstance) AddFieldsToWatch(fields []dcgm.Short) error {
+	inst.mu.Lock()
+	for _, field := range fields {
+		inst.watchedFields[field] = struct{}{}
+	}
+	currentInst := inst.current
+	inst.mu.Unlock()
+
+	if currentInst != nil && currentInst.DCGMExists() {
+		return currentInst.AddFieldsToWatch(fields)
+	}
+	return nil
+}
+
+func (inst *reconnectingInstance) GetWatchedFields() []dcgm.Short {
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+
+	fields := make([]dcgm.Short, 0, len(inst.watchedFields))
+	for fieldID := range inst.watchedFields {
+		fields = append(fields, fieldID)
+	}
+
+	return fields
+}
+
+func (inst *reconnectingInstance) RemoveFieldsFromWatch(fields []dcgm.Short) error {
+	inst.mu.Lock()
+	for _, field := range fields {
+		delete(inst.watchedFields, field)
+	}
+	currentInst := inst.current
+	inst.mu.Unlock()
+
+	if currentInst != nil && currentInst.DCGMExists() {
+		return currentInst.RemoveFieldsFromWatch(fields)
+	}
+	return nil
+}
+
+func (inst *reconnectingInstance) GetLatestValuesForFields(deviceID uint, fields []dcgm.Short) ([]dcgm.FieldValue_v1, error) {
+	currentInst := inst.getCurrent()
+	if currentInst == nil {
+		return nil, fmt.Errorf("DCGM is not available")
+	}
+	return currentInst.GetLatestValuesForFields(deviceID, fields)
+}
+
+func (inst *reconnectingInstance) GetGroupHandle() dcgm.GroupHandle {
+	currentInst := inst.getCurrent()
+	if currentInst == nil {
+		return dcgm.GroupHandle{}
+	}
+	return currentInst.GetGroupHandle()
+}
+
+func (inst *reconnectingInstance) GetDevices() []DeviceInfo {
+	currentInst := inst.getCurrent()
+	if currentInst == nil {
+		return nil
+	}
+	return currentInst.GetDevices()
+}
+
+func (inst *reconnectingInstance) Shutdown() error {
+	var shutdownErr error
+	inst.shutdownOnce.Do(func() {
+		close(inst.stopCh)
+
+		currentInst := inst.getCurrent()
+		if currentInst != nil {
+			shutdownErr = currentInst.Shutdown()
+		}
+	})
+	return shutdownErr
 }
 
 var _ Instance = &noOpInstance{}

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
@@ -237,6 +237,35 @@ func TestReconnectingInstanceReturnsDeferredWatchedFields(t *testing.T) {
 	}
 }
 
+func TestReconnectingInstanceInvokesReconnectCallbacks(t *testing.T) {
+	originalNewConnectedInstanceFunc := newConnectedInstanceFunc
+	defer func() {
+		newConnectedInstanceFunc = originalNewConnectedInstanceFunc
+	}()
+
+	mock := newMockTrackingInstance()
+	newConnectedInstanceFunc = func() (Instance, error) {
+		return mock, nil
+	}
+
+	reconnectingInst := newReconnectingInstance(NewNoOp(), time.Hour)
+	defer reconnectingInst.Shutdown()
+
+	internalInst := reconnectingInst.(*reconnectingInstance)
+	callbackCount := 0
+	internalInst.RegisterReconnectCallback(func() {
+		callbackCount++
+	})
+
+	if err := internalInst.reconnectNow(); err != nil {
+		t.Fatalf("reconnectNow() failed: %v", err)
+	}
+
+	if callbackCount != 1 {
+		t.Fatalf("expected reconnect callback to run once, got %d", callbackCount)
+	}
+}
+
 func TestNewWithContextReturnsUnderlyingError(t *testing.T) {
 	originalNewInstanceFunc := newInstanceFunc
 	defer func() {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
@@ -266,6 +266,111 @@ func TestReconnectingInstanceInvokesReconnectCallbacks(t *testing.T) {
 	}
 }
 
+func TestReconnectingInstanceDoesNotDropRegistrationsDuringReplay(t *testing.T) {
+	originalNewConnectedInstanceFunc := newConnectedInstanceFunc
+	defer func() {
+		newConnectedInstanceFunc = originalNewConnectedInstanceFunc
+	}()
+
+	mock := newBlockingReplayMockInstance()
+	newConnectedInstanceFunc = func() (Instance, error) {
+		return mock, nil
+	}
+
+	internalInst := &reconnectingInstance{
+		current:           NewNoOp(),
+		watchedFields:     make(map[dcgm.Short]struct{}),
+		groupEntities:     make(map[uint]struct{}),
+		reconnectInterval: time.Hour,
+		stopCh:            make(chan struct{}),
+	}
+	defer internalInst.Shutdown()
+
+	if err := internalInst.AddHealthWatch(dcgm.DCGM_HEALTH_WATCH_PCIE); err != nil {
+		t.Fatalf("AddHealthWatch(PCIE) failed: %v", err)
+	}
+
+	reconnectErrCh := make(chan error, 1)
+	go func() {
+		reconnectErrCh <- internalInst.reconnectNow()
+	}()
+
+	<-mock.firstAddHealthStarted
+
+	addErrCh := make(chan error, 1)
+	go func() {
+		addErrCh <- internalInst.AddHealthWatch(dcgm.DCGM_HEALTH_WATCH_THERMAL)
+	}()
+
+	select {
+	case err := <-addErrCh:
+		t.Fatalf("expected AddHealthWatch to wait for reconnect swap, got early return: %v", err)
+	case <-time.After(50 * time.Millisecond):
+		// expected: blocked until reconnect replay + swap complete
+	}
+
+	close(mock.unblockFirstAddHealth)
+
+	if err := <-reconnectErrCh; err != nil {
+		t.Fatalf("reconnectNow() failed: %v", err)
+	}
+	if err := <-addErrCh; err != nil {
+		t.Fatalf("AddHealthWatch(THERMAL) failed: %v", err)
+	}
+
+	expectedSystems := dcgm.DCGM_HEALTH_WATCH_PCIE | dcgm.DCGM_HEALTH_WATCH_THERMAL
+	if mock.watchedSystems != expectedSystems {
+		t.Fatalf("expected watched systems 0x%x after replay window, got 0x%x", expectedSystems, mock.watchedSystems)
+	}
+}
+
+func TestReconnectingInstanceAbortsInFlightReconnectOnShutdown(t *testing.T) {
+	originalNewConnectedInstanceFunc := newConnectedInstanceFunc
+	defer func() {
+		newConnectedInstanceFunc = originalNewConnectedInstanceFunc
+	}()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	mock := newMockTrackingInstance()
+	newConnectedInstanceFunc = func() (Instance, error) {
+		close(started)
+		<-release
+		return mock, nil
+	}
+
+	internalInst := &reconnectingInstance{
+		current:           NewNoOp(),
+		watchedFields:     make(map[dcgm.Short]struct{}),
+		groupEntities:     make(map[uint]struct{}),
+		reconnectInterval: time.Hour,
+		stopCh:            make(chan struct{}),
+	}
+
+	reconnectErrCh := make(chan error, 1)
+	go func() {
+		reconnectErrCh <- internalInst.reconnectNow()
+	}()
+
+	<-started
+	shutdownErr := internalInst.Shutdown()
+	if shutdownErr != nil {
+		t.Fatalf("Shutdown() failed: %v", shutdownErr)
+	}
+	close(release)
+
+	reconnectErr := <-reconnectErrCh
+	if !errors.Is(reconnectErr, errReconnectAborted) {
+		t.Fatalf("expected reconnect to abort with %v, got %v", errReconnectAborted, reconnectErr)
+	}
+
+	internalInst.currentMu.RLock()
+	defer internalInst.currentMu.RUnlock()
+	if internalInst.current != nil {
+		t.Fatalf("expected current instance to remain nil after shutdown")
+	}
+}
+
 func TestNewWithContextReturnsUnderlyingError(t *testing.T) {
 	originalNewInstanceFunc := newInstanceFunc
 	defer func() {
@@ -606,3 +711,26 @@ func (m *mockTrackingInstance) GetLatestValuesForFields(deviceID uint, fields []
 func (m *mockTrackingInstance) GetGroupHandle() dcgm.GroupHandle { return dcgm.GroupHandle{} }
 func (m *mockTrackingInstance) GetDevices() []DeviceInfo         { return nil }
 func (m *mockTrackingInstance) Shutdown() error                  { return nil }
+
+type blockingReplayMockInstance struct {
+	*mockTrackingInstance
+	firstAddHealthStarted chan struct{}
+	unblockFirstAddHealth chan struct{}
+	blockFirstAddHealth   sync.Once
+}
+
+func newBlockingReplayMockInstance() *blockingReplayMockInstance {
+	return &blockingReplayMockInstance{
+		mockTrackingInstance:  newMockTrackingInstance(),
+		firstAddHealthStarted: make(chan struct{}),
+		unblockFirstAddHealth: make(chan struct{}),
+	}
+}
+
+func (m *blockingReplayMockInstance) AddHealthWatch(system dcgm.HealthSystem) error {
+	m.blockFirstAddHealth.Do(func() {
+		close(m.firstAddHealthStarted)
+		<-m.unblockFirstAddHealth
+	})
+	return m.mockTrackingInstance.AddHealthWatch(system)
+}

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
@@ -130,9 +130,14 @@ func TestInstanceWhenDCGMNotAvailable(t *testing.T) {
 
 func TestNewWithContextReturnsNoOpOnTimeout(t *testing.T) {
 	originalNewInstanceFunc := newInstanceFunc
+	originalNewConnectedInstanceFunc := newConnectedInstanceFunc
 	defer func() {
 		newInstanceFunc = originalNewInstanceFunc
+		newConnectedInstanceFunc = originalNewConnectedInstanceFunc
 	}()
+	newConnectedInstanceFunc = func() (Instance, error) {
+		return nil, errors.New("dcgm unavailable for reconnect test")
+	}
 
 	blocker := make(chan struct{})
 	newInstanceFunc = func() (Instance, error) {
@@ -147,6 +152,7 @@ func TestNewWithContextReturnsNoOpOnTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewWithContext() returned error: %v", err)
 	}
+	defer inst.Shutdown()
 	if inst == nil {
 		t.Fatal("instance should not be nil")
 	}
@@ -155,6 +161,80 @@ func TestNewWithContextReturnsNoOpOnTimeout(t *testing.T) {
 	}
 
 	close(blocker)
+}
+
+func TestReconnectingInstanceReplaysDeferredState(t *testing.T) {
+	originalNewConnectedInstanceFunc := newConnectedInstanceFunc
+	defer func() {
+		newConnectedInstanceFunc = originalNewConnectedInstanceFunc
+	}()
+
+	mock := newMockTrackingInstance()
+	newConnectedInstanceFunc = func() (Instance, error) {
+		return mock, nil
+	}
+
+	reconnectingInst := newReconnectingInstance(NewNoOp(), time.Hour)
+	defer reconnectingInst.Shutdown()
+
+	if err := reconnectingInst.AddHealthWatch(dcgm.DCGM_HEALTH_WATCH_PCIE); err != nil {
+		t.Fatalf("AddHealthWatch() failed: %v", err)
+	}
+	fields := []dcgm.Short{dcgm.DCGM_FI_DEV_FB_FREE, dcgm.DCGM_FI_DEV_FB_USED}
+	if err := reconnectingInst.AddFieldsToWatch(fields); err != nil {
+		t.Fatalf("AddFieldsToWatch() failed: %v", err)
+	}
+	if err := reconnectingInst.AddEntityToGroup(3); err != nil {
+		t.Fatalf("AddEntityToGroup() failed: %v", err)
+	}
+
+	internalInst := reconnectingInst.(*reconnectingInstance)
+	if err := internalInst.reconnectNow(); err != nil {
+		t.Fatalf("reconnectNow() failed: %v", err)
+	}
+
+	if !reconnectingInst.DCGMExists() {
+		t.Fatalf("expected reconnecting instance to report DCGM available")
+	}
+	if mock.watchedSystems != dcgm.DCGM_HEALTH_WATCH_PCIE {
+		t.Fatalf("expected watched systems 0x%x, got 0x%x", dcgm.DCGM_HEALTH_WATCH_PCIE, mock.watchedSystems)
+	}
+	if _, ok := mock.entities[3]; !ok {
+		t.Fatalf("expected entity 3 to be replayed to connected instance")
+	}
+	if len(mock.watchedFields) != len(fields) {
+		t.Fatalf("expected %d watched fields, got %d", len(fields), len(mock.watchedFields))
+	}
+	for _, field := range fields {
+		if _, ok := mock.watchedFields[field]; !ok {
+			t.Fatalf("expected watched field %d to be replayed", field)
+		}
+	}
+}
+
+func TestReconnectingInstanceReturnsDeferredWatchedFields(t *testing.T) {
+	reconnectingInst := newReconnectingInstance(NewNoOp(), time.Hour)
+	defer reconnectingInst.Shutdown()
+
+	fields := []dcgm.Short{dcgm.DCGM_FI_DEV_FB_FREE, dcgm.DCGM_FI_DEV_FB_USED}
+	if err := reconnectingInst.AddFieldsToWatch(fields); err != nil {
+		t.Fatalf("AddFieldsToWatch() failed: %v", err)
+	}
+
+	gotFields := reconnectingInst.GetWatchedFields()
+	if len(gotFields) != len(fields) {
+		t.Fatalf("expected %d watched fields, got %d", len(fields), len(gotFields))
+	}
+
+	gotSet := make(map[dcgm.Short]struct{}, len(gotFields))
+	for _, field := range gotFields {
+		gotSet[field] = struct{}{}
+	}
+	for _, field := range fields {
+		if _, ok := gotSet[field]; !ok {
+			t.Fatalf("expected watched field %d in deferred state", field)
+		}
+	}
 }
 
 func TestNewWithContextReturnsUnderlyingError(t *testing.T) {
@@ -442,3 +522,58 @@ func TestHealthCheckMultipleSystems(t *testing.T) {
 		t.Logf("%s: health=%v, incidents=%d", sys.name, health, len(incidents))
 	}
 }
+
+type mockTrackingInstance struct {
+	watchedSystems dcgm.HealthSystem
+	watchedFields  map[dcgm.Short]struct{}
+	entities       map[uint]struct{}
+}
+
+func newMockTrackingInstance() *mockTrackingInstance {
+	return &mockTrackingInstance{
+		watchedFields: make(map[dcgm.Short]struct{}),
+		entities:      make(map[uint]struct{}),
+	}
+}
+
+func (m *mockTrackingInstance) DCGMExists() bool { return true }
+func (m *mockTrackingInstance) AddEntityToGroup(entityID uint) error {
+	m.entities[entityID] = struct{}{}
+	return nil
+}
+func (m *mockTrackingInstance) AddHealthWatch(system dcgm.HealthSystem) error {
+	m.watchedSystems |= system
+	return nil
+}
+func (m *mockTrackingInstance) RemoveHealthWatch(system dcgm.HealthSystem) error {
+	m.watchedSystems &^= system
+	return nil
+}
+func (m *mockTrackingInstance) HealthCheck(system dcgm.HealthSystem) (dcgm.HealthResult, []dcgm.Incident, error) {
+	return dcgm.DCGM_HEALTH_RESULT_PASS, nil, nil
+}
+func (m *mockTrackingInstance) AddFieldsToWatch(fields []dcgm.Short) error {
+	for _, field := range fields {
+		m.watchedFields[field] = struct{}{}
+	}
+	return nil
+}
+func (m *mockTrackingInstance) GetWatchedFields() []dcgm.Short {
+	fields := make([]dcgm.Short, 0, len(m.watchedFields))
+	for field := range m.watchedFields {
+		fields = append(fields, field)
+	}
+	return fields
+}
+func (m *mockTrackingInstance) RemoveFieldsFromWatch(fields []dcgm.Short) error {
+	for _, field := range fields {
+		delete(m.watchedFields, field)
+	}
+	return nil
+}
+func (m *mockTrackingInstance) GetLatestValuesForFields(deviceID uint, fields []dcgm.Short) ([]dcgm.FieldValue_v1, error) {
+	return nil, nil
+}
+func (m *mockTrackingInstance) GetGroupHandle() dcgm.GroupHandle { return dcgm.GroupHandle{} }
+func (m *mockTrackingInstance) GetDevices() []DeviceInfo         { return nil }
+func (m *mockTrackingInstance) Shutdown() error                  { return nil }


### PR DESCRIPTION
## Description

- Introduce a reconnecting DCGM instance wrapper in `third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go`.
- Track desired registrations in wrapper state (health watches, watched fields, added entities) so calls made while DCGM is unavailable are replayed when reconnect succeeds.
- Run a background reconcile loop every 30s (or configurable, default 30s) that:
1) attempts dcgm.Init when unavailable,
2) atomically swaps in the real instance on success,
3) replays registrations,
4) logs state transition once (down->up / up->down).
- Update `FieldValueCache` in `field_cache.go` to support late availability:
1) don’t permanently skip start when DCGM is initially unavailable,
2) lazily (re)run field-group setup when instance becomes available and fields exist.
- Keep `HealthCache` polling but reduce noisy warnings when DCGM is simply not loaded yet; reserve warning/error for real API failures.
- Handle direct-setup components (dcgm/cpu, dcgm/prof) with lazy one-time setup in Check() (or explicit EnsureInitialized) so they can recover after late DCGM availability too.

## Note
- Current deferred registration: components declare watches/fields immediately; DCGM wrapper buffers intent and replays when DCGM is up.
- Alternative approach (register only after up): some manager must remember all intended watches/fields and execute registration later. 
The current implementation allows minimal invasive change to existing component flow, and it works for startup races and late DCGM readiness. It also aturally supports replays when DCGM reconnects (not just first startup).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * GPU monitoring now registers watches earlier and tolerates delayed DCGM availability; registrations are replayed when DCGM reconnects.
  * New background reconnecting behavior remembers and replays health/field watches and entity registrations.
  * Polling and health checks treat transient DCGM unavailability as recoverable; NVSwitch/entity registration is deduplicated and tracked.

* **Tests**
  * Added tests for reconnect behavior, deferred registrations, uninitialized-group handling, and state replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->