### PR TITLE
fix: fern docs url

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 instances:
-  - url: fleet-intelligence-agent.docs.buildwithfern.com/fleet-intel/agent
+  - url: fleet-intel.docs.buildwithfern.com/fleet-intel/agent
     custom-domain: docs.nvidia.com/fleet-intel/agent
     multi-source: true
 


### PR DESCRIPTION
This fix will allow preview all of the combined documents.

Fern uses a set of URLs to preview documents.  Our tooling picks URLs for this, but picked a unique one for each repo (the Service and the Agent) but we need these to be the same across all combined repos to make it all work together.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation site URL to the new fleet-intel domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->