### PR TITLE
[codex] fix reflect pointer vet lint

### DIFF
--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -562,7 +562,7 @@ func convertStructToOTLPAttributesWithPrefix(v interface{}, prefix string) []*co
 	}
 
 	val := reflect.ValueOf(v)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return attributes
 		}
@@ -623,7 +623,7 @@ func convertStructToOTLPAttributesWithPrefix(v interface{}, prefix string) []*co
 				attributes = append(attributes, nestedAttributes...)
 				continue
 			}
-		case reflect.Ptr:
+		case reflect.Pointer:
 			// Handle pointer fields by dereferencing and processing recursively
 			if !field.IsNil() {
 				nestedAttributes := convertStructToOTLPAttributesWithPrefix(field.Interface(), fullFieldName)


### PR DESCRIPTION
## Summary
- Replace deprecated reflect.Ptr usages with reflect.Pointer in OTLP conversion reflection code.

## Why
- CI runs golangci-lint 2.12.0, whose govet inline analyzer flags reflect.Ptr and expects the canonical reflect.Pointer constant.

## Validation
- go test ./internal/exporter/converter
- golangci-lint run --timeout=5m