### PR TITLE
fix: context deadline exceeded shouldn't throw an error

### DIFF
--- a/deployments/helm/fleet-intelligence-agent/README.md
+++ b/deployments/helm/fleet-intelligence-agent/README.md
@@ -51,6 +51,8 @@ Common values (defaults from `values.yaml`):
 | `enroll.tokenSecretName` | `""` | Secret name for enrollment token. |
 | `enroll.tokenSecretKey` | `token` | Secret key for enrollment token. |
 | `enroll.tokenValue` | `""` | Inline token value (optional). |
+| `enroll.nodeGroup` | `null` | Optional `--node-group` enroll flag. `null` omits flag, `""` clears stored value. |
+| `enroll.computeZone` | `null` | Optional `--compute-zone` enroll flag. `null` omits flag, `""` clears stored value. |
 | `enroll.securityContext.runAsUser` | `0` | Run enrollment init as root. |
 | `ports.http` | `15133` | HTTP port. |
 | `resources.requests.cpu` | `100m` | CPU request. |
@@ -70,6 +72,7 @@ Common values (defaults from `values.yaml`):
 
 `enroll.enabled` and `enroll.unenroll` are mutually exclusive; do not set both to `true`.
 Set `enroll.force=true` to append `--force` to `fleetint enroll`.
+Set `enroll.nodeGroup` / `enroll.computeZone` to pass optional enrollment metadata via the init container command.
 
 See `docs/install-helm.md` for the enrollment flow and secret creation steps.
 

--- a/deployments/helm/fleet-intelligence-agent/README.md
+++ b/deployments/helm/fleet-intelligence-agent/README.md
@@ -51,8 +51,8 @@ Common values (defaults from `values.yaml`):
 | `enroll.tokenSecretName` | `""` | Secret name for enrollment token. |
 | `enroll.tokenSecretKey` | `token` | Secret key for enrollment token. |
 | `enroll.tokenValue` | `""` | Inline token value (optional). |
-| `enroll.nodeGroup` | `null` | Optional `--node-group` enroll flag. `null` omits flag, `""` clears stored value. |
-| `enroll.computeZone` | `null` | Optional `--compute-zone` enroll flag. `null` omits flag, `""` clears stored value. |
+| `enroll.nodeGroup` | `(not set)` | Optional `--node-group` enroll flag. Omit key to omit flag, set `""` to clear stored value. |
+| `enroll.computeZone` | `(not set)` | Optional `--compute-zone` enroll flag. Omit key to omit flag, set `""` to clear stored value. |
 | `enroll.securityContext.runAsUser` | `0` | Run enrollment init as root. |
 | `ports.http` | `15133` | HTTP port. |
 | `resources.requests.cpu` | `100m` | CPU request. |

--- a/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
+++ b/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
@@ -74,6 +74,12 @@ spec:
               {{- if .Values.enroll.force }}
               --force
               {{- end }}
