### PR TITLE
fix: ubuntu deb package upgrade restart the service

### DIFF
--- a/deployments/packages/scripts/postinst
+++ b/deployments/packages/scripts/postinst
@@ -21,11 +21,11 @@ else
         configure)
             if [ -n "$2" ]; then
                 # $2 is the previous version — Debian upgrade path
-                echo "Upgrade detected - (re)starting service..."
+                echo "Upgrade detected - restarting service if already running..."
                 if systemctl is-active --quiet fleetintd.service; then
                     systemctl restart fleetintd.service || echo "[WARNING] Failed to restart service"
                 else
-                    systemctl start fleetintd.service || echo "[WARNING] Failed to start service"
+                    echo "Service is not running - not starting during upgrade"
                 fi
             else
                 echo "Fresh installation - enabling and starting service..."
@@ -39,11 +39,11 @@ else
             systemctl start fleetintd.service || echo "[WARNING] Failed to start service"
             ;;
         upgrade|2)
-            echo "Upgrade detected - (re)starting service..."
+            echo "Upgrade detected - restarting service if already running..."
             if systemctl is-active --quiet fleetintd.service; then
                 systemctl restart fleetintd.service || echo "[WARNING] Failed to restart service"
             else
-                systemctl start fleetintd.service || echo "[WARNING] Failed to start service"
+                echo "Service is not running - not starting during upgrade"
             fi
             ;;
         abort-upgrade|abort-remove|abort-deconfigure)

--- a/deployments/packages/scripts/postinst
+++ b/deployments/packages/scripts/postinst
@@ -18,7 +18,22 @@ else
     systemctl daemon-reload || echo "[WARNING] Failed to reload systemd daemon"
 
     case "$1" in
-        configure|install|1)
+        configure)
+            if [ -n "$2" ]; then
+                # $2 is the previous version — Debian upgrade path
+                echo "Upgrade detected - (re)starting service..."
+                if systemctl is-active --quiet fleetintd.service; then
+                    systemctl restart fleetintd.service || echo "[WARNING] Failed to restart service"
+                else
+                    systemctl start fleetintd.service || echo "[WARNING] Failed to start service"
+                fi
+            else
+                echo "Fresh installation - enabling and starting service..."
+                systemctl enable fleetintd.service || echo "[WARNING] Failed to enable service"
+                systemctl start fleetintd.service || echo "[WARNING] Failed to start service"
+            fi
+            ;;
+        install|1)
             echo "Fresh installation - enabling and starting service..."
             systemctl enable fleetintd.service || echo "[WARNING] Failed to enable service"
             systemctl start fleetintd.service || echo "[WARNING] Failed to start service"


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined install/upgrade behavior for the bundled service: fresh installs enable and start the service, while upgrades and configuration runs now only restart the service if it is already running, avoiding unintended service starts. This reduces unexpected service restarts and improves stability during package operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->