### PR TITLE
feat: add collectedAt to node upsert

### DIFF
--- a/internal/backendclient/types.go
+++ b/internal/backendclient/types.go
@@ -34,6 +34,7 @@ type NodeUpsertRequest struct {
 	MachineID               string        `json:"machineId"`
 	BootID                  string        `json:"bootID"`
 	Uptime                  *time.Time    `json:"uptime,omitempty"`
+	CollectedAt             *time.Time    `json:"collectedAt,omitempty"`
 	EnrolledAt              *time.Time    `json:"enrolledAt,omitempty"`
 	NetPrivateIP            string        `json:"netPrivateIP,omitempty"`
 	NodeGroup               string        `json:"nodeGroup"`

--- a/internal/inventory/mapper/backend.go
+++ b/internal/inventory/mapper/backend.go
@@ -71,6 +71,11 @@ func ToNodeUpsertRequest(s *inventory.Snapshot) *backendclient.NodeUpsertRequest
 		normalized := s.Uptime.UTC()
 		uptime = &normalized
 	}
+	var collectedAt *time.Time
+	if !s.CollectedAt.IsZero() {
+		normalized := s.CollectedAt.UTC()
+		collectedAt = &normalized
+	}
 
 	return &backendclient.NodeUpsertRequest{
 		Hostname: s.Hostname,
@@ -88,6 +93,7 @@ func ToNodeUpsertRequest(s *inventory.Snapshot) *backendclient.NodeUpsertRequest
 		SystemUUID:              s.SystemUUID,
 		BootID:                  s.BootID,
 		Uptime:                  uptime,
+		CollectedAt:             collectedAt,
 		OperatingSystem:         s.OperatingSystem,
 		OSImage:                 s.OSImage,
 		KernelVersion:           s.KernelVersion,

--- a/internal/inventory/mapper/backend_test.go
+++ b/internal/inventory/mapper/backend_test.go
@@ -49,7 +49,9 @@ func TestToNodeUpsertRequestAgentConfigJSONIncludesZeroValues(t *testing.T) {
 
 func TestToNodeUpsertRequest(t *testing.T) {
 	bootTime := time.Date(2026, 4, 28, 12, 30, 0, 0, time.FixedZone("PDT", -7*60*60))
+	collectedAt := time.Date(2026, 4, 28, 13, 30, 0, 0, time.FixedZone("PDT", -7*60*60))
 	req := ToNodeUpsertRequest(&inventory.Snapshot{
+		CollectedAt:             collectedAt,
 		Hostname:                "host-a",
 		MachineID:               "machine-id",
 		SystemUUID:              "uuid-1",
@@ -128,6 +130,8 @@ func TestToNodeUpsertRequest(t *testing.T) {
 	require.Equal(t, "machine-id", req.MachineID)
 	require.NotNil(t, req.Uptime)
 	require.Equal(t, bootTime.UTC(), *req.Uptime)
+	require.NotNil(t, req.CollectedAt)
+	require.Equal(t, collectedAt.UTC(), *req.CollectedAt)
 	require.Equal(t, int64(30), req.AgentConfig.TotalComponents)
 	require.Equal(t, int64(86400), req.AgentConfig.RetentionPeriodSeconds)
 	require.Equal(t, []string{"cpu", "gpu"}, req.AgentConfig.EnabledComponents)

--- a/internal/inventory/sink/backend_test.go
+++ b/internal/inventory/sink/backend_test.go
@@ -170,8 +170,9 @@ func TestBackendSinkExportUsesState(t *testing.T) {
 	}
 
 	err := s.Export(context.Background(), &inventory.Snapshot{
-		Hostname:  "host-a",
-		MachineID: "machine-id",
+		CollectedAt: time.Date(2026, 5, 6, 16, 0, 0, 0, time.UTC),
+		Hostname:    "host-a",
+		MachineID:   "machine-id",
 	})
 	require.NoError(t, err)
 	require.Equal(t, "node-1", client.nodeUUID)
@@ -180,6 +181,8 @@ func TestBackendSinkExportUsesState(t *testing.T) {
 	require.Equal(t, "host-a", client.req.Hostname)
 	require.Equal(t, "group-a", client.req.NodeGroup)
 	require.Equal(t, "zone-a", client.req.ComputeZone)
+	require.NotNil(t, client.req.CollectedAt)
+	require.Equal(t, time.Date(2026, 5, 6, 16, 0, 0, 0, time.UTC), *client.req.CollectedAt)
 	require.NotNil(t, client.req.EnrolledAt)
 	require.Equal(t, enrollmentTime, *client.req.EnrolledAt)
 }

--- a/internal/validation/outbound/validator.go
+++ b/internal/validation/outbound/validator.go
@@ -79,6 +79,7 @@ func ValidateNodeUpsertRequest(req *backendclient.NodeUpsertRequest) []Issue {
 	requireNonEmpty(&issues, "identity", "systemUUID", req.SystemUUID, SeverityCritical)
 
 	validateTimeSanity(&issues, "time", "uptime", req.Uptime)
+	validateTimeSanity(&issues, "time", "collectedAt", req.CollectedAt)
 	validateTimeSanity(&issues, "time", "enrolledAt", req.EnrolledAt)
 
 	validateLen(&issues, "length", "hostname", req.Hostname, 255)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timestamp tracking to record when node and inventory data is collected. The system now validates collection timestamps to ensure data integrity and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/fleet-intelligence-agent/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->