### PR TITLE
docs: update supported platform docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ Built on top of [leptonai/gpud](https://github.com/leptonai/gpud)
 
 ## Overview
 
-For installation prerequisites and setup details, see:
-[Helm Installation](docs/install-helm.md), [DEB Installation](docs/install-deb.md), and [RPM Installation](docs/install-rpm.md).
-
 **What It Monitors:**
 - GPU Metrics: Power, temperature, clocks, utilization, memory, Xid events
 - System Metrics: CPU, memory, disk, network usage
@@ -20,7 +17,7 @@ For installation prerequisites and setup details, see:
 - Remote Export: Sends telemetry data to OpenTelemetry-compatible endpoints via OTLP over HTTP
 
 **Key Features:**
-- Lightweight: <100MB RAM, <1% CPU usage
+- Lightweight: <500MB RAM, <1% CPU usage
 - Non-intrusive: Read-only operations, no system modifications
 - Production-ready: 24/7 datacenter operation
 
@@ -28,13 +25,15 @@ For installation prerequisites and setup details, see:
 
 | OS Family | Supported Versions | Architecture | GPU |
 |-----------|--------------------|--------------|-----|
-| Ubuntu | 22.04, 24.04 | x86_64, ARM64 | Hopper, Blackwell, Rubin |
-| RHEL | 8, 9, 10 | x86_64, ARM64 | Hopper, Blackwell, Rubin |
-| Rocky Linux | 8, 9, 10 | x86_64, ARM64 | Hopper, Blackwell, Rubin |
-| AlmaLinux | 8, 9, 10 | x86_64, ARM64 | Hopper, Blackwell, Rubin |
-| Amazon Linux | 2023 | x86_64, ARM64 | Hopper, Blackwell, Rubin |
+| Ubuntu | 22.04, 24.04 | x86_64, ARM64 | Ampere, Ada Lovelace, Hopper, Blackwell, Rubin |
+| RHEL | 8, 9, 10 | x86_64, ARM64 | Ampere, Ada Lovelace, Hopper, Blackwell, Rubin |
+| Rocky Linux | 8, 9, 10 | x86_64, ARM64 | Ampere, Ada Lovelace, Hopper, Blackwell, Rubin |
+| AlmaLinux | 8, 9, 10 | x86_64, ARM64 | Ampere, Ada Lovelace, Hopper, Blackwell, Rubin |
+| Amazon Linux | 2023 | x86_64, ARM64 | Ampere, Ada Lovelace, Hopper, Blackwell, Rubin |
 
 ## Documentation
+
+**Important:** Documentation links are relative to the branch or tag you are viewing. The default GitHub view uses `main`, which may describe unreleased changes. When installing or upgrading a specific agent version, switch to that version's release tag first.
 
 - [Helm Installation](docs/install-helm.md) - Kubernetes (Helm) installation and troubleshooting
 - [DEB Installation](docs/install-deb.md) - Ubuntu package install, update, and uninstall

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,7 +92,7 @@ Validates the local prerequisites required for installation and enrollment.
 
 **What it checks:**
 - NVIDIA GPU presence
-- supported GPU architecture (`Hopper`, `Blackwell`, `Rubin`, `Ampere`, `Ada Lovelace`)
+- supported GPU architecture (`Ampere`, `Ada Lovelace`, `Hopper`, `Blackwell`, `Rubin`)
 - NVIDIA driver major version (`510` or newer)
 - DCGM HostEngine reachability
 - DCGM HostEngine minimum version (`4.2.3`)
@@ -384,7 +384,7 @@ scrape_configs:
 
 ### High resource usage
 
-The agent should use <100MB RAM and <1% CPU. Higher usage might indicate:
+The agent should use <500MB RAM and <1% CPU. Higher usage might indicate:
 
 - Very frequent collection intervals (check `FLEETINT_COLLECT_INTERVAL`)
 - Large lookback windows (check `FLEETINT_METRICS_LOOKBACK` and `FLEETINT_EVENTS_LOOKBACK`)


### PR DESCRIPTION
## Summary

- Update documented RAM usage guidance from `<100MB` to `<500MB`.
- Add Ampere and Ada Lovelace to the supported GPU architecture lists, ordered before Hopper, Blackwell, and Rubin.
- Add a bold warning that README documentation links point to `main` and release-specific installs should use docs from the matching release tag.

## Validation

- Reviewed the staged diff for `README.md` and `docs/usage.md`.
- No tests run; documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated resource guidance: target RAM threshold for "High resource usage" guidance changed from <100MB to <500MB.
  * Expanded supported GPU architectures in platform tables to include Ampere and Ada Lovelace alongside previously listed models.
  * Added an "Important" note clarifying linked documentation points to the main branch and may describe unreleased changes; recommend using documentation from the release tag matching your agent version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/fleet-intelligence-agent/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->