### PR TITLE
chore: update go version to 1.26.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, 'release/**' ]
 
 env:
-  GO_VERSION: '1.26.3'
+  GO_VERSION: '1.26.4'
   GOFLAGS: '-trimpath'
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'  # Triggers on version tags like v1.0.0, v2.1.3, etc.
 
 env:
-  GO_VERSION: '1.26.3'
+  GO_VERSION: '1.26.4'
 
 permissions:
   contents: write  # Needed for creating GitHub releases

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: 1.26.3
+  go: 1.26.4
 linters:
   default: none
   enable:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Please start all enhancement, bugfix, or change requests by opening a GitHub iss
 ## Development
 
 ### Prerequisites
-- Go 1.24+ (see `go.mod`)
+- Go 1.26.4+ (see `go.mod`)
 - Make
 - golangci-lint (optional locally, required in CI)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG DCGM_VERSION="4.4.2-1-ubuntu22.04"
 
-FROM golang:1.26.3 AS build
+FROM golang:1.26.4 AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/Dockerfile.citests
+++ b/Dockerfile.citests
@@ -16,7 +16,7 @@
 # Run specific package tests:
 #   docker run --rm fleet-intelligence-agent:test go test -v ./internal/...
 #
-FROM golang:1.26.3
+FROM golang:1.26.4
 
 ARG TARGETARCH
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,7 +11,7 @@ cd fleet-intelligence-agent
 
 ### Prerequisites
 
-- **Go**: 1.26.3
+- **Go**: 1.26.4
 - **GoReleaser**: For building packages (install from [goreleaser.com](https://goreleaser.com/install/))
 - **For ARM64 cross-compilation** (optional): `gcc-aarch64-linux-gnu` and `g++-aarch64-linux-gnu`
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/fleet-intelligence-agent
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/NVIDIA/fleet-intelligence-sdk v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain version from 1.26.3 to 1.26.4 across all CI workflows, Docker images, linting configuration, and project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->