### PR TITLE
feat: mark persistence mode diable as warning level

### DIFF
--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/persistence-mode/component.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/persistence-mode/component.go
@@ -170,6 +170,7 @@ func (c *component) Check() components.CheckResult {
 		persistenceMode, err := c.getPersistenceModeFunc(uuid, dev)
 		if err != nil {
 			cr.err = err
+			// deliberately stayed Unhealthy to indicate NVML query errors, GPU-lost, and GPU-requires-reset
 			cr.health = apiv1.HealthStateTypeUnhealthy
 			cr.reason = "error getting persistence mode"
 
@@ -208,7 +209,10 @@ func (c *component) Check() components.CheckResult {
 	}
 
 	if len(notEnabled) > 0 {
-		cr.health = apiv1.HealthStateTypeUnhealthy
+		// Persistence mode being disabled is a configuration issue that does not
+		// affect running workloads, so it is flagged as a warning (Degraded)
+		// rather than critical (Unhealthy).
+		cr.health = apiv1.HealthStateTypeDegraded
 		if len(notEnabled) == len(cr.PersistenceModes) {
 			cr.reason = fmt.Sprintf("all %d GPU(s) disabled persistence mode", len(devs))
 		} else {

--- a/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/persistence-mode/component_test.go
+++ b/third_party/fleet-intelligence-sdk/components/accelerator/nvidia/persistence-mode/component_test.go
@@ -337,8 +337,8 @@ func TestCheck_MultipleDevices(t *testing.T) {
 	require.True(t, ok, "result should be of type *checkResult")
 
 	require.NotNil(t, data, "data should not be nil")
-	// This should be unhealthy since one device has persistence mode supported but not enabled
-	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, data.health, "data should be marked unhealthy")
+	// This should be degraded (warning) since one device has persistence mode supported but not enabled
+	assert.Equal(t, apiv1.HealthStateTypeDegraded, data.health, "data should be marked degraded")
 	assert.Equal(t, "gpu-uuid-456 persistence mode supported but not enabled", data.reason)
 	assert.Len(t, data.PersistenceModes, 2)
 
@@ -734,7 +734,7 @@ func TestPersistenceModeCheck(t *testing.T) {
 				{UUID: "GPU-1", Supported: true, Enabled: true},
 				{UUID: "GPU-2", Supported: true, Enabled: false},
 			},
-			expectedHealth:    apiv1.HealthStateTypeUnhealthy,
+			expectedHealth:    apiv1.HealthStateTypeDegraded,
 			expectedReasonCmp: "GPU-2 persistence mode supported but not enabled",
 		},
 		{
@@ -743,7 +743,7 @@ func TestPersistenceModeCheck(t *testing.T) {
 				{UUID: "GPU-1", Supported: true, Enabled: false},
 				{UUID: "GPU-2", Supported: true, Enabled: false},
 			},
-			expectedHealth:    apiv1.HealthStateTypeUnhealthy,
+			expectedHealth:    apiv1.HealthStateTypeDegraded,
 			expectedReasonCmp: "all 2 GPU(s) disabled persistence mode",
 		},
 		{


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health status for NVIDIA persistence mode is now reported as **Degraded** when persistence mode is disabled, instead of **Unhealthy**.
  * Error-related checks continue to report **Unhealthy** for actual query failures, keeping critical issues distinct from configuration issues.
  * Updated expected health results in related checks to match the new status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->