### PR TITLE
fix: degrade dcgm query timeouts

### DIFF
--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/query_validator.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/query_validator.go
@@ -210,9 +210,7 @@ func IsUnhealthyAPIError(err error) bool {
 	case dcgm.DCGM_ST_NVML_ERROR,
 		dcgm.DCGM_ST_GPU_IS_LOST,
 		dcgm.DCGM_ST_RESET_REQUIRED,
-		dcgm.DCGM_ST_GPU_NOT_SUPPORTED,
-		dcgm.DCGM_ST_TIMEOUT,
-		dcgm.DCGM_ST_NVML_DRIVER_TIMEOUT:
+		dcgm.DCGM_ST_GPU_NOT_SUPPORTED:
 		return true
 	default:
 		return false

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/query_validator_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/query_validator_test.go
@@ -16,7 +16,10 @@
 package dcgm
 
 import (
+	"fmt"
 	"testing"
+
+	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
 )
 
 // Note: Tests for CheckSentinel() and CheckSentinelV2() require actual DCGM library
@@ -62,6 +65,31 @@ func TestSentinelType_String(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.sentinel.String(); got != tt.want {
 				t.Errorf("SentinelType.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsUnhealthyAPIError(t *testing.T) {
+	tests := []struct {
+		name string
+		code int32
+		want bool
+	}{
+		{"nvml error is unhealthy", dcgm.DCGM_ST_NVML_ERROR, true},
+		{"gpu lost is unhealthy", dcgm.DCGM_ST_GPU_IS_LOST, true},
+		{"reset required is unhealthy", dcgm.DCGM_ST_RESET_REQUIRED, true},
+		{"gpu not supported is unhealthy", dcgm.DCGM_ST_GPU_NOT_SUPPORTED, true},
+		{"dcgm timeout is degraded", dcgm.DCGM_ST_TIMEOUT, false},
+		{"nvml driver timeout is degraded", dcgm.DCGM_ST_NVML_DRIVER_TIMEOUT, false},
+		{"stale data is not unhealthy", dcgm.DCGM_ST_STALE_DATA, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := fmt.Errorf("dcgm request failed with error code %d", tt.code)
+			if got := IsUnhealthyAPIError(err); got != tt.want {
+				t.Errorf("IsUnhealthyAPIError() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted how certain DCGM error states are classified as unhealthy, so timeout-related conditions are no longer treated the same as other unhealthy errors.

* **Tests**
  * Added coverage for unhealthy-error detection to verify the expected behavior across multiple DCGM status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->