### PR TITLE
fix: make DCGM group name configurable and different for each process

### DIFF
--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -124,8 +124,10 @@ func Scan(ctx context.Context, opts ...Option) error {
 		}
 	}
 
+	dcgmGroupNames := components.NewDCGMGroupNames(fmt.Sprintf("scan-%d", os.Getpid()))
+
 	// Initialize DCGM instance for DCGM-based health checks
-	dcgmInstance, err := nvidiadcgm.New()
+	dcgmInstance, err := nvidiadcgm.NewWithGroupName(dcgmGroupNames.HealthMonitoringGroup)
 	if err != nil {
 		return err
 	}
@@ -159,6 +161,7 @@ func Scan(ctx context.Context, opts ...Option) error {
 		DCGMInstance:        dcgmInstance,
 		DCGMHealthCache:     dcgmHealthCache,
 		DCGMFieldValueCache: dcgmFieldValueCache,
+		DCGMGroupNames:      dcgmGroupNames,
 		NVIDIAToolOverwrites: nvidiacommon.ToolOverwrites{
 			InfinibandClassRootDir: op.infinibandClassRootDir,
 		},
@@ -191,7 +194,7 @@ func Scan(ctx context.Context, opts ...Option) error {
 	}
 
 	// Set up DCGM field watching after all components have registered their fields
-	if err := dcgmFieldValueCache.SetupFieldWatching(); err != nil {
+	if err := dcgmFieldValueCache.SetupFieldWatchingWithName(dcgmGroupNames.GPUFieldGroup); err != nil {
 		log.Logger.Warnw("failed to set up DCGM field watching", "error", err)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -296,9 +296,11 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 		return nil, fmt.Errorf("failed to create NVML instance: %w", err)
 	}
 
+	dcgmGroupNames := components.NewDCGMGroupNames(fmt.Sprintf("daemon-%d", stdos.Getpid()))
+
 	// Initialize DCGM instance
 	dcgmInitCtx, dcgmInitCancel := context.WithTimeout(ctx, time.Minute)
-	dcgmInstance, err := nvidiadcgm.NewWithContext(dcgmInitCtx)
+	dcgmInstance, err := nvidiadcgm.NewWithContextAndGroupName(dcgmInitCtx, dcgmGroupNames.HealthMonitoringGroup)
 	dcgmInitCancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DCGM instance: %w", err)
@@ -337,6 +339,7 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 		DCGMInstance:         dcgmInstance,
 		DCGMHealthCache:      dcgmHealthCache,
 		DCGMFieldValueCache:  dcgmFieldValueCache,
+		DCGMGroupNames:       dcgmGroupNames,
 		NVIDIAToolOverwrites: config.NvidiaToolOverwrites,
 		DBRW:                 dbRW,
 		DBRO:                 dbRO,
@@ -364,7 +367,7 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 
 	// Set up DCGM field watching after all components have registered their fields
 	if dcgmFieldValueCache != nil {
-		if err := dcgmFieldValueCache.SetupFieldWatching(); err != nil {
+		if err := dcgmFieldValueCache.SetupFieldWatchingWithName(dcgmGroupNames.GPUFieldGroup); err != nil {
 			log.Logger.Errorw("failed to set up DCGM field watching, DCGM metrics collection unavailable", "error", err)
 		}
 	}

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/cpu/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/cpu/component.go
@@ -65,6 +65,7 @@ type component struct {
 
 func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	cctx, ccancel := context.WithCancel(gpudInstance.RootCtx)
+	dcgmGroupNames := gpudInstance.DCGMGroupNames.WithDefaults()
 
 	healthCheckInterval := defaultHealthCheckInterval
 	if gpudInstance.HealthCheckInterval > 0 {
@@ -100,7 +101,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		c.cpuEntities = cpuEntities
 
 		// Create a dedicated DCGM group for CPUs
-		cpuGroupHandle, err := dcgm.CreateGroup("gpud-cpu-group")
+		cpuGroupHandle, err := dcgm.CreateGroup(dcgmGroupNames.CPUGroup)
 		if err != nil {
 			log.Logger.Warnw("failed to create DCGM group for CPUs", "error", err)
 			c.setupDegradedReason = fmt.Sprintf("failed to create DCGM CPU group: %v", err)
@@ -119,7 +120,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		}
 
 		// Create a field group for this component's CPU fields
-		fieldGroupName := "gpud-cpu-fields"
+		fieldGroupName := dcgmGroupNames.CPUFieldGroup
 		fieldGroupID, err := dcgm.FieldGroupCreate(fieldGroupName, cpuLevelFields)
 		if err != nil {
 			log.Logger.Warnw("failed to create DCGM field group for CPU fields", "error", err)

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/prof/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/dcgm/prof/component.go
@@ -68,6 +68,7 @@ type component struct {
 // fieldValidator validates fields based on hardware support
 func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	cctx, ccancel := context.WithCancel(gpudInstance.RootCtx)
+	dcgmGroupNames := gpudInstance.DCGMGroupNames.WithDefaults()
 
 	healthCheckInterval := defaultHealthCheckInterval
 	if gpudInstance.HealthCheckInterval > 0 {
@@ -119,7 +120,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		c.watchedFields = validFields
 
 		// Create field group with ONLY hardware-validated fields
-		fieldGroupName := "gpud-prof-fields"
+		fieldGroupName := dcgmGroupNames.ProfilingFieldGroup
 		fieldGroupID, err := dcgm.FieldGroupCreate(fieldGroupName, validFields)
 		if err != nil {
 			log.Logger.Warnw("failed to create DCGM field group", "error", err)
@@ -280,7 +281,7 @@ func (c *component) Check() components.CheckResult {
 					"action", "systemd/k8s will restart agent and recreate DCGM resources")
 				os.Exit(1)
 			}
-			
+
 			// Check if this is a transient error (benign, skip)
 			if nvidiadcgm.IsTransientError(err) {
 				log.Logger.Infow("DCGM transient error, will retry",
@@ -289,7 +290,7 @@ func (c *component) Check() components.CheckResult {
 					"error", err)
 				continue
 			}
-			
+
 			// For unhealthy or unknown errors, set component state
 			if nvidiadcgm.IsUnhealthyAPIError(err) {
 				cr.health = apiv1.HealthStateTypeUnhealthy
@@ -314,101 +315,101 @@ func (c *component) Check() components.CheckResult {
 
 			// Value is valid - export metric based on field type
 			switch val.FieldID {
-		case dcgm.DCGM_FI_PROF_GR_ENGINE_ACTIVE:
-			metricDCGMFIProfGrEngineActive.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_GR_ENGINE_ACTIVE:
+				metricDCGMFIProfGrEngineActive.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_SM_ACTIVE:
-			metricDCGMFIProfSmActive.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_SM_ACTIVE:
+				metricDCGMFIProfSmActive.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_SM_OCCUPANCY:
-			metricDCGMFIProfSmOccupancy.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_SM_OCCUPANCY:
+				metricDCGMFIProfSmOccupancy.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_PIPE_TENSOR_ACTIVE:
-			metricDCGMFIProfPipeTensorActive.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_PIPE_TENSOR_ACTIVE:
+				metricDCGMFIProfPipeTensorActive.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_PIPE_TENSOR_IMMA_ACTIVE:
-			metricDCGMFIProfPipeTensorImmaActive.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_PIPE_TENSOR_IMMA_ACTIVE:
+				metricDCGMFIProfPipeTensorImmaActive.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_PIPE_TENSOR_HMMA_ACTIVE:
-			metricDCGMFIProfPipeTensorHmmaActive.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_PIPE_TENSOR_HMMA_ACTIVE:
+				metricDCGMFIProfPipeTensorHmmaActive.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_PIPE_TENSOR_DFMA_ACTIVE:
-			metricDCGMFIProfPipeTensorDfmaActive.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_PIPE_TENSOR_DFMA_ACTIVE:
+				metricDCGMFIProfPipeTensorDfmaActive.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_PIPE_INT_ACTIVE:
-			metricDCGMFIProfPipeIntActive.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_PIPE_INT_ACTIVE:
+				metricDCGMFIProfPipeIntActive.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_DRAM_ACTIVE:
-			metricDCGMFIProfDramActive.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_DRAM_ACTIVE:
+				metricDCGMFIProfDramActive.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_PIPE_FP64_ACTIVE:
-			metricDCGMFIProfPipeFp64Active.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_PIPE_FP64_ACTIVE:
+				metricDCGMFIProfPipeFp64Active.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_PIPE_FP32_ACTIVE:
-			metricDCGMFIProfPipeFp32Active.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_PIPE_FP32_ACTIVE:
+				metricDCGMFIProfPipeFp32Active.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_PIPE_FP16_ACTIVE:
-			metricDCGMFIProfPipeFp16Active.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(val.Float64())
+			case dcgm.DCGM_FI_PROF_PIPE_FP16_ACTIVE:
+				metricDCGMFIProfPipeFp16Active.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(val.Float64())
 
-		case dcgm.DCGM_FI_PROF_PCIE_TX_BYTES:
-			metricDCGMFIProfPcieTxBytes.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(float64(val.Int64()))
+			case dcgm.DCGM_FI_PROF_PCIE_TX_BYTES:
+				metricDCGMFIProfPcieTxBytes.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(float64(val.Int64()))
 
-		case dcgm.DCGM_FI_PROF_PCIE_RX_BYTES:
-			metricDCGMFIProfPcieRxBytes.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(float64(val.Int64()))
+			case dcgm.DCGM_FI_PROF_PCIE_RX_BYTES:
+				metricDCGMFIProfPcieRxBytes.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(float64(val.Int64()))
 
-		case dcgm.DCGM_FI_PROF_NVLINK_TX_BYTES:
-			metricDCGMFIProfNvlinkTxBytes.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(float64(val.Int64()))
+			case dcgm.DCGM_FI_PROF_NVLINK_TX_BYTES:
+				metricDCGMFIProfNvlinkTxBytes.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(float64(val.Int64()))
 
-		case dcgm.DCGM_FI_PROF_NVLINK_RX_BYTES:
-			metricDCGMFIProfNvlinkRxBytes.With(prometheus.Labels{
-				"uuid":      device.UUID,
-				"gpu": fmt.Sprintf("%d", device.ID),
-			}).Set(float64(val.Int64()))
+			case dcgm.DCGM_FI_PROF_NVLINK_RX_BYTES:
+				metricDCGMFIProfNvlinkRxBytes.With(prometheus.Labels{
+					"uuid": device.UUID,
+					"gpu":  fmt.Sprintf("%d", device.ID),
+				}).Set(float64(val.Int64()))
 			}
 		}
 	}

--- a/third_party/fleet-intelligence-sdk/components/registry.go
+++ b/third_party/fleet-intelligence-sdk/components/registry.go
@@ -35,11 +35,12 @@ type GPUdInstance struct {
 
 	KernelModulesToCheck []string
 
-	DCGMInstance        nvidiadcgm.Instance
-	DCGMHealthCache     *nvidiadcgm.HealthCache     // Shared cache for DCGM health check results
-	DCGMFieldValueCache *nvidiadcgm.FieldValueCache // Shared cache for DCGM field values (GPU devices only)
-	NVMLInstance        nvidianvml.Instance
-	NVIDIAToolOverwrites     nvidiacommon.ToolOverwrites
+	DCGMInstance         nvidiadcgm.Instance
+	DCGMHealthCache      *nvidiadcgm.HealthCache     // Shared cache for DCGM health check results
+	DCGMFieldValueCache  *nvidiadcgm.FieldValueCache // Shared cache for DCGM field values (GPU devices only)
+	DCGMGroupNames       DCGMGroupNames
+	NVMLInstance         nvidianvml.Instance
+	NVIDIAToolOverwrites nvidiacommon.ToolOverwrites
 
 	DBRW *sql.DB
 	DBRO *sql.DB
@@ -54,6 +55,52 @@ type GPUdInstance struct {
 	HealthCheckInterval time.Duration
 
 	FailureInjector *FailureInjector
+}
+
+// DCGMGroupNames names the DCGM groups and field groups owned by one fleetint process.
+type DCGMGroupNames struct {
+	HealthMonitoringGroup string
+	GPUFieldGroup         string
+	CPUGroup              string
+	CPUFieldGroup         string
+	ProfilingFieldGroup   string
+}
+
+// NewDCGMGroupNames returns a fleetint-owned set of DCGM names for a single owner.
+func NewDCGMGroupNames(owner string) DCGMGroupNames {
+	return DCGMGroupNames{
+		HealthMonitoringGroup: fmt.Sprintf("fleetint-%s-health", owner),
+		GPUFieldGroup:         fmt.Sprintf("fleetint-%s-gpu-fields", owner),
+		CPUGroup:              fmt.Sprintf("fleetint-%s-cpu", owner),
+		CPUFieldGroup:         fmt.Sprintf("fleetint-%s-cpu-fields", owner),
+		ProfilingFieldGroup:   fmt.Sprintf("fleetint-%s-prof-fields", owner),
+	}
+}
+
+// DefaultDCGMGroupNames returns fleetint defaults for callers that do not provide names.
+func DefaultDCGMGroupNames() DCGMGroupNames {
+	return NewDCGMGroupNames("default")
+}
+
+// WithDefaults fills any missing names with fleetint defaults.
+func (n DCGMGroupNames) WithDefaults() DCGMGroupNames {
+	defaults := DefaultDCGMGroupNames()
+	if n.HealthMonitoringGroup == "" {
+		n.HealthMonitoringGroup = defaults.HealthMonitoringGroup
+	}
+	if n.GPUFieldGroup == "" {
+		n.GPUFieldGroup = defaults.GPUFieldGroup
+	}
+	if n.CPUGroup == "" {
+		n.CPUGroup = defaults.CPUGroup
+	}
+	if n.CPUFieldGroup == "" {
+		n.CPUFieldGroup = defaults.CPUFieldGroup
+	}
+	if n.ProfilingFieldGroup == "" {
+		n.ProfilingFieldGroup = defaults.ProfilingFieldGroup
+	}
+	return n
 }
 
 type FailureInjector struct {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/field_cache.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/field_cache.go
@@ -56,7 +56,7 @@ func NewFieldValueCache(ctx context.Context, instance Instance, pollInterval tim
 		cancel:         ccancel,
 		instance:       instance,
 		values:         make(map[uint]map[dcgm.Short]dcgm.FieldValue_v1),
-		fieldGroupName: "gpud-gpu-fields",
+		fieldGroupName: "fleetint-default-gpu-fields",
 		pollInterval:   pollInterval,
 	}
 

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -246,6 +246,12 @@ var newConnectedInstanceWithGroupNameFunc = func(groupName string) (Instance, er
 	return newConnectedInstance(groupName)
 }
 
+var dcgmInitFunc = func(initParams dcgmInitParams) (func(), error) {
+	return dcgm.Init(dcgm.Standalone, initParams.address, initParams.isUnixSocket)
+}
+
+var dcgmNewDefaultGroupFunc = dcgm.NewDefaultGroup
+
 func newInitializedInstance() (Instance, error) {
 	connectedInst, err := newConnectedInstanceFunc()
 	if err != nil {
@@ -280,7 +286,7 @@ func newConnectedInstance(groupName string) (Instance, error) {
 	}
 	initParams := resolveInitFromEnv()
 
-	cleanup, err := dcgm.Init(dcgm.Standalone, initParams.address, initParams.isUnixSocket)
+	cleanup, err := dcgmInitFunc(initParams)
 	if err != nil {
 		return nil, err
 	}
@@ -288,8 +294,11 @@ func newConnectedInstance(groupName string) (Instance, error) {
 	log.Logger.Debugw("DCGM initialized successfully")
 
 	// Create group with GPUs. Components add their own entities (e.g., NVSwitch).
-	groupHandle, err := dcgm.NewDefaultGroup(groupName)
+	groupHandle, err := dcgmNewDefaultGroupFunc(groupName)
 	if err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
 		return nil, fmt.Errorf("failed to create custom DCGM group: %w", err)
 	}
 

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -33,6 +33,7 @@ import (
 var _ Instance = &instance{}
 
 const defaultDCGMReconnectInterval = 30 * time.Second
+const defaultDCGMGroupName = "fleetint-default-health"
 
 var dcgmReconnectInterval = defaultDCGMReconnectInterval
 var errReconnectAborted = errors.New("dcgm reconnect aborted")
@@ -172,10 +173,21 @@ func New() (Instance, error) {
 	return newInitializedInstance()
 }
 
+// NewWithGroupName creates a DCGM instance with a caller-owned DCGM group name.
+func NewWithGroupName(groupName string) (Instance, error) {
+	return newInitializedInstanceWithGroupName(groupName)
+}
+
 // NewWithContext creates a DCGM instance with a bounded wait. If initialization
 // exceeds the context deadline, it returns a no-op instance so callers can
 // continue startup without blocking on slow DCGM device enumeration.
 func NewWithContext(ctx context.Context) (Instance, error) {
+	return NewWithContextAndGroupName(ctx, defaultDCGMGroupName)
+}
+
+// NewWithContextAndGroupName creates a DCGM instance with a bounded wait and
+// caller-owned DCGM group name.
+func NewWithContextAndGroupName(ctx context.Context, groupName string) (Instance, error) {
 	type result struct {
 		inst Instance
 		err  error
@@ -186,7 +198,7 @@ func NewWithContext(ctx context.Context) (Instance, error) {
 	initFn := newInstanceFunc
 
 	go func() {
-		inst, err := initFn()
+		inst, err := initFnWithGroupName(initFn, groupName)
 		select {
 		case resultCh <- result{inst: inst, err: err}:
 		case <-abandonCh:
@@ -207,7 +219,7 @@ func NewWithContext(ctx context.Context) (Instance, error) {
 				"retryInterval", dcgmReconnectInterval.String(),
 			)
 		}
-		return newReconnectingInstance(res.inst, dcgmReconnectInterval), nil
+		return newReconnectingInstanceWithGroupName(res.inst, dcgmReconnectInterval, groupName), nil
 	case <-ctx.Done():
 		close(abandonCh)
 		log.Logger.Warnw(
@@ -215,12 +227,23 @@ func NewWithContext(ctx context.Context) (Instance, error) {
 			"error", ctx.Err(),
 			"retryInterval", dcgmReconnectInterval.String(),
 		)
-		return newReconnectingInstance(NewNoOp(), dcgmReconnectInterval), nil
+		return newReconnectingInstanceWithGroupName(NewNoOp(), dcgmReconnectInterval, groupName), nil
 	}
 }
 
+func initFnWithGroupName(initFn func() (Instance, error), groupName string) (Instance, error) {
+	if groupName == "" || groupName == defaultDCGMGroupName {
+		return initFn()
+	}
+	return newInitializedInstanceWithGroupName(groupName)
+}
+
 var newConnectedInstanceFunc = func() (Instance, error) {
-	return newConnectedInstance()
+	return newConnectedInstance(defaultDCGMGroupName)
+}
+
+var newConnectedInstanceWithGroupNameFunc = func(groupName string) (Instance, error) {
+	return newConnectedInstance(groupName)
 }
 
 func newInitializedInstance() (Instance, error) {
@@ -232,7 +255,29 @@ func newInitializedInstance() (Instance, error) {
 	return connectedInst, nil
 }
 
-func newConnectedInstance() (Instance, error) {
+func newInitializedInstanceWithGroupName(groupName string) (Instance, error) {
+	if groupName == "" {
+		groupName = defaultDCGMGroupName
+	}
+	connectedInst, err := connectWithGroupName(groupName)
+	if err != nil {
+		log.Logger.Warnw("DCGM initialization failed, returning no-op instance", "error", err)
+		return NewNoOp(), nil
+	}
+	return connectedInst, nil
+}
+
+func connectWithGroupName(groupName string) (Instance, error) {
+	if groupName == "" || groupName == defaultDCGMGroupName {
+		return newConnectedInstanceFunc()
+	}
+	return newConnectedInstanceWithGroupNameFunc(groupName)
+}
+
+func newConnectedInstance(groupName string) (Instance, error) {
+	if groupName == "" {
+		groupName = defaultDCGMGroupName
+	}
 	initParams := resolveInitFromEnv()
 
 	cleanup, err := dcgm.Init(dcgm.Standalone, initParams.address, initParams.isUnixSocket)
@@ -243,12 +288,12 @@ func newConnectedInstance() (Instance, error) {
 	log.Logger.Debugw("DCGM initialized successfully")
 
 	// Create group with GPUs. Components add their own entities (e.g., NVSwitch).
-	groupHandle, err := dcgm.NewDefaultGroup("gpud-health-monitoring")
+	groupHandle, err := dcgm.NewDefaultGroup(groupName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create custom DCGM group: %w", err)
 	}
 
-	log.Logger.Infow("created custom DCGM group for isolated health monitoring")
+	log.Logger.Infow("created custom DCGM group for isolated health monitoring", "groupName", groupName)
 
 	// Fetch and cache device information once during initialization
 	deviceIDs, err := dcgm.GetSupportedDevices()
@@ -497,6 +542,7 @@ type reconnectingInstance struct {
 	generation     uint64
 
 	reconnectInterval time.Duration
+	groupName         string
 	stopCh            chan struct{}
 	shutdownOnce      sync.Once
 }
@@ -508,11 +554,18 @@ type reconnectStateSnapshot struct {
 }
 
 func newReconnectingInstance(initial Instance, reconnectInterval time.Duration) Instance {
+	return newReconnectingInstanceWithGroupName(initial, reconnectInterval, defaultDCGMGroupName)
+}
+
+func newReconnectingInstanceWithGroupName(initial Instance, reconnectInterval time.Duration, groupName string) Instance {
 	if initial == nil {
 		initial = NewNoOp()
 	}
 	if reconnectInterval <= 0 {
 		reconnectInterval = defaultDCGMReconnectInterval
+	}
+	if groupName == "" {
+		groupName = defaultDCGMGroupName
 	}
 
 	inst := &reconnectingInstance{
@@ -520,6 +573,7 @@ func newReconnectingInstance(initial Instance, reconnectInterval time.Duration) 
 		watchedFields:     make(map[dcgm.Short]struct{}),
 		groupEntities:     make(map[uint]struct{}),
 		reconnectInterval: reconnectInterval,
+		groupName:         groupName,
 		stopCh:            make(chan struct{}),
 	}
 
@@ -589,7 +643,7 @@ func (inst *reconnectingInstance) reconnectNow() error {
 	expectedGeneration := inst.generation
 	inst.reconnectMu.Unlock()
 
-	connectedInst, err := newConnectedInstanceFunc()
+	connectedInst, err := connectWithGroupName(inst.groupName)
 	if err != nil {
 		return err
 	}

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
@@ -59,6 +59,41 @@ func TestResolveInitFromEnv(t *testing.T) {
 	}
 }
 
+func TestNewConnectedInstanceCleansUpWhenGroupCreationFails(t *testing.T) {
+	originalDCGMInitFunc := dcgmInitFunc
+	originalDCGMNewDefaultGroupFunc := dcgmNewDefaultGroupFunc
+	defer func() {
+		dcgmInitFunc = originalDCGMInitFunc
+		dcgmNewDefaultGroupFunc = originalDCGMNewDefaultGroupFunc
+	}()
+
+	cleanupCalled := false
+	dcgmInitFunc = func(_ dcgmInitParams) (func(), error) {
+		return func() {
+			cleanupCalled = true
+		}, nil
+	}
+
+	expectedErr := errors.New("invalid group name")
+	dcgmNewDefaultGroupFunc = func(_ string) (dcgm.GroupHandle, error) {
+		return dcgm.GroupHandle{}, expectedErr
+	}
+
+	inst, err := newConnectedInstance("invalid group")
+	if err == nil {
+		t.Fatalf("expected newConnectedInstance() to fail")
+	}
+	if inst != nil {
+		t.Fatalf("expected nil instance on group creation failure")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected error %v, got %v", expectedErr, err)
+	}
+	if !cleanupCalled {
+		t.Fatalf("expected DCGM cleanup to be called when group creation fails")
+	}
+}
+
 func TestInstance(t *testing.T) {
 	inst, err := New()
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated GPU/DCGM monitoring to use explicit, process-/owner-derived DCGM group and field-group names instead of defaults or hard-coded identifiers, improving isolation across concurrent processes.
  * Aligned GPU field-watching with the selected named groups, and ensured reconnect behavior reuses the same group naming.
  * Standardized default GPU field-group naming for field caching.
* **Tests**
  * Added a unit test covering cleanup when DCGM group creation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->