### PR TITLE
fix: mandatory initial node upsert

### DIFF
--- a/internal/enrollment/enrollment.go
+++ b/internal/enrollment/enrollment.go
@@ -22,17 +22,19 @@ import (
 	"net/url"
 	"time"
 
+	pkghost "github.com/NVIDIA/fleet-intelligence-sdk/pkg/host"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
 	pkgmetadata "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metadata"
 	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/sqlite"
+	"github.com/google/uuid"
 
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/agentstate"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/backendclient"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/endpoint"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/inventory"
-	inventorysink "github.com/NVIDIA/fleet-intelligence-agent/internal/inventory/sink"
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/inventory/mapper"
 	inventorysource "github.com/NVIDIA/fleet-intelligence-agent/internal/inventory/source"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/registry"
@@ -41,6 +43,7 @@ import (
 var (
 	newBackendClient               = backendclient.New
 	syncInventoryAfterEnroll       = syncInventoryOnce
+	storeEnrollmentConfig          = storeConfigInMetadata
 	postEnrollInventorySyncTimeout = time.Minute
 )
 
@@ -64,15 +67,22 @@ func EnrollWithConfig(ctx context.Context, baseEndpoint, sakToken string, cfg *c
 	if err != nil {
 		return err
 	}
-	if err := storeConfigInMetadata(ctx, baseURL.String(), jwtToken, sakToken); err != nil {
-		return fmt.Errorf("failed to store configuration: %w", err)
+
+	nodeUUID := resolveNodeUUID(ctx)
+	if nodeUUID == "" {
+		return fmt.Errorf("failed to resolve node UUID")
 	}
+
 	syncCtx, cancel := context.WithTimeout(ctx, postEnrollInventorySyncTimeout)
 	defer cancel()
 	if err := runWithContext(syncCtx, func() error {
-		return syncInventoryAfterEnroll(syncCtx, cfg)
+		return syncInventoryAfterEnroll(syncCtx, client, nodeUUID, jwtToken, cfg)
 	}); err != nil {
-		log.Logger.Warnw("post-enroll inventory sync failed", "error", err)
+		return fmt.Errorf("initial node upsert failed: %w", err)
+	}
+
+	if err := storeEnrollmentConfig(ctx, baseURL.String(), jwtToken, sakToken, nodeUUID); err != nil {
+		return fmt.Errorf("failed to store configuration: %w", err)
 	}
 	return nil
 }
@@ -111,7 +121,7 @@ func normalizeBackendBaseURL(raw string) (*url.URL, error) {
 	return endpoint.ValidateBackendEndpoint(normalized)
 }
 
-func storeConfigInMetadata(ctx context.Context, baseURL, jwtToken, sakToken string) error {
+func storeConfigInMetadata(ctx context.Context, baseURL, jwtToken, sakToken, nodeUUID string) error {
 	stateFile, err := config.DefaultStateFile()
 	if err != nil {
 		return fmt.Errorf("failed to get state file path: %w", err)
@@ -139,7 +149,34 @@ func storeConfigInMetadata(ctx context.Context, baseURL, jwtToken, sakToken stri
 	if err := pkgmetadata.SetMetadata(ctx, dbRW, agentstate.MetadataKeyBackendBaseURL, baseURL); err != nil {
 		return fmt.Errorf("failed to set backend base URL: %w", err)
 	}
+	if err := pkgmetadata.SetMetadata(ctx, dbRW, pkgmetadata.MetadataKeyMachineID, nodeUUID); err != nil {
+		return fmt.Errorf("failed to set node UUID: %w", err)
+	}
 	return nil
+}
+
+func resolveNodeUUID(ctx context.Context) string {
+	state := agentstate.NewSQLite()
+	if existing, ok, err := state.GetNodeUUID(ctx); err == nil && ok && existing != "" {
+		if _, parseErr := uuid.Parse(existing); parseErr == nil {
+			return existing
+		}
+		log.Logger.Warnw("ignoring invalid persisted node UUID", "node_uuid", existing)
+	} else if err != nil {
+		log.Logger.Warnw("failed to read persisted node UUID; generating a new one", "error", err)
+	}
+
+	nodeUUID, err := pkghost.GetDmidecodeUUID(ctx)
+	if err == nil && nodeUUID != "" {
+		if _, parseErr := uuid.Parse(nodeUUID); parseErr == nil {
+			return nodeUUID
+		}
+		log.Logger.Warnw("ignoring invalid hardware node UUID", "node_uuid", nodeUUID)
+	} else if err != nil {
+		log.Logger.Warnw("failed to get hardware node UUID; generating a new one", "error", err)
+	}
+
+	return uuid.NewString()
 }
 
 type machineInfoCollectorFunc func(context.Context) (*machineinfo.MachineInfo, error)
@@ -148,16 +185,33 @@ func (f machineInfoCollectorFunc) Collect(ctx context.Context) (*machineinfo.Mac
 	return f(ctx)
 }
 
-func syncInventoryOnce(ctx context.Context, cfg *config.Config) error {
-	state := agentstate.NewSQLite()
-	sink := inventorysink.NewBackendSink(state)
+type initialNodeUpsertSink struct {
+	client   backendclient.Client
+	nodeUUID string
+	jwt      string
+}
+
+func (s *initialNodeUpsertSink) Export(ctx context.Context, snap *inventory.Snapshot) error {
+	if s.client == nil {
+		return fmt.Errorf("initial node upsert requires backend client")
+	}
+	if s.nodeUUID == "" {
+		return fmt.Errorf("initial node upsert requires node UUID")
+	}
+	if s.jwt == "" {
+		return fmt.Errorf("initial node upsert requires JWT")
+	}
+	return s.client.UpsertNode(ctx, s.nodeUUID, mapper.ToNodeUpsertRequest(snap), s.jwt)
+}
+
+func buildInventorySource(ctx context.Context, cfg *config.Config) (inventory.Source, func(), error) {
 	allComponents := registry.AllComponentNames()
 
 	if cfg == nil {
 		var err error
 		cfg, err = config.Default(ctx)
 		if err != nil {
-			return fmt.Errorf("load default config for inventory sync: %w", err)
+			return nil, nil, fmt.Errorf("load default config for inventory sync: %w", err)
 		}
 	}
 	retentionPeriodSeconds, enabledComponents, disabledComponents := cfg.InventoryAgentConfig(allComponents)
@@ -166,11 +220,10 @@ func syncInventoryOnce(ctx context.Context, cfg *config.Config) error {
 
 	nvmlInstance, err := nvidianvml.New()
 	if err != nil {
-		return fmt.Errorf("initialize nvml for inventory sync: %w", err)
+		return nil, nil, fmt.Errorf("initialize nvml for inventory sync: %w", err)
 	}
-	defer func() { _ = nvmlInstance.Shutdown() }()
 
-	src := inventorysource.NewMachineInfoSourceWithAgentConfig(
+	return inventorysource.NewMachineInfoSourceWithAgentConfig(
 		machineInfoCollectorFunc(func(context.Context) (*machineinfo.MachineInfo, error) {
 			return machineinfo.GetMachineInfo(nvmlInstance)
 		}),
@@ -184,7 +237,20 @@ func syncInventoryOnce(ctx context.Context, cfg *config.Config) error {
 			AttestationEnabled:         attestationEnabled,
 			AttestationIntervalSeconds: attestationIntervalSeconds,
 		},
-	)
+	), func() { _ = nvmlInstance.Shutdown() }, nil
+}
+
+func syncInventoryOnce(ctx context.Context, client backendclient.Client, nodeUUID, jwt string, cfg *config.Config) error {
+	src, cleanup, err := buildInventorySource(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	sink := &initialNodeUpsertSink{
+		client:   client,
+		nodeUUID: nodeUUID,
+		jwt:      jwt,
+	}
 	manager := inventory.NewManager(src, sink, inventory.InventoryConfig{})
 	_, err = manager.CollectOnce(ctx)
 	return err

--- a/internal/enrollment/enrollment_test.go
+++ b/internal/enrollment/enrollment_test.go
@@ -25,14 +25,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	pkgmetadata "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metadata"
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/sqlite"
+
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/backendclient"
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/config"
 )
 
 type fakeBackendClient struct {
-	enrollSAK string
-	enrollJWT string
-	enrollErr error
+	enrollSAK      string
+	enrollJWT      string
+	enrollErr      error
+	upsertNodeUUID string
+	upsertJWT      string
+	upsertReq      *backendclient.NodeUpsertRequest
+	upsertErr      error
 }
 
 func (f *fakeBackendClient) Enroll(_ context.Context, sakToken string) (string, error) {
@@ -40,8 +47,11 @@ func (f *fakeBackendClient) Enroll(_ context.Context, sakToken string) (string, 
 	return f.enrollJWT, f.enrollErr
 }
 
-func (f *fakeBackendClient) UpsertNode(context.Context, string, *backendclient.NodeUpsertRequest, string) error {
-	return nil
+func (f *fakeBackendClient) UpsertNode(_ context.Context, nodeUUID string, req *backendclient.NodeUpsertRequest, jwt string) error {
+	f.upsertNodeUUID = nodeUUID
+	f.upsertReq = req
+	f.upsertJWT = jwt
+	return f.upsertErr
 }
 
 func (f *fakeBackendClient) GetNonce(context.Context, string, string) (*backendclient.NonceResponse, error) {
@@ -67,8 +77,11 @@ func TestEnrollWorkflow(t *testing.T) {
 	}
 
 	syncCalled := false
-	syncInventoryAfterEnroll = func(ctx context.Context, cfg *config.Config) error {
+	syncInventoryAfterEnroll = func(ctx context.Context, gotClient backendclient.Client, nodeUUID, jwt string, cfg *config.Config) error {
 		syncCalled = true
+		require.Same(t, client, gotClient)
+		require.NotEmpty(t, nodeUUID)
+		require.Equal(t, "jwt-token", jwt)
 		return nil
 	}
 
@@ -98,7 +111,10 @@ func TestEnrollWorkflowPassesConfigToInventorySync(t *testing.T) {
 			Enabled: true,
 		},
 	}
-	syncInventoryAfterEnroll = func(ctx context.Context, gotCfg *config.Config) error {
+	syncInventoryAfterEnroll = func(ctx context.Context, gotClient backendclient.Client, nodeUUID, jwt string, gotCfg *config.Config) error {
+		require.NotNil(t, gotClient)
+		require.NotEmpty(t, nodeUUID)
+		require.Equal(t, "jwt-token", jwt)
 		require.Same(t, wantCfg, gotCfg)
 		return nil
 	}
@@ -122,7 +138,10 @@ func TestEnrollWorkflowDefaultWrapperUsesNilConfig(t *testing.T) {
 		return &fakeBackendClient{enrollJWT: "jwt-token"}, nil
 	}
 
-	syncInventoryAfterEnroll = func(ctx context.Context, gotCfg *config.Config) error {
+	syncInventoryAfterEnroll = func(ctx context.Context, gotClient backendclient.Client, nodeUUID, jwt string, gotCfg *config.Config) error {
+		require.NotNil(t, gotClient)
+		require.NotEmpty(t, nodeUUID)
+		require.Equal(t, "jwt-token", jwt)
 		require.Nil(t, gotCfg)
 		return nil
 	}
@@ -147,7 +166,7 @@ func TestEnrollWorkflowNormalizesLegacyEndpointToBaseURL(t *testing.T) {
 		require.Equal(t, "https://example.com", rawBaseURL)
 		return client, nil
 	}
-	syncInventoryAfterEnroll = func(context.Context, *config.Config) error { return nil }
+	syncInventoryAfterEnroll = func(context.Context, backendclient.Client, string, string, *config.Config) error { return nil }
 
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
@@ -165,7 +184,11 @@ func TestEnrollWorkflowErrors(t *testing.T) {
 
 	t.Run("localhost http endpoint allowed", func(t *testing.T) {
 		originalFactory := newBackendClient
-		t.Cleanup(func() { newBackendClient = originalFactory })
+		originalSync := syncInventoryAfterEnroll
+		t.Cleanup(func() {
+			newBackendClient = originalFactory
+			syncInventoryAfterEnroll = originalSync
+		})
 
 		called := false
 		newBackendClient = func(rawBaseURL string) (backendclient.Client, error) {
@@ -173,6 +196,7 @@ func TestEnrollWorkflowErrors(t *testing.T) {
 			require.Equal(t, "http://localhost:8080", rawBaseURL)
 			return &fakeBackendClient{enrollJWT: "jwt-token"}, nil
 		}
+		syncInventoryAfterEnroll = func(context.Context, backendclient.Client, string, string, *config.Config) error { return nil }
 
 		tmpHome := t.TempDir()
 		t.Setenv("HOME", tmpHome)
@@ -218,7 +242,7 @@ func TestEnrollWorkflowErrors(t *testing.T) {
 			require.Equal(t, "http://localhost:8080", rawBaseURL)
 			return &fakeBackendClient{enrollJWT: "jwt-token"}, nil
 		}
-		syncInventoryAfterEnroll = func(context.Context, *config.Config) error { return nil }
+		syncInventoryAfterEnroll = func(context.Context, backendclient.Client, string, string, *config.Config) error { return nil }
 
 		tmpHome := t.TempDir()
 		t.Setenv("HOME", tmpHome)
@@ -229,29 +253,40 @@ func TestEnrollWorkflowErrors(t *testing.T) {
 	})
 }
 
-func TestEnrollWorkflowInventorySyncFailureIsNonFatal(t *testing.T) {
+func TestEnrollWorkflowInventorySyncFailureIsFatal(t *testing.T) {
 	originalFactory := newBackendClient
 	originalSync := syncInventoryAfterEnroll
+	originalStore := storeEnrollmentConfig
 	t.Cleanup(func() {
 		newBackendClient = originalFactory
 		syncInventoryAfterEnroll = originalSync
+		storeEnrollmentConfig = originalStore
 	})
 
 	newBackendClient = func(rawBaseURL string) (backendclient.Client, error) {
 		return &fakeBackendClient{enrollJWT: "jwt-token"}, nil
 	}
-	syncInventoryAfterEnroll = func(ctx context.Context, cfg *config.Config) error {
+	syncInventoryAfterEnroll = func(ctx context.Context, gotClient backendclient.Client, nodeUUID, jwt string, cfg *config.Config) error {
+		require.NotNil(t, gotClient)
+		require.NotEmpty(t, nodeUUID)
+		require.Equal(t, "jwt-token", jwt)
 		return errors.New("inventory failed")
+	}
+	storeCalled := false
+	storeEnrollmentConfig = func(context.Context, string, string, string, string) error {
+		storeCalled = true
+		return nil
 	}
 
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
 	err := Enroll(context.Background(), "https://example.com", "sak-token")
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "initial node upsert failed")
+	require.False(t, storeCalled, "enroll should not persist active metadata when initial node upsert fails")
 }
 
-func TestEnrollWorkflowInventorySyncTimeoutIsNonFatal(t *testing.T) {
+func TestEnrollWorkflowInventorySyncTimeoutIsFatal(t *testing.T) {
 	originalFactory := newBackendClient
 	originalSync := syncInventoryAfterEnroll
 	originalTimeout := postEnrollInventorySyncTimeout
@@ -268,7 +303,7 @@ func TestEnrollWorkflowInventorySyncTimeoutIsNonFatal(t *testing.T) {
 
 	syncStarted := make(chan struct{})
 	releaseSync := make(chan struct{})
-	syncInventoryAfterEnroll = func(context.Context, *config.Config) error {
+	syncInventoryAfterEnroll = func(context.Context, backendclient.Client, string, string, *config.Config) error {
 		close(syncStarted)
 		<-releaseSync
 		return nil
@@ -279,7 +314,7 @@ func TestEnrollWorkflowInventorySyncTimeoutIsNonFatal(t *testing.T) {
 
 	start := time.Now()
 	err := Enroll(context.Background(), "https://example.com", "sak-token")
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "initial node upsert failed")
 	require.Less(t, time.Since(start), time.Second)
 
 	select {
@@ -305,7 +340,10 @@ func TestEnrollWorkflowInventorySyncUsesRemainingEnrollTimeout(t *testing.T) {
 	}
 	postEnrollInventorySyncTimeout = time.Minute
 
-	syncInventoryAfterEnroll = func(ctx context.Context, cfg *config.Config) error {
+	syncInventoryAfterEnroll = func(ctx context.Context, gotClient backendclient.Client, nodeUUID, jwt string, cfg *config.Config) error {
+		require.NotNil(t, gotClient)
+		require.NotEmpty(t, nodeUUID)
+		require.Equal(t, "jwt-token", jwt)
 		deadline, ok := ctx.Deadline()
 		require.True(t, ok)
 		require.Less(t, time.Until(deadline), 5*time.Second)
@@ -335,11 +373,19 @@ func TestStoreConfigInMetadataSecuresFreshStateFile(t *testing.T) {
 		"https://example.com",
 		"jwt-token",
 		"sak-token",
+		"550e8400-e29b-41d4-a716-446655440000",
 	)
 	require.NoError(t, err)
 
 	stateFile, err := config.DefaultStateFile()
 	require.NoError(t, err)
+	db, err := sqlite.Open(stateFile, sqlite.WithReadOnly(true))
+	require.NoError(t, err)
+	defer db.Close()
+	machineID, err := pkgmetadata.ReadMachineID(context.Background(), db)
+	require.NoError(t, err)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", machineID)
+
 	for _, candidate := range []string{stateFile, stateFile + "-wal", stateFile + "-shm"} {
 		info, err := os.Stat(candidate)
 		if os.IsNotExist(err) {


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced node enrollment process with improved UUID management, persistence, and resolution capabilities to ensure consistent node identification.
  * Refactored inventory synchronization workflow to be tightly integrated with the enrollment process for better data consistency.

* **Bug Fixes**
  * Node inventory synchronization failures now prevent enrollment completion instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->