### PR TITLE
feat: Inband attestation should collect stderr from nvattest sdk

### DIFF
--- a/internal/attestation/collector.go
+++ b/internal/attestation/collector.go
@@ -92,7 +92,6 @@ func (c *cliEvidenceCollector) Collect(ctx context.Context, nonce string) (*SDKR
 		fields = append(fields, "exit_error", err)
 	}
 	log.Logger.Infow("nvattest completed", fields...)
-	log.Logger.Infow("nvattest response", "response", response)
 	return &response, nil
 }
 

--- a/internal/attestation/collector.go
+++ b/internal/attestation/collector.go
@@ -81,6 +81,8 @@ func (c *cliEvidenceCollector) Collect(ctx context.Context, nonce string) (*SDKR
 			parseErr, stderr.String(), stdout.String(), errText,
 		)
 	}
+	response.ResultMessage = fmt.Sprintf("%s | raw_stderr: %s", response.ResultMessage, stderr.String())
+
 	fields := []interface{}{
 		"result_code", response.ResultCode,
 		"result_message", response.ResultMessage,
@@ -90,6 +92,7 @@ func (c *cliEvidenceCollector) Collect(ctx context.Context, nonce string) (*SDKR
 		fields = append(fields, "exit_error", err)
 	}
 	log.Logger.Infow("nvattest completed", fields...)
+	log.Logger.Infow("nvattest response", "response", response)
 	return &response, nil
 }
 

--- a/internal/attestation/collector_test.go
+++ b/internal/attestation/collector_test.go
@@ -54,7 +54,7 @@ func TestCLIEvidenceCollectorParsesResponse(t *testing.T) {
 	resp, err := collector.Collect(context.Background(), "abc123")
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.ResultCode)
-	require.Equal(t, "ok", resp.ResultMessage)
+	require.Contains(t, resp.ResultMessage, "ok | raw_stderr:")
 	require.Len(t, resp.Evidences, 1)
 	require.Equal(t, "BLACKWELL", resp.Evidences[0].Arch)
 	require.Equal(t, "550.120", resp.Evidences[0].DriverVersion)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attestation command feedback by appending the underlying CLI’s raw error output to the result message (in addition to any existing message content) when parsing succeeds.
* **Tests**
  * Updated the attestation collector test to verify the result message contains the expected base text plus the appended stderr details, rather than requiring an exact match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->