### PR TITLE
chore: add readme for agent local db to be persistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ Built on top of [leptonai/gpud](https://github.com/leptonai/gpud)
 - Non-intrusive: Read-only operations, no system modifications
 - Production-ready: 24/7 datacenter operation
 
+## Persistent Local State
+
+The agent stores its node identity, enrollment metadata, and retained metrics and
+events in `/var/lib/fleetint/fleetint.state` by default. The
+`/var/lib/fleetint` directory must use persistent local storage that survives
+agent and host restarts, reboots, upgrades, and reinstalls.
+
+Deleting or replacing this directory removes the persisted node identity and
+enrollment credentials. The agent may then generate a new node identity and
+create a separate record for the same physical node in Fleet Intelligence. When
+using custom images, installers, or container deployments, preserve or mount
+this directory from persistent host storage and restrict access because it
+contains enrollment credentials.
+
 ## Supported Platforms
 
 | OS Family | Supported Versions | Architecture | GPU |


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on persistent local storage for agent identity, enrollment metadata, and retained metrics or events.
  * Documented the risks of deleting or replacing the state directory, including loss of enrollment credentials.
  * Added deployment and access-control recommendations for custom images, installers, and containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->