+              {{- if ne .Values.enroll.nodeGroup nil }}
+              --node-group {{ .Values.enroll.nodeGroup | quote }}
+              {{- end }}
+              {{- if ne .Values.enroll.computeZone nil }}
+              --compute-zone {{ .Values.enroll.computeZone | quote }}
+              {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           env:

--- a/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
+++ b/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
@@ -74,10 +74,10 @@ spec:
               {{- if .Values.enroll.force }}
               --force
               {{- end }}
-              {{- if ne .Values.enroll.nodeGroup nil }}
+              {{- if hasKey .Values.enroll "nodeGroup" }}
               --node-group {{ .Values.enroll.nodeGroup | quote }}
               {{- end }}
-              {{- if ne .Values.enroll.computeZone nil }}
+              {{- if hasKey .Values.enroll "computeZone" }}
               --compute-zone {{ .Values.enroll.computeZone | quote }}
               {{- end }}
           securityContext:

--- a/deployments/helm/fleet-intelligence-agent/values.yaml
+++ b/deployments/helm/fleet-intelligence-agent/values.yaml
@@ -61,10 +61,13 @@ enroll:
   tokenSecretName: ""
   tokenSecretKey: "token"
   tokenValue: ""
-  # Optional enrollment metadata. Keep null to omit flag (preserve existing value).
-  # Set to a string to overwrite. Set to empty string "" to clear.
-  nodeGroup: ""
-  computeZone: ""
+  # Optional enrollment metadata:
+  # - omit key to preserve existing stored value
+  # - set non-empty string to overwrite
+  # - set empty string ("") to clear
+  #
+  # nodeGroup: "prod-a"
+  # computeZone: "us-east-1c"
 
 ports:
   http: 15133

--- a/deployments/helm/fleet-intelligence-agent/values.yaml
+++ b/deployments/helm/fleet-intelligence-agent/values.yaml
@@ -61,6 +61,10 @@ enroll:
   tokenSecretName: ""
   tokenSecretKey: "token"
   tokenValue: ""
+  # Optional enrollment metadata. Keep null to omit flag (preserve existing value).
+  # Set to a string to overwrite. Set to empty string "" to clear.
+  nodeGroup: ""
+  computeZone: ""
 
 ports:
   http: 15133

--- a/docs/install-helm.md
+++ b/docs/install-helm.md
@@ -89,7 +89,7 @@ helm upgrade fleet-intelligence-agent oci://ghcr.io/nvidia/charts/fleet-intellig
 ```
 
 Notes:
-- Keep `enroll.nodeGroup` / `enroll.computeZone` unset (`null`) to omit the flag and preserve existing stored values.
+- Omit `enroll.nodeGroup` / `enroll.computeZone` keys to omit the flags and preserve existing stored values.
 - Set either value to an empty string to clear it (for example: `--set-string enroll.nodeGroup=""`).
 
 Upgrade (no enrollment):

--- a/docs/install-helm.md
+++ b/docs/install-helm.md
@@ -75,6 +75,23 @@ helm upgrade fleet-intelligence-agent oci://ghcr.io/nvidia/charts/fleet-intellig
   --set enroll.tokenSecretName="$ENROLL_TOKEN_SECRET_NAME"
 ```
 
+Optional: include node metadata during automatic enrollment:
+
+```bash
+helm upgrade fleet-intelligence-agent oci://ghcr.io/nvidia/charts/fleet-intelligence-agent \
+  --version "$CHART_VERSION" \
+  --namespace "$NS" \
+  --set enroll.enabled=true \
+  --set enroll.endpoint="$ENROLL_ENDPOINT" \
+  --set enroll.tokenSecretName="$ENROLL_TOKEN_SECRET_NAME" \
+  --set-string enroll.nodeGroup="prod-a" \
+  --set-string enroll.computeZone="us-east-1c"
+```
+
+Notes:
+- Keep `enroll.nodeGroup` / `enroll.computeZone` unset (`null`) to omit the flag and preserve existing stored values.
+- Set either value to an empty string to clear it (for example: `--set-string enroll.nodeGroup=""`).
+
 Upgrade (no enrollment):
 
 ```bash

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -116,6 +116,16 @@ func (e *healthExporter) Start() error {
 
 	log.Logger.Infow("Starting health exporter")
 
+	// In offline mode, emit one export immediately so short runs don't exit
+	// before the first ticker cycle and leave an empty output directory.
+	if e.options.config.OfflineMode {
+		if err := e.export(); err != nil {
+			log.Logger.Errorw("Initial offline export failed", "error", err)
+		} else {
+			e.lastExport = time.Now().UTC()
+		}
+	}
+
 	// Start the health export ticker
 	go func() {
 		ticker := time.NewTicker(e.options.config.Interval.Duration)

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -284,6 +284,33 @@ func TestStart(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("offline mode performs initial export before first tick", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := &config.HealthExporterConfig{
+			Interval:     metav1.Duration{Duration: 1 * time.Hour},
+			Timeout:      metav1.Duration{Duration: 30 * time.Second},
+			OfflineMode:  true,
+			OutputPath:   tmpDir,
+			OutputFormat: "json",
+		}
+
+		exporter, err := New(ctx, WithConfig(cfg), WithMachineID("test-machine-id"))
+		require.NoError(t, err)
+		require.NotNil(t, exporter)
+
+		err = exporter.Start()
+		require.NoError(t, err)
+
+		// Initial export should be written immediately, without waiting for ticker.
+		time.Sleep(100 * time.Millisecond)
+		entries, err := os.ReadDir(tmpDir)
+		require.NoError(t, err)
+		assert.Greater(t, len(entries), 0, "Expected offline files from initial export")
+
+		err = exporter.Stop()
+		require.NoError(t, err)
+	})
+
 }
 
 // TestStop tests the Stop function

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -311,6 +311,58 @@ func TestStart(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("offline initial export includes collected data", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfg := &config.HealthExporterConfig{
+			Interval:     metav1.Duration{Duration: 1 * time.Hour},
+			Timeout:      metav1.Duration{Duration: 30 * time.Second},
+			OfflineMode:  true,
+			OutputPath:   tmpDir,
+			OutputFormat: "json",
+		}
+
+		exporter, err := New(ctx, WithConfig(cfg), WithMachineID("test-machine-id"))
+		require.NoError(t, err)
+		require.NotNil(t, exporter)
+
+		he := exporter.(*healthExporter)
+		mockCollector := &MockCollector{}
+		mockCollector.On("Collect", mock.Anything).Return(&collector.HealthData{
+			MachineID: "test-machine",
+			Timestamp: time.Now(),
+			Metrics: []pkgmetrics.Metric{
+				{
+					Name:             "test_metric",
+					Value:            42.0,
+					UnixMilliseconds: time.Now().UnixMilli(),
+				},
+			},
+		}, nil).Once()
+		he.collector = mockCollector
+
+		err = exporter.Start()
+		require.NoError(t, err)
+
+		entries, err := os.ReadDir(tmpDir)
+		require.NoError(t, err)
+		require.Greater(t, len(entries), 0, "Expected offline files from initial export")
+
+		allContent := ""
+		for _, entry := range entries {
+			fullPath := filepath.Join(tmpDir, entry.Name())
+			content, readErr := os.ReadFile(fullPath)
+			require.NoError(t, readErr)
+			allContent += string(content)
+		}
+		assert.Contains(t, allContent, "test_metric")
+		assert.Contains(t, allContent, "machine.id")
+
+		mockCollector.AssertExpectations(t)
+
+		err = exporter.Stop()
+		require.NoError(t, err)
+	})
+
 }
 
 // TestStop tests the Stop function

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,6 +89,12 @@ type Server struct {
 	// signal handler in run.go both call Stop(), so without this guard
 	// components, databases, and the health exporter would be closed twice.
 	stopOnce sync.Once
+	loopWG   sync.WaitGroup
+
+	// loopCtx/loopCancel control background inventory and attestation goroutines.
+	// Stop() cancels this context and waits on loopWG for graceful shutdown.
+	loopCtx    context.Context
+	loopCancel context.CancelFunc
 
 	machineID string
 }
@@ -210,14 +216,32 @@ func getAttestationTimeout(cfg *config.Config) time.Duration {
 	return config.DefaultAttestationTimeout
 }
 
-func shouldLogLoopExitError(err error) bool {
+func shouldLogLoopExitError(ctx context.Context, err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if ctx != nil && ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 		return false
 	}
 	return true
+}
+
+func waitForWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	if timeout <= 0 {
+		<-done
+		return true
+	}
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
 }
 
 // shouldEnableComponent determines if a component should be enabled based on configuration
@@ -245,11 +269,14 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 		return nil, err
 	}
 
+	loopCtx, loopCancel := context.WithCancel(ctx)
 	s := &Server{
 		auditLogger: auditLogger,
 		dbRW:        dbRW,
 		dbRO:        dbRO,
 		config:      config,
+		loopCtx:     loopCtx,
+		loopCancel:  loopCancel,
 	}
 	defer func() {
 		if retErr != nil {
@@ -393,8 +420,8 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 		}
 	}
 
-	s.startInventoryLoop(ctx, config, nvmlInstance, dcgmGPUIndexes)
-	s.startAttestationLoop(ctx, config)
+	s.startInventoryLoop(loopCtx, config, nvmlInstance, dcgmGPUIndexes)
+	s.startAttestationLoop(loopCtx, config)
 
 	// Create and start health exporter with all dependencies if enabled
 	if config.HealthExporter != nil {
@@ -472,8 +499,10 @@ func (s *Server) startInventoryLoop(
 		StartupJitter: inventory.DefaultStartupJitter,
 	})
 
+	s.loopWG.Add(1)
 	go func() {
-		if err := manager.Run(ctx); shouldLogLoopExitError(err) {
+		defer s.loopWG.Done()
+		if err := manager.Run(ctx); shouldLogLoopExitError(ctx, err) {
 			log.Logger.Errorw("inventory loop manager exited", "error", err)
 		}
 	}()
@@ -507,8 +536,10 @@ func (s *Server) startAttestationLoop(ctx context.Context, cfg *config.Config) {
 		},
 	)
 
+	s.loopWG.Add(1)
 	go func() {
-		if err := manager.Run(ctx); shouldLogLoopExitError(err) {
+		defer s.loopWG.Done()
+		if err := manager.Run(ctx); shouldLogLoopExitError(ctx, err) {
 			log.Logger.Errorw("attestation loop exited", "error", err)
 		}
 	}()
@@ -526,6 +557,15 @@ func (s *Server) GetHealthExporter() exporter.Exporter {
 // signal handler in run.go both invoke it.
 func (s *Server) Stop() {
 	s.stopOnce.Do(func() {
+		// Signal inventory/attestation loops to stop and wait for graceful exit
+		// before we close dependencies they may still be using.
+		if s.loopCancel != nil {
+			s.loopCancel()
+		}
+		if !waitForWaitGroup(&s.loopWG, 10*time.Second) {
+			log.Logger.Warnw("timed out waiting for background loops to stop")
+		}
+
 		// Gracefully shut down the HTTP server so in-flight requests complete
 		// before we close databases and components underneath them.
 		if s.srv != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -216,16 +216,6 @@ func getAttestationTimeout(cfg *config.Config) time.Duration {
 	return config.DefaultAttestationTimeout
 }
 
-func shouldLogLoopExitError(ctx context.Context, err error) bool {
-	if err == nil {
-		return false
-	}
-	if ctx != nil && ctx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
-		return false
-	}
-	return true
-}
-
 func waitForWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
 	done := make(chan struct{})
 	go func() {
@@ -502,7 +492,7 @@ func (s *Server) startInventoryLoop(
 	s.loopWG.Add(1)
 	go func() {
 		defer s.loopWG.Done()
-		if err := manager.Run(ctx); shouldLogLoopExitError(ctx, err) {
+		if err := manager.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			log.Logger.Errorw("inventory loop manager exited", "error", err)
 		}
 	}()
@@ -539,7 +529,7 @@ func (s *Server) startAttestationLoop(ctx context.Context, cfg *config.Config) {
 	s.loopWG.Add(1)
 	go func() {
 		defer s.loopWG.Done()
-		if err := manager.Run(ctx); shouldLogLoopExitError(ctx, err) {
+		if err := manager.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			log.Logger.Errorw("attestation loop exited", "error", err)
 		}
 	}()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -210,6 +210,16 @@ func getAttestationTimeout(cfg *config.Config) time.Duration {
 	return config.DefaultAttestationTimeout
 }
 
+func shouldLogLoopExitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return true
+}
+
 // shouldEnableComponent determines if a component should be enabled based on configuration
 func shouldEnableComponent(name string, enabledByDefault bool, config *config.Config) bool {
 	shouldEnable := enabledByDefault
@@ -463,7 +473,7 @@ func (s *Server) startInventoryLoop(
 	})
 
 	go func() {
-		if err := manager.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		if err := manager.Run(ctx); shouldLogLoopExitError(err) {
 			log.Logger.Errorw("inventory loop manager exited", "error", err)
 		}
 	}()
@@ -498,7 +508,7 @@ func (s *Server) startAttestationLoop(ctx context.Context, cfg *config.Config) {
 	)
 
 	go func() {
-		if err := manager.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		if err := manager.Run(ctx); shouldLogLoopExitError(err) {
 			log.Logger.Errorw("attestation loop exited", "error", err)
 		}
 	}()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -160,25 +161,60 @@ func TestGetInventorySyncTimeout(t *testing.T) {
 }
 
 func TestShouldLogLoopExitError(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deadlineCtx, deadlineCancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer deadlineCancel()
+	<-deadlineCtx.Done()
+
 	t.Run("nil error", func(t *testing.T) {
-		assert.False(t, shouldLogLoopExitError(nil))
+		assert.False(t, shouldLogLoopExitError(context.Background(), nil))
 	})
 
-	t.Run("context canceled", func(t *testing.T) {
-		assert.False(t, shouldLogLoopExitError(context.Canceled))
+	t.Run("context canceled during shutdown", func(t *testing.T) {
+		assert.False(t, shouldLogLoopExitError(canceledCtx, context.Canceled))
 	})
 
-	t.Run("context deadline exceeded", func(t *testing.T) {
-		assert.False(t, shouldLogLoopExitError(context.DeadlineExceeded))
+	t.Run("context deadline exceeded during shutdown", func(t *testing.T) {
+		assert.False(t, shouldLogLoopExitError(deadlineCtx, context.DeadlineExceeded))
 	})
 
 	t.Run("wrapped deadline exceeded", func(t *testing.T) {
 		err := errors.Join(errors.New("loop stopped"), context.DeadlineExceeded)
-		assert.False(t, shouldLogLoopExitError(err))
+		assert.False(t, shouldLogLoopExitError(deadlineCtx, err))
+	})
+
+	t.Run("deadline exceeded while parent context still active", func(t *testing.T) {
+		assert.True(t, shouldLogLoopExitError(context.Background(), context.DeadlineExceeded))
+	})
+
+	t.Run("canceled while parent context still active", func(t *testing.T) {
+		assert.True(t, shouldLogLoopExitError(context.Background(), context.Canceled))
 	})
 
 	t.Run("real error", func(t *testing.T) {
-		assert.True(t, shouldLogLoopExitError(errors.New("unexpected failure")))
+		assert.True(t, shouldLogLoopExitError(context.Background(), errors.New("unexpected failure")))
+	})
+}
+
+func TestWaitForWaitGroup(t *testing.T) {
+	t.Run("returns true when waitgroup completes", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(10 * time.Millisecond)
+		}()
+		assert.True(t, waitForWaitGroup(&wg, 200*time.Millisecond))
+	})
+
+	t.Run("returns false on timeout", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		assert.False(t, waitForWaitGroup(&wg, 10*time.Millisecond))
+		wg.Done()
+		assert.True(t, waitForWaitGroup(&wg, 100*time.Millisecond))
 	})
 }
 
@@ -461,6 +497,24 @@ func TestServerStop(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestServerStopCancelsBackgroundLoops(t *testing.T) {
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	s := &Server{
+		loopCtx:    loopCtx,
+		loopCancel: loopCancel,
+	}
+	s.loopWG.Add(1)
+	go func() {
+		defer s.loopWG.Done()
+		<-loopCtx.Done()
+	}()
+
+	s.Stop()
+
+	assert.ErrorIs(t, loopCtx.Err(), context.Canceled)
+	assert.True(t, waitForWaitGroup(&s.loopWG, 100*time.Millisecond))
 }
 
 // TestServerStopWithDatabases tests Stop with actual database connections.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -17,6 +17,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -156,6 +157,29 @@ func TestGetInventorySyncTimeout(t *testing.T) {
 			assert.Equal(t, tt.expected, getInventorySyncTimeout(tt.config))
 		})
 	}
+}
+
+func TestShouldLogLoopExitError(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, shouldLogLoopExitError(nil))
+	})
+
+	t.Run("context canceled", func(t *testing.T) {
+		assert.False(t, shouldLogLoopExitError(context.Canceled))
+	})
+
+	t.Run("context deadline exceeded", func(t *testing.T) {
+		assert.False(t, shouldLogLoopExitError(context.DeadlineExceeded))
+	})
+
+	t.Run("wrapped deadline exceeded", func(t *testing.T) {
+		err := errors.Join(errors.New("loop stopped"), context.DeadlineExceeded)
+		assert.False(t, shouldLogLoopExitError(err))
+	})
+
+	t.Run("real error", func(t *testing.T) {
+		assert.True(t, shouldLogLoopExitError(errors.New("unexpected failure")))
+	})
 }
 
 func TestGetAttestationSettings(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -17,7 +17,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -158,44 +157,6 @@ func TestGetInventorySyncTimeout(t *testing.T) {
 			assert.Equal(t, tt.expected, getInventorySyncTimeout(tt.config))
 		})
 	}
-}
-
-func TestShouldLogLoopExitError(t *testing.T) {
-	canceledCtx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	deadlineCtx, deadlineCancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-	defer deadlineCancel()
-	<-deadlineCtx.Done()
-
-	t.Run("nil error", func(t *testing.T) {
-		assert.False(t, shouldLogLoopExitError(context.Background(), nil))
-	})
-
-	t.Run("context canceled during shutdown", func(t *testing.T) {
-		assert.False(t, shouldLogLoopExitError(canceledCtx, context.Canceled))
-	})
-
-	t.Run("context deadline exceeded during shutdown", func(t *testing.T) {
-		assert.False(t, shouldLogLoopExitError(deadlineCtx, context.DeadlineExceeded))
-	})
-
-	t.Run("wrapped deadline exceeded", func(t *testing.T) {
-		err := errors.Join(errors.New("loop stopped"), context.DeadlineExceeded)
-		assert.False(t, shouldLogLoopExitError(deadlineCtx, err))
-	})
-
-	t.Run("deadline exceeded while parent context still active", func(t *testing.T) {
-		assert.True(t, shouldLogLoopExitError(context.Background(), context.DeadlineExceeded))
-	})
-
-	t.Run("canceled while parent context still active", func(t *testing.T) {
-		assert.True(t, shouldLogLoopExitError(context.Background(), context.Canceled))
-	})
-
-	t.Run("real error", func(t *testing.T) {
-		assert.True(t, shouldLogLoopExitError(context.Background(), errors.New("unexpected failure")))
-	})
 }
 
 func TestWaitForWaitGroup(t *testing.T) {


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline mode now performs an immediate export at startup so short-lived runs produce output before the first scheduled interval.

* **Improvements**
  * Server shutdown now coordinates and waits for background loops to exit, with bounded wait and clearer timeout handling.

* **Documentation**
  * Helm chart README, values, daemonset template, and install guide updated with optional enrollment metadata flags and usage notes.

* **Tests**
  * Added tests for offline export behavior and for background-loop coordination and shutdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/fleet-intelligence-agent/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->