### PR TITLE
Clarify the documentation on dependencies. 

### DIFF
--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -4,7 +4,7 @@
 
 Before installing Fleet Intelligence Agent, ensure the following prerequisites are met:
 
-- Configure a NVIDIA package repository for automatic dependency installation.
+- Configure an NVIDIA package repository for automatic dependency installation.
   The following dependencies are required and satisfied by the CUDA (network or local) repository.  
   - `datacenter-gpu-manager-4-proprietary` (DCGM)
   - `nvattest` (NVIDIA Attestation SDK CLI, NVAT)

--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -13,7 +13,7 @@ Before installing Fleet Intelligence Agent, ensure the following prerequisites a
 - NVIDIA Datacenter Driver major version `510` or newer is installed
 - Install/upgrade commands are run as `root` or with `sudo`
 - Attestation for the fleetint use case only supports Blackwell and newer GPUs, and applies to non-CC mode systems
-  - Fleetint is supported without attestation for Hopper and newer GPUs.
+  - Fleetint is supported without attestation for Hopper GPUs.
 - For NVSwitch systems (driver branch must match installed datacenter driver):
   - Hopper (pre-4th gen NVSwitch): install `cuda-drivers-fabricmanager-<driver-branch>`
   - Blackwell (4th gen NVSwitch): install `nvidia-open-<driver-branch>` and `nvlink5-<driver-branch>`

--- a/docs/install-deb.md
+++ b/docs/install-deb.md
@@ -2,29 +2,23 @@
 
 ## Prerequisites
 
-The Fleet Intelligence Agent DEB package has the following runtime dependencies:
-
-- `datacenter-gpu-manager-4-proprietary` (DCGM)
-- `nvattest` (NVIDIA Attestation SDK CLI, NVAT)
-- `corelib` (NVAT GPU evidence source dependency)
-
 Before installing Fleet Intelligence Agent, ensure the following prerequisites are met:
 
-- NVIDIA package repository is configured (network or local CUDA repository) so `datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib` can be installed
+- Configure a NVIDIA package repository for automatic dependency installation.
+  The following dependencies are required and satisfied by the CUDA (network or local) repository.  
+  - `datacenter-gpu-manager-4-proprietary` (DCGM)
+  - `nvattest` (NVIDIA Attestation SDK CLI, NVAT)
+  - `corelib` (NVAT GPU evidence source dependency)
 - DCGM HostEngine `4.2.3` or newer
 - NVIDIA Datacenter Driver major version `510` or newer is installed
 - Install/upgrade commands are run as `root` or with `sudo`
 - Attestation for the fleetint use case only supports Blackwell and newer GPUs, and applies to non-CC mode systems
+  - Fleetint is supported without attestation for Hopper and newer GPUs.
 - For NVSwitch systems (driver branch must match installed datacenter driver):
   - Hopper (pre-4th gen NVSwitch): install `cuda-drivers-fabricmanager-<driver-branch>`
   - Blackwell (4th gen NVSwitch): install `nvidia-open-<driver-branch>` and `nvlink5-<driver-branch>`
 
-References:
-- DCGM: <https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#installation>
-- Fabric Manager: <https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#installing-fabric-manager>
-- NVAT (`nvattest`/`corelib`): <https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/overview.html>
-
-Fleet Intelligence Agent package dependencies (`datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib`) are available through NVIDIA's CUDA repository. Before installing Fleet Intelligence Agent, add the appropriate NVIDIA CUDA repository for your system:
+Fleet Intelligence Agent package dependencies are available through NVIDIA's CUDA repository. Before installing Fleet Intelligence Agent, add the appropriate NVIDIA CUDA repository for your system:
 
 ```bash
 # Ubuntu 22.04 (x86_64)
@@ -89,3 +83,8 @@ The service will automatically restart with the new version.
 sudo apt remove fleetint
 sudo apt purge fleetint  # Also removes configuration files
 ```
+
+References:
+- DCGM: <https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#installation>
+- Fabric Manager: <https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#installing-fabric-manager>
+- NVAT (`nvattest`/`corelib`): <https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/overview.html>

--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -14,7 +14,7 @@ Before installing Fleet Intelligence Agent, ensure the following prerequisites a
 - Install/upgrade commands are run as `root` or with `sudo`
 - `dnf-plugins-core` is installed (required for `dnf config-manager`)
 - Attestation for the fleetint use case only supports Blackwell and newer GPUs, and applies to non-CC mode systems
-  - Fleetint is supported without attestation for Hopper and newer GPUs.
+  - Fleetint is supported without attestation for Hopper GPUs.
 - For NVSwitch systems (driver branch must match installed datacenter driver):
   - Hopper (pre-4th gen NVSwitch): install `nvidia-driver:<driver-branch>/fm`
   - Blackwell (4th gen NVSwitch): install `nvidia-driver-<driver-branch>-open` and `nvlink-<driver-branch>`

--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -2,30 +2,24 @@
 
 ## Prerequisites
 
-The Fleet Intelligence Agent RPM package has the following runtime dependencies:
-
-- `datacenter-gpu-manager-4-proprietary` (DCGM)
-- `nvattest` (NVIDIA Attestation SDK CLI, NVAT)
-- `corelib` (NVAT GPU evidence source dependency)
-
 Before installing Fleet Intelligence Agent, ensure the following prerequisites are met:
 
-- NVIDIA package repository is configured (network or local CUDA repository) so `datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib` can be installed
+- Configure an NVIDIA package repository for automatic dependency installation.
+  The following dependencies are required and satisfied by the CUDA (network or local) repository.
+  - `datacenter-gpu-manager-4-proprietary` (DCGM)
+  - `nvattest` (NVIDIA Attestation SDK CLI, NVAT)
+  - `corelib` (NVAT GPU evidence source dependency)
 - DCGM HostEngine `4.2.3` or newer
 - NVIDIA Datacenter Driver major version `510` or newer is installed
 - Install/upgrade commands are run as `root` or with `sudo`
 - `dnf-plugins-core` is installed (required for `dnf config-manager`)
 - Attestation for the fleetint use case only supports Blackwell and newer GPUs, and applies to non-CC mode systems
+  - Fleetint is supported without attestation for Hopper and newer GPUs.
 - For NVSwitch systems (driver branch must match installed datacenter driver):
   - Hopper (pre-4th gen NVSwitch): install `nvidia-driver:<driver-branch>/fm`
   - Blackwell (4th gen NVSwitch): install `nvidia-driver-<driver-branch>-open` and `nvlink-<driver-branch>`
 
-References:
-- DCGM: <https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#installation>
-- Fabric Manager: <https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#installing-fabric-manager>
-- NVAT (`nvattest`/`corelib`): <https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/overview.html>
-
-Fleet Intelligence Agent package dependencies (`datacenter-gpu-manager-4-proprietary`, `nvattest`, and `corelib`) are available through NVIDIA's CUDA repository. Before installing Fleet Intelligence Agent, add the appropriate NVIDIA CUDA repository for your system.
+Fleet Intelligence Agent package dependencies are available through NVIDIA's CUDA repository. Before installing Fleet Intelligence Agent, add the appropriate NVIDIA CUDA repository for your system:
 
 Install `dnf-plugins-core` first if `dnf config-manager` is not available:
 
@@ -113,3 +107,8 @@ The service will automatically restart with the new version.
 ```bash
 sudo dnf remove fleetint
 ```
+
+References:
+- DCGM: <https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/getting-started.html#installation>
+- Fabric Manager: <https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#installing-fabric-manager>
+- NVAT (`nvattest`/`corelib`): <https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/overview.html>


### PR DESCRIPTION
This is based on some customer feedback.

## Description
- Move the dependencies section into the instructions and change to indicate that by setting up the CUDA repo the dependencies are automatically included in the install.  
- Made a note that Fleet Intelligence works for Hopper and above, but that attestation only works for Blackwell and above. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Debian install guide reorganized: prerequisites now start with a consolidated checklist including explicit instruction to configure the NVIDIA CUDA package repository; runtime dependencies are listed as satisfied by the CUDA repo; dependency guidance moved to precede installation steps; references moved to the document end.
  * RPM install guide updated: pre-install checklist enumerates CUDA-resolved runtime dependencies and minimum DCGM/driver versions; attestation support and NVSwitch guidance clarified and organized by GPU generation/driver branch; references relocated to the end.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/fleet-intelligence-agent/pull/190)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->