### PR TITLE
feat: enrich OTLP telemetry identity

### DIFF
--- a/internal/backendclient/types.go
+++ b/internal/backendclient/types.go
@@ -80,14 +80,16 @@ type GPUInfo struct {
 }
 
 type GPUDevice struct {
-	UUID         string `json:"uuid"`
-	BusID        string `json:"busID"`
-	SN           string `json:"sn"`
-	MinorID      string `json:"minorID"`
-	BoardID      int    `json:"boardID"`
-	VBIOSVersion string `json:"vbiosVersion"`
-	ChassisSN    string `json:"chassisSN"`
-	GPUIndex     string `json:"gpuIndex,omitempty"`
+	UUID         string  `json:"uuid"`
+	BusID        string  `json:"busID"`
+	ClusterUUID  string  `json:"clusterUUID,omitempty"`
+	CliqueID     *uint32 `json:"cliqueID,omitempty"`
+	SN           string  `json:"sn"`
+	MinorID      string  `json:"minorID"`
+	BoardID      int     `json:"boardID"`
+	VBIOSVersion string  `json:"vbiosVersion"`
+	ChassisSN    string  `json:"chassisSN"`
+	GPUIndex     string  `json:"gpuIndex,omitempty"`
 }
 
 type DiskInfo struct {

--- a/internal/exporter/collector/collector.go
+++ b/internal/exporter/collector/collector.go
@@ -58,6 +58,7 @@ type HealthData struct {
 	Timestamp      time.Time
 	MachineInfo    *machineinfo.MachineInfo
 	GPUUUIDToIndex map[string]string
+	EntityCatalog  *EntityCatalog
 	Metrics        pkgmetrics.Metrics
 	Events         eventstore.Events
 	ComponentData  map[string]interface{}
@@ -109,7 +110,8 @@ func New(
 	}
 
 	var provider machineInfoProvider
-	if cfg != nil && cfg.IncludeMachineInfo && collectorOpts.nvmlInstance != nil {
+	needsIdentity := cfg != nil && (cfg.IncludeMachineInfo || cfg.IncludeMetrics || cfg.IncludeEvents || cfg.IncludeComponentData)
+	if needsIdentity && collectorOpts.nvmlInstance != nil {
 		var machineInfoOpts []machineinfo.MachineInfoOption
 		if len(dcgmGPUIndexes) > 0 {
 			machineInfoOpts = append(machineInfoOpts, machineinfo.WithDCGMGPUIndexes(dcgmGPUIndexes))
@@ -145,11 +147,17 @@ func (c *collector) Collect(ctx context.Context) (*HealthData, error) {
 		MachineID:      c.machineID,
 		Timestamp:      time.Now().UTC(),
 		GPUUUIDToIndex: cloneStringMap(c.dcgmGPUIndexes),
+		EntityCatalog:  NewEntityCatalog(nil, c.dcgmGPUIndexes),
 	}
 
-	// Collect machine info if enabled. The converter only exports selected fields.
-	if c.config.IncludeMachineInfo {
+	// Identity enrichment uses cached machine info independently of whether the
+	// full machine-info payload is enabled for export.
+	if c.machineInfoProvider != nil {
 		c.collectMachineInfo(ctx, data)
+		data.EntityCatalog = NewEntityCatalog(data.MachineInfo, c.dcgmGPUIndexes)
+		if !c.config.IncludeMachineInfo {
+			data.MachineInfo = nil
+		}
 	}
 
 	// Collect metrics if enabled

--- a/internal/exporter/collector/identity.go
+++ b/internal/exporter/collector/identity.go
@@ -1,5 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package collector
 

--- a/internal/exporter/collector/identity.go
+++ b/internal/exporter/collector/identity.go
@@ -74,7 +74,7 @@ func NewEntityCatalog(info *machineinfo.MachineInfo, dcgmGPUIndexes map[string]s
 	catalog.GPUDriverVersion = strings.TrimSpace(info.GPUDriverVersion)
 	catalog.CUDADriverVersion = strings.TrimSpace(info.CUDAVersion)
 	if !info.Uptime.IsZero() {
-		catalog.BootTime = info.Uptime.Time.UTC()
+		catalog.BootTime = info.Uptime.UTC()
 	}
 	if info.GPUInfo == nil {
 		return catalog

--- a/internal/exporter/collector/identity.go
+++ b/internal/exporter/collector/identity.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
+)
+
+// GPUIdentity contains stable, non-workload identity for one physical GPU.
+type GPUIdentity struct {
+	UUID         string
+	GPU          string
+	PCIBusID     string
+	Device       string
+	ModelName    string
+	GPUSerial    string
+	VBIOSVersion string
+	ClusterUUID  string
+	CliqueID     string
+}
+
+// EntityCatalog is an immutable identity snapshot shared by metric and log conversion.
+// MIG identities are intentionally outside this catalog.
+type EntityCatalog struct {
+	Hostname          string
+	GPUDriverVersion  string
+	CUDADriverVersion string
+	BootTime          time.Time
+	GPUsByUUID        map[string]GPUIdentity
+	GPUUUIDByIndex    map[string]string
+}
+
+// NewEntityCatalog builds a physical-entity identity snapshot from cached inventory.
+func NewEntityCatalog(info *machineinfo.MachineInfo, dcgmGPUIndexes map[string]string) *EntityCatalog {
+	catalog := &EntityCatalog{
+		GPUsByUUID:     make(map[string]GPUIdentity),
+		GPUUUIDByIndex: make(map[string]string),
+	}
+
+	for uuid, gpu := range dcgmGPUIndexes {
+		uuid = strings.TrimSpace(uuid)
+		gpu = strings.TrimSpace(gpu)
+		if uuid == "" {
+			continue
+		}
+		identity := GPUIdentity{UUID: uuid, GPU: gpu}
+		catalog.GPUsByUUID[uuid] = identity
+		if gpu != "" {
+			catalog.GPUUUIDByIndex[gpu] = uuid
+		}
+	}
+
+	if info == nil {
+		return catalog
+	}
+	catalog.Hostname = strings.TrimSpace(info.Hostname)
+	catalog.GPUDriverVersion = strings.TrimSpace(info.GPUDriverVersion)
+	catalog.CUDADriverVersion = strings.TrimSpace(info.CUDAVersion)
+	if !info.Uptime.IsZero() {
+		catalog.BootTime = info.Uptime.Time.UTC()
+	}
+	if info.GPUInfo == nil {
+		return catalog
+	}
+
+	defaultModelName := strings.TrimSpace(info.GPUInfo.Product)
+	for _, gpuInfo := range info.GPUInfo.GPUs {
+		uuid := strings.TrimSpace(gpuInfo.UUID)
+		if uuid == "" {
+			continue
+		}
+
+		identity := catalog.GPUsByUUID[uuid]
+		identity.UUID = uuid
+		if identity.GPU == "" {
+			identity.GPU = strings.TrimSpace(gpuInfo.GPUIndex)
+		}
+		identity.PCIBusID = strings.TrimSpace(gpuInfo.BusID)
+		identity.GPUSerial = strings.TrimSpace(gpuInfo.SN)
+		identity.VBIOSVersion = strings.TrimSpace(gpuInfo.VBIOSVersion)
+		identity.ModelName = strings.TrimSpace(gpuInfo.ModelName)
+		if identity.ModelName == "" {
+			identity.ModelName = defaultModelName
+		}
+		identity.ClusterUUID = strings.TrimSpace(gpuInfo.ClusterUUID)
+		if gpuInfo.CliqueID != nil {
+			identity.CliqueID = strconv.FormatUint(uint64(*gpuInfo.CliqueID), 10)
+		}
+
+		minorID := strings.TrimSpace(gpuInfo.MinorID)
+		if minor, err := strconv.Atoi(minorID); err == nil && minor >= 0 {
+			identity.Device = "nvidia" + strconv.Itoa(minor)
+		}
+
+		catalog.GPUsByUUID[uuid] = identity
+		if identity.GPU != "" {
+			catalog.GPUUUIDByIndex[identity.GPU] = uuid
+		}
+	}
+
+	return catalog
+}

--- a/internal/exporter/collector/identity.go
+++ b/internal/exporter/collector/identity.go
@@ -30,6 +30,7 @@ type GPUIdentity struct {
 	PCIBusID     string
 	Device       string
 	ModelName    string
+	Architecture string
 	GPUSerial    string
 	VBIOSVersion string
 	ClusterUUID  string
@@ -42,6 +43,7 @@ type EntityCatalog struct {
 	Hostname          string
 	GPUDriverVersion  string
 	CUDADriverVersion string
+	KernelVersion     string
 	BootTime          time.Time
 	GPUsByUUID        map[string]GPUIdentity
 	GPUUUIDByIndex    map[string]string
@@ -73,6 +75,7 @@ func NewEntityCatalog(info *machineinfo.MachineInfo, dcgmGPUIndexes map[string]s
 	catalog.Hostname = strings.TrimSpace(info.Hostname)
 	catalog.GPUDriverVersion = strings.TrimSpace(info.GPUDriverVersion)
 	catalog.CUDADriverVersion = strings.TrimSpace(info.CUDAVersion)
+	catalog.KernelVersion = strings.TrimSpace(info.KernelVersion)
 	if !info.Uptime.IsZero() {
 		catalog.BootTime = info.Uptime.UTC()
 	}
@@ -81,6 +84,7 @@ func NewEntityCatalog(info *machineinfo.MachineInfo, dcgmGPUIndexes map[string]s
 	}
 
 	defaultModelName := strings.TrimSpace(info.GPUInfo.Product)
+	defaultArchitecture := strings.TrimSpace(info.GPUInfo.Architecture)
 	for _, gpuInfo := range info.GPUInfo.GPUs {
 		uuid := strings.TrimSpace(gpuInfo.UUID)
 		if uuid == "" {
@@ -93,6 +97,7 @@ func NewEntityCatalog(info *machineinfo.MachineInfo, dcgmGPUIndexes map[string]s
 			identity.GPU = strings.TrimSpace(gpuInfo.GPUIndex)
 		}
 		identity.PCIBusID = strings.TrimSpace(gpuInfo.BusID)
+		identity.Architecture = defaultArchitecture
 		identity.GPUSerial = strings.TrimSpace(gpuInfo.SN)
 		identity.VBIOSVersion = strings.TrimSpace(gpuInfo.VBIOSVersion)
 		identity.ModelName = strings.TrimSpace(gpuInfo.ModelName)

--- a/internal/exporter/collector/identity_test.go
+++ b/internal/exporter/collector/identity_test.go
@@ -34,9 +34,11 @@ func TestNewEntityCatalog(t *testing.T) {
 		Hostname:         "gpu-node-01",
 		GPUDriverVersion: "575.57.08",
 		CUDAVersion:      "12.9",
+		KernelVersion:    "6.14.0-27-generic",
 		Uptime:           metav1.NewTime(bootTime),
 		GPUInfo: &apiv1.MachineGPUInfo{
-			Product: "fallback-model",
+			Product:      "fallback-model",
+			Architecture: "hopper",
 			GPUs: []apiv1.MachineGPUInstance{
 				{
 					UUID:         "GPU-abc",
@@ -63,6 +65,7 @@ func TestNewEntityCatalog(t *testing.T) {
 	assert.Equal(t, "gpu-node-01", catalog.Hostname)
 	assert.Equal(t, "575.57.08", catalog.GPUDriverVersion)
 	assert.Equal(t, "12.9", catalog.CUDADriverVersion)
+	assert.Equal(t, "6.14.0-27-generic", catalog.KernelVersion)
 	assert.Equal(t, bootTime, catalog.BootTime)
 	assert.Equal(t, GPUIdentity{
 		UUID:         "GPU-abc",
@@ -70,12 +73,14 @@ func TestNewEntityCatalog(t *testing.T) {
 		PCIBusID:     "0000:01:00.0",
 		Device:       "nvidia2",
 		ModelName:    "NVIDIA H100",
+		Architecture: "hopper",
 		GPUSerial:    "GPU-SERIAL-123",
 		VBIOSVersion: "97.00.82.00.5F",
 		ClusterUUID:  "11111111-2222-3333-4444-555555555555",
 		CliqueID:     "0",
 	}, catalog.GPUsByUUID["GPU-abc"])
 	assert.Equal(t, "fallback-model", catalog.GPUsByUUID["GPU-def"].ModelName)
+	assert.Equal(t, "hopper", catalog.GPUsByUUID["GPU-def"].Architecture)
 	assert.Empty(t, catalog.GPUsByUUID["GPU-def"].GPUSerial)
 	assert.Empty(t, catalog.GPUsByUUID["GPU-def"].Device)
 	assert.Equal(t, "GPU-abc", catalog.GPUUUIDByIndex["0"])

--- a/internal/exporter/collector/identity_test.go
+++ b/internal/exporter/collector/identity_test.go
@@ -1,5 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package collector
 

--- a/internal/exporter/collector/identity_test.go
+++ b/internal/exporter/collector/identity_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/NVIDIA/fleet-intelligence-agent/internal/machineinfo"
+)
+
+func TestNewEntityCatalog(t *testing.T) {
+	cliqueID := uint32(0)
+	bootTime := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	info := &machineinfo.MachineInfo{
+		Hostname:         "gpu-node-01",
+		GPUDriverVersion: "575.57.08",
+		CUDAVersion:      "12.9",
+		Uptime:           metav1.NewTime(bootTime),
+		GPUInfo: &apiv1.MachineGPUInfo{
+			Product: "fallback-model",
+			GPUs: []apiv1.MachineGPUInstance{
+				{
+					UUID:         "GPU-abc",
+					GPUIndex:     "7",
+					BusID:        "0000:01:00.0",
+					MinorID:      "2",
+					ModelName:    "NVIDIA H100",
+					SN:           "GPU-SERIAL-123",
+					VBIOSVersion: "97.00.82.00.5F",
+					ClusterUUID:  "11111111-2222-3333-4444-555555555555",
+					CliqueID:     &cliqueID,
+				},
+				{
+					UUID:     "GPU-def",
+					GPUIndex: "8",
+					MinorID:  "-1",
+				},
+			},
+		},
+	}
+
+	catalog := NewEntityCatalog(info, map[string]string{"GPU-abc": "0"})
+	require.NotNil(t, catalog)
+	assert.Equal(t, "gpu-node-01", catalog.Hostname)
+	assert.Equal(t, "575.57.08", catalog.GPUDriverVersion)
+	assert.Equal(t, "12.9", catalog.CUDADriverVersion)
+	assert.Equal(t, bootTime, catalog.BootTime)
+	assert.Equal(t, GPUIdentity{
+		UUID:         "GPU-abc",
+		GPU:          "0",
+		PCIBusID:     "0000:01:00.0",
+		Device:       "nvidia2",
+		ModelName:    "NVIDIA H100",
+		GPUSerial:    "GPU-SERIAL-123",
+		VBIOSVersion: "97.00.82.00.5F",
+		ClusterUUID:  "11111111-2222-3333-4444-555555555555",
+		CliqueID:     "0",
+	}, catalog.GPUsByUUID["GPU-abc"])
+	assert.Equal(t, "fallback-model", catalog.GPUsByUUID["GPU-def"].ModelName)
+	assert.Empty(t, catalog.GPUsByUUID["GPU-def"].GPUSerial)
+	assert.Empty(t, catalog.GPUsByUUID["GPU-def"].Device)
+	assert.Equal(t, "GPU-abc", catalog.GPUUUIDByIndex["0"])
+	assert.Equal(t, "GPU-def", catalog.GPUUUIDByIndex["8"])
+}

--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -123,7 +123,7 @@ func (c *otlpConverter) createOTLPResource(data *collector.HealthData) *resource
 		},
 	}
 
-	if hostname := identityHostname(data); hostname != "" {
+	if hostname := resolveOTLPHostname(); hostname != "" {
 		attributes = append(attributes, &commonv1.KeyValue{Key: "host.name", Value: stringAnyValue(hostname)})
 	}
 	if data.NodeGroup != "" {
@@ -168,16 +168,6 @@ func resolveOTLPHostname() string {
 		return ""
 	}
 	return strings.TrimSpace(hostname)
-}
-
-func identityHostname(data *collector.HealthData) string {
-	if data.EntityCatalog != nil && data.EntityCatalog.Hostname != "" {
-		return data.EntityCatalog.Hostname
-	}
-	if data.MachineInfo != nil && strings.TrimSpace(data.MachineInfo.Hostname) != "" {
-		return strings.TrimSpace(data.MachineInfo.Hostname)
-	}
-	return resolveOTLPHostname()
 }
 
 // convertMetricsToOTLP converts health metrics to OTLP metrics format
@@ -468,7 +458,6 @@ func addLabelIfMissing(labels map[string]string, key, value string) {
 // convertToOTLPLogs converts HealthData events and component data to OTLP log records
 func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.LogRecord {
 	var logRecords []*logsv1.LogRecord
-	identity := newIdentityContext(data)
 
 	// Add events as log records
 	if len(data.Events) > 0 {
@@ -505,13 +494,9 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 					},
 				},
 			}
-			extraInfo := cloneStringMap(event.ExtraInfo)
-			eventIdentity := identity.identityForEvent(extraInfo)
-			if len(eventIdentity) > 0 {
-				if rawIdentity, err := json.Marshal(eventIdentity); err == nil {
-					extraInfo["identity"] = string(rawIdentity)
-				}
-				attributes = append(attributes, labelsToOTLPAttributes(eventIdentity)...)
+			extraInfo := event.ExtraInfo
+			if extraInfo == nil {
+				extraInfo = map[string]string{}
 			}
 			attributes = append(attributes, &commonv1.KeyValue{
 				Key:   "extra_info",
@@ -622,7 +607,7 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 			if typedIncidents, ok := toHealthStateIncidents(incidents); ok && len(typedIncidents) > 0 {
 				attributes = append(attributes, &commonv1.KeyValue{
 					Key:   "incidents",
-					Value: incidentsToOTLPArrayValue(typedIncidents, identity),
+					Value: incidentsToOTLPArrayValue(typedIncidents),
 				})
 			}
 
@@ -644,14 +629,6 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 	return logRecords
 }
 
-func cloneStringMap(src map[string]string) map[string]string {
-	dst := make(map[string]string, len(src)+1)
-	for key, value := range src {
-		dst[key] = value
-	}
-	return dst
-}
-
 func labelsToOTLPAttributes(labels map[string]string) []*commonv1.KeyValue {
 	keys := make([]string, 0, len(labels))
 	for key := range labels {
@@ -664,51 +641,6 @@ func labelsToOTLPAttributes(labels map[string]string) []*commonv1.KeyValue {
 		attributes = append(attributes, &commonv1.KeyValue{Key: key, Value: stringAnyValue(labels[key])})
 	}
 	return attributes
-}
-
-func (ctx identityContext) identityForEvent(extraInfo map[string]string) map[string]string {
-	labels := make(map[string]string)
-	for _, key := range []string{"uuid", "gpu_uuid", "device_uuid", "gpu", "entity_id", "nvlink", "nvswitch", "cpu", "cpucore"} {
-		if value := strings.TrimSpace(extraInfo[key]); value != "" {
-			labels[key] = value
-		}
-	}
-
-	if labels["uuid"] == "" {
-		labels["uuid"] = labels["device_uuid"]
-	}
-	delete(labels, "device_uuid")
-	if key, value := identityFromEntityID(labels["entity_id"]); key != "" && labels[key] == "" {
-		labels[key] = value
-	}
-	delete(labels, "entity_id")
-
-	if labels["uuid"] == "" && labels["gpu_uuid"] == "" && labels["gpu"] == "" && labels["nvlink"] == "" &&
-		labels["nvswitch"] == "" && labels["cpu"] == "" && labels["cpucore"] == "" {
-		return nil
-	}
-	return ctx.enrichLabels(labels)
-}
-
-func identityFromEntityID(entityID string) (string, string) {
-	prefix, id, ok := strings.Cut(strings.TrimSpace(entityID), "-")
-	if !ok || strings.TrimSpace(id) == "" {
-		return "", ""
-	}
-	switch strings.ToLower(strings.TrimSpace(prefix)) {
-	case "gpu":
-		return "gpu", strings.TrimSpace(id)
-	case "nvswitch":
-		return "nvswitch", strings.TrimSpace(id)
-	case "nvlink":
-		return "nvlink", strings.TrimSpace(id)
-	case "cpu":
-		return "cpu", strings.TrimSpace(id)
-	case "cpucore", "cpu_core":
-		return "cpucore", strings.TrimSpace(id)
-	default:
-		return "", ""
-	}
 }
 
 func extraInfoToAnyValue(extraInfo map[string]string) *commonv1.AnyValue {
@@ -727,7 +659,7 @@ func extraInfoToAnyValue(extraInfo map[string]string) *commonv1.AnyValue {
 	}
 }
 
-func incidentsToOTLPArrayValue(incidents []apiv1.HealthStateIncident, identity identityContext) *commonv1.AnyValue {
+func incidentsToOTLPArrayValue(incidents []apiv1.HealthStateIncident) *commonv1.AnyValue {
 	values := make([]*commonv1.AnyValue, 0, len(incidents))
 	for _, inc := range incidents {
 		kvs := []*commonv1.KeyValue{
@@ -736,8 +668,6 @@ func incidentsToOTLPArrayValue(incidents []apiv1.HealthStateIncident, identity i
 			{Key: "severity", Value: stringAnyValue(string(inc.Health))},
 			{Key: "error", Value: stringAnyValue(inc.Error)},
 		}
-		incidentIdentity := identity.identityForEvent(map[string]string{"entity_id": inc.EntityID})
-		kvs = append(kvs, labelsToOTLPAttributes(incidentIdentity)...)
 		values = append(values, &commonv1.AnyValue{
 			Value: &commonv1.AnyValue_KvlistValue{
 				KvlistValue: &commonv1.KeyValueList{Values: kvs},

--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -34,7 +35,10 @@ import (
 	"github.com/NVIDIA/fleet-intelligence-agent/internal/exporter/collector"
 )
 
-var osHostname = os.Hostname
+var (
+	osHostname     = os.Hostname
+	agentStartTime = time.Now().UTC()
+)
 
 // OTLPData holds both metrics and logs for OTLP export
 type OTLPData struct {
@@ -119,13 +123,8 @@ func (c *otlpConverter) createOTLPResource(data *collector.HealthData) *resource
 		},
 	}
 
-	if hostname := resolveOTLPHostname(); hostname != "" {
-		attributes = append(attributes, &commonv1.KeyValue{
-			Key: "host.name",
-			Value: &commonv1.AnyValue{
-				Value: &commonv1.AnyValue_StringValue{StringValue: hostname},
-			},
-		})
+	if hostname := identityHostname(data); hostname != "" {
+		attributes = append(attributes, &commonv1.KeyValue{Key: "host.name", Value: stringAnyValue(hostname)})
 	}
 	if data.NodeGroup != "" {
 		attributes = append(attributes, &commonv1.KeyValue{
@@ -171,16 +170,26 @@ func resolveOTLPHostname() string {
 	return strings.TrimSpace(hostname)
 }
 
+func identityHostname(data *collector.HealthData) string {
+	if data.EntityCatalog != nil && data.EntityCatalog.Hostname != "" {
+		return data.EntityCatalog.Hostname
+	}
+	if data.MachineInfo != nil && strings.TrimSpace(data.MachineInfo.Hostname) != "" {
+		return strings.TrimSpace(data.MachineInfo.Hostname)
+	}
+	return resolveOTLPHostname()
+}
+
 // convertMetricsToOTLP converts health metrics to OTLP metrics format
 func (c *otlpConverter) convertMetricsToOTLP(data *collector.HealthData) []*metricsv1.Metric {
 	var otlpMetrics []*metricsv1.Metric
 
-	gpuUUIDToIndex := buildGPUUUIDToIndexMap(data)
+	identity := newIdentityContext(data)
 
 	// Convert regular metrics if available
 	if len(data.Metrics) > 0 {
 		for _, metric := range data.Metrics {
-			otlpMetrics = append(otlpMetrics, c.convertMetricToOTLP(metric, gpuUUIDToIndex))
+			otlpMetrics = append(otlpMetrics, c.convertMetricToOTLP(metric, identity))
 		}
 	}
 
@@ -240,17 +249,113 @@ func (c *otlpConverter) convertMetricsToOTLP(data *collector.HealthData) []*metr
 		},
 	}
 	otlpMetrics = append(otlpMetrics, upMetric)
+	if !data.Timestamp.IsZero() && !data.Timestamp.Before(agentStartTime) {
+		otlpMetrics = append(otlpMetrics, gaugeMetric(
+			"fleetint_agent_uptime_seconds",
+			"Time elapsed since the Fleet Intelligence agent process started.",
+			"",
+			data.Timestamp,
+			data.Timestamp.Sub(agentStartTime).Seconds(),
+			nil,
+		))
+	}
+	otlpMetrics = append(otlpMetrics, inventoryMetrics(data, identity.catalog)...)
 
 	return otlpMetrics
 }
 
-func (c *otlpConverter) convertMetricToOTLP(metric pkgmetrics.Metric, gpuUUIDToIndex map[string]string) *metricsv1.Metric {
+func inventoryMetrics(data *collector.HealthData, catalog *collector.EntityCatalog) []*metricsv1.Metric {
+	if catalog == nil {
+		return nil
+	}
+
+	var inventory []*metricsv1.Metric
+	softwareLabels := map[string]string{}
+	addLabelIfMissing(softwareLabels, "gpu_driver_version", catalog.GPUDriverVersion)
+	addLabelIfMissing(softwareLabels, "cuda_driver_version", catalog.CUDADriverVersion)
+	if len(softwareLabels) > 0 {
+		inventory = append(inventory, gaugeMetric(
+			"fleetint_node_software_info",
+			"Node-scoped GPU software version information.",
+			"",
+			data.Timestamp,
+			1,
+			softwareLabels,
+		))
+	}
+
+	if !catalog.BootTime.IsZero() && !data.Timestamp.IsZero() && !data.Timestamp.Before(catalog.BootTime) {
+		inventory = append(inventory, gaugeMetric(
+			"fleetint_node_uptime_seconds",
+			"Time elapsed since the node last booted.",
+			"",
+			data.Timestamp,
+			data.Timestamp.Sub(catalog.BootTime).Seconds(),
+			nil,
+		))
+	}
+
+	uuids := make([]string, 0, len(catalog.GPUsByUUID))
+	for uuid := range catalog.GPUsByUUID {
+		uuids = append(uuids, uuid)
+	}
+	sort.Strings(uuids)
+
+	firmwarePoints := make([]*metricsv1.NumberDataPoint, 0, len(uuids))
+	for _, uuid := range uuids {
+		gpu := catalog.GPUsByUUID[uuid]
+		if gpu.GPUSerial == "" && gpu.VBIOSVersion == "" {
+			continue
+		}
+		labels := map[string]string{}
+		addLabelIfMissing(labels, "gpu", gpu.GPU)
+		addLabelIfMissing(labels, "uuid", gpu.UUID)
+		addLabelIfMissing(labels, "gpu_serial", gpu.GPUSerial)
+		addLabelIfMissing(labels, "vbios_version", gpu.VBIOSVersion)
+		firmwarePoints = append(firmwarePoints, gaugeDataPoint(data.Timestamp, 1, labels))
+	}
+	if len(firmwarePoints) > 0 {
+		inventory = append(inventory, &metricsv1.Metric{
+			Name:        "fleetint_gpu_firmware_info",
+			Description: "Per-GPU serial number and VBIOS version information.",
+			Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{
+				DataPoints: firmwarePoints,
+			}},
+		})
+	}
+
+	return inventory
+}
+
+func gaugeMetric(name, description, unit string, timestamp time.Time, value float64, labels map[string]string) *metricsv1.Metric {
+	return &metricsv1.Metric{
+		Name:        name,
+		Description: description,
+		Unit:        unit,
+		Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{
+			DataPoints: []*metricsv1.NumberDataPoint{gaugeDataPoint(timestamp, value, labels)},
+		}},
+	}
+}
+
+func gaugeDataPoint(timestamp time.Time, value float64, labels map[string]string) *metricsv1.NumberDataPoint {
+	return &metricsv1.NumberDataPoint{
+		TimeUnixNano: uint64(timestamp.UnixNano()),
+		Value: &metricsv1.NumberDataPoint_AsDouble{
+			AsDouble: value,
+		},
+		Attributes: labelsToOTLPAttributes(labels),
+	}
+}
+
+func (c *otlpConverter) convertMetricToOTLP(metric pkgmetrics.Metric, identity identityContext) *metricsv1.Metric {
+	labels := identity.enrichLabels(metric.Labels)
 	dataPoint := &metricsv1.NumberDataPoint{
 		TimeUnixNano: uint64(metric.UnixMilliseconds) * 1_000_000,
 		Value: &metricsv1.NumberDataPoint_AsDouble{
 			AsDouble: metric.Value,
 		},
-		Attributes: c.convertLabelsToOTLPAttributes(metric.Labels, gpuUUIDToIndex),
+		Attributes: labelsToOTLPAttributes(labels),
 	}
 
 	otlpMetric := &metricsv1.Metric{
@@ -277,55 +382,93 @@ func (c *otlpConverter) convertMetricToOTLP(metric pkgmetrics.Metric, gpuUUIDToI
 	return otlpMetric
 }
 
-// convertLabelsToOTLPAttributes converts metric labels to OTLP attributes.
-// If the labels contain a "uuid" key but no "gpu" key, it enriches the
-// attributes with the GPU index looked up from the machine info mapping.
-// DCGM metrics already carry a "gpu" label and are left unchanged.
-func (c *otlpConverter) convertLabelsToOTLPAttributes(labels map[string]string, gpuUUIDToIndex map[string]string) []*commonv1.KeyValue {
-	var attributes []*commonv1.KeyValue
-	for key, value := range labels {
-		attributes = append(attributes, &commonv1.KeyValue{
-			Key: key,
-			Value: &commonv1.AnyValue{
-				Value: &commonv1.AnyValue_StringValue{StringValue: value},
-			},
-		})
+// convertLabelsToOTLPAttributes adds stable physical-entity identity without
+// overwriting labels emitted by a component. MIG is intentionally unsupported.
+func (c *otlpConverter) convertLabelsToOTLPAttributes(labels map[string]string, identity identityContext) []*commonv1.KeyValue {
+	enriched := identity.enrichLabels(labels)
+	keys := make([]string, 0, len(enriched))
+	for key := range enriched {
+		keys = append(keys, key)
 	}
+	sort.Strings(keys)
 
-	if _, hasGPU := labels["gpu"]; !hasGPU {
-		if uuid, hasUUID := labels["uuid"]; hasUUID {
-			if gpuIndex, ok := gpuUUIDToIndex[uuid]; ok {
-				attributes = append(attributes, &commonv1.KeyValue{
-					Key: "gpu",
-					Value: &commonv1.AnyValue{
-						Value: &commonv1.AnyValue_StringValue{StringValue: gpuIndex},
-					},
-				})
-			}
-		}
+	attributes := make([]*commonv1.KeyValue, 0, len(keys))
+	for _, key := range keys {
+		attributes = append(attributes, &commonv1.KeyValue{Key: key, Value: stringAnyValue(enriched[key])})
 	}
-
 	return attributes
 }
 
-// buildGPUUUIDToIndexMap builds a UUID → GPU index lookup from the collector snapshot.
-func buildGPUUUIDToIndexMap(data *collector.HealthData) map[string]string {
-	m := make(map[string]string)
-	if len(data.GPUUUIDToIndex) == 0 {
-		return m
+type identityContext struct {
+	catalog *collector.EntityCatalog
+}
+
+func newIdentityContext(data *collector.HealthData) identityContext {
+	catalog := data.EntityCatalog
+	if catalog == nil && data.MachineInfo != nil {
+		catalog = collector.NewEntityCatalog(data.MachineInfo, data.GPUUUIDToIndex)
 	}
-	for uuid, gpuIndex := range data.GPUUUIDToIndex {
-		if uuid == "" || gpuIndex == "" {
-			continue
+	ctx := identityContext{catalog: catalog}
+	return ctx
+}
+
+func (ctx identityContext) enrichLabels(labels map[string]string) map[string]string {
+	enriched := make(map[string]string, len(labels)+6)
+	for key, value := range labels {
+		if value = strings.TrimSpace(value); value != "" {
+			enriched[key] = value
 		}
-		m[uuid] = gpuIndex
 	}
-	return m
+
+	if cpuID := enriched["cpu_id"]; cpuID != "" {
+		addLabelIfMissing(enriched, "cpu", cpuID)
+	}
+
+	if ctx.catalog == nil {
+		return enriched
+	}
+
+	uuid := enriched["uuid"]
+	isGPUParentNVLink := enriched["gpu_uuid"] != ""
+	if isGPUParentNVLink {
+		uuid = enriched["gpu_uuid"]
+	}
+	if uuid == "" && enriched["gpu"] != "" {
+		uuid = ctx.catalog.GPUUUIDByIndex[enriched["gpu"]]
+	}
+	if uuid == "" {
+		return enriched
+	}
+
+	gpuIdentity, ok := ctx.catalog.GPUsByUUID[uuid]
+	if !ok {
+		return enriched
+	}
+	if isGPUParentNVLink {
+		addLabelIfMissing(enriched, "gpu_uuid", gpuIdentity.UUID)
+	} else {
+		addLabelIfMissing(enriched, "uuid", gpuIdentity.UUID)
+	}
+	addLabelIfMissing(enriched, "gpu", gpuIdentity.GPU)
+	addLabelIfMissing(enriched, "pci_bus_id", gpuIdentity.PCIBusID)
+	addLabelIfMissing(enriched, "device", gpuIdentity.Device)
+	addLabelIfMissing(enriched, "model_name", gpuIdentity.ModelName)
+	addLabelIfMissing(enriched, "gpu_serial", gpuIdentity.GPUSerial)
+	addLabelIfMissing(enriched, "cluster_uuid", gpuIdentity.ClusterUUID)
+	addLabelIfMissing(enriched, "clique_id", gpuIdentity.CliqueID)
+	return enriched
+}
+
+func addLabelIfMissing(labels map[string]string, key, value string) {
+	if labels[key] == "" && strings.TrimSpace(value) != "" {
+		labels[key] = strings.TrimSpace(value)
+	}
 }
 
 // convertToOTLPLogs converts HealthData events and component data to OTLP log records
 func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.LogRecord {
 	var logRecords []*logsv1.LogRecord
+	identity := newIdentityContext(data)
 
 	// Add events as log records
 	if len(data.Events) > 0 {
@@ -362,9 +505,13 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 					},
 				},
 			}
-			extraInfo := event.ExtraInfo
-			if extraInfo == nil {
-				extraInfo = map[string]string{}
+			extraInfo := cloneStringMap(event.ExtraInfo)
+			eventIdentity := identity.identityForEvent(extraInfo)
+			if len(eventIdentity) > 0 {
+				if rawIdentity, err := json.Marshal(eventIdentity); err == nil {
+					extraInfo["identity"] = string(rawIdentity)
+				}
+				attributes = append(attributes, labelsToOTLPAttributes(eventIdentity)...)
 			}
 			attributes = append(attributes, &commonv1.KeyValue{
 				Key:   "extra_info",
@@ -475,7 +622,7 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 			if typedIncidents, ok := toHealthStateIncidents(incidents); ok && len(typedIncidents) > 0 {
 				attributes = append(attributes, &commonv1.KeyValue{
 					Key:   "incidents",
-					Value: incidentsToOTLPArrayValue(typedIncidents),
+					Value: incidentsToOTLPArrayValue(typedIncidents, identity),
 				})
 			}
 
@@ -497,6 +644,73 @@ func (c *otlpConverter) convertToOTLPLogs(data *collector.HealthData) []*logsv1.
 	return logRecords
 }
 
+func cloneStringMap(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src)+1)
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
+
+func labelsToOTLPAttributes(labels map[string]string) []*commonv1.KeyValue {
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	attributes := make([]*commonv1.KeyValue, 0, len(keys))
+	for _, key := range keys {
+		attributes = append(attributes, &commonv1.KeyValue{Key: key, Value: stringAnyValue(labels[key])})
+	}
+	return attributes
+}
+
+func (ctx identityContext) identityForEvent(extraInfo map[string]string) map[string]string {
+	labels := make(map[string]string)
+	for _, key := range []string{"uuid", "gpu_uuid", "device_uuid", "gpu", "entity_id", "nvlink", "nvswitch", "cpu", "cpucore"} {
+		if value := strings.TrimSpace(extraInfo[key]); value != "" {
+			labels[key] = value
+		}
+	}
+
+	if labels["uuid"] == "" {
+		labels["uuid"] = labels["device_uuid"]
+	}
+	delete(labels, "device_uuid")
+	if key, value := identityFromEntityID(labels["entity_id"]); key != "" && labels[key] == "" {
+		labels[key] = value
+	}
+	delete(labels, "entity_id")
+
+	if labels["uuid"] == "" && labels["gpu_uuid"] == "" && labels["gpu"] == "" && labels["nvlink"] == "" &&
+		labels["nvswitch"] == "" && labels["cpu"] == "" && labels["cpucore"] == "" {
+		return nil
+	}
+	return ctx.enrichLabels(labels)
+}
+
+func identityFromEntityID(entityID string) (string, string) {
+	prefix, id, ok := strings.Cut(strings.TrimSpace(entityID), "-")
+	if !ok || strings.TrimSpace(id) == "" {
+		return "", ""
+	}
+	switch strings.ToLower(strings.TrimSpace(prefix)) {
+	case "gpu":
+		return "gpu", strings.TrimSpace(id)
+	case "nvswitch":
+		return "nvswitch", strings.TrimSpace(id)
+	case "nvlink":
+		return "nvlink", strings.TrimSpace(id)
+	case "cpu":
+		return "cpu", strings.TrimSpace(id)
+	case "cpucore", "cpu_core":
+		return "cpucore", strings.TrimSpace(id)
+	default:
+		return "", ""
+	}
+}
+
 func extraInfoToAnyValue(extraInfo map[string]string) *commonv1.AnyValue {
 	values := make([]*commonv1.KeyValue, 0, len(extraInfo))
 	for key, raw := range extraInfo {
@@ -513,7 +727,7 @@ func extraInfoToAnyValue(extraInfo map[string]string) *commonv1.AnyValue {
 	}
 }
 
-func incidentsToOTLPArrayValue(incidents []apiv1.HealthStateIncident) *commonv1.AnyValue {
+func incidentsToOTLPArrayValue(incidents []apiv1.HealthStateIncident, identity identityContext) *commonv1.AnyValue {
 	values := make([]*commonv1.AnyValue, 0, len(incidents))
 	for _, inc := range incidents {
 		kvs := []*commonv1.KeyValue{
@@ -522,6 +736,8 @@ func incidentsToOTLPArrayValue(incidents []apiv1.HealthStateIncident) *commonv1.
 			{Key: "severity", Value: stringAnyValue(string(inc.Health))},
 			{Key: "error", Value: stringAnyValue(inc.Error)},
 		}
+		incidentIdentity := identity.identityForEvent(map[string]string{"entity_id": inc.EntityID})
+		kvs = append(kvs, labelsToOTLPAttributes(incidentIdentity)...)
 		values = append(values, &commonv1.AnyValue{
 			Value: &commonv1.AnyValue_KvlistValue{
 				KvlistValue: &commonv1.KeyValueList{Values: kvs},

--- a/internal/exporter/converter/otlp.go
+++ b/internal/exporter/converter/otlp.go
@@ -263,10 +263,11 @@ func inventoryMetrics(data *collector.HealthData, catalog *collector.EntityCatal
 	softwareLabels := map[string]string{}
 	addLabelIfMissing(softwareLabels, "gpu_driver_version", catalog.GPUDriverVersion)
 	addLabelIfMissing(softwareLabels, "cuda_driver_version", catalog.CUDADriverVersion)
+	addLabelIfMissing(softwareLabels, "kernel_version", catalog.KernelVersion)
 	if len(softwareLabels) > 0 {
 		inventory = append(inventory, gaugeMetric(
 			"fleetint_node_software_info",
-			"Node-scoped GPU software version information.",
+			"Node-scoped GPU software and kernel version information.",
 			"",
 			data.Timestamp,
 			1,
@@ -294,7 +295,7 @@ func inventoryMetrics(data *collector.HealthData, catalog *collector.EntityCatal
 	firmwarePoints := make([]*metricsv1.NumberDataPoint, 0, len(uuids))
 	for _, uuid := range uuids {
 		gpu := catalog.GPUsByUUID[uuid]
-		if gpu.GPUSerial == "" && gpu.VBIOSVersion == "" {
+		if gpu.GPUSerial == "" && gpu.VBIOSVersion == "" && gpu.Architecture == "" {
 			continue
 		}
 		labels := map[string]string{}
@@ -302,12 +303,13 @@ func inventoryMetrics(data *collector.HealthData, catalog *collector.EntityCatal
 		addLabelIfMissing(labels, "uuid", gpu.UUID)
 		addLabelIfMissing(labels, "gpu_serial", gpu.GPUSerial)
 		addLabelIfMissing(labels, "vbios_version", gpu.VBIOSVersion)
+		addLabelIfMissing(labels, "gpu_architecture", gpu.Architecture)
 		firmwarePoints = append(firmwarePoints, gaugeDataPoint(data.Timestamp, 1, labels))
 	}
 	if len(firmwarePoints) > 0 {
 		inventory = append(inventory, &metricsv1.Metric{
 			Name:        "fleetint_gpu_firmware_info",
-			Description: "Per-GPU serial number and VBIOS version information.",
+			Description: "Per-GPU architecture, serial number, and VBIOS version information.",
 			Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{
 				DataPoints: firmwarePoints,
 			}},

--- a/internal/exporter/converter/otlp_test.go
+++ b/internal/exporter/converter/otlp_test.go
@@ -556,7 +556,7 @@ func TestOTLPConverter_ConvertLabelsToOTLPAttributes(t *testing.T) {
 	}
 
 	converter := &otlpConverter{}
-	attrs := converter.convertLabelsToOTLPAttributes(labels, nil)
+	attrs := converter.convertLabelsToOTLPAttributes(labels, identityContext{})
 
 	assert.Len(t, attrs, 3)
 
@@ -575,15 +575,29 @@ func TestOTLPConverter_ConvertLabelsToOTLPAttributes_EmptyLabels(t *testing.T) {
 	labels := map[string]string{}
 
 	converter := &otlpConverter{}
-	attrs := converter.convertLabelsToOTLPAttributes(labels, nil)
+	attrs := converter.convertLabelsToOTLPAttributes(labels, identityContext{})
 
 	assert.Empty(t, attrs)
 }
 
 func TestOTLPConverter_ConvertLabelsToOTLPAttributes_EnrichesGPUIndex(t *testing.T) {
-	gpuUUIDToIndex := map[string]string{
-		"GPU-abc-123": "0",
-		"GPU-def-456": "1",
+	converter := &otlpConverter{}
+	identity := identityContext{
+		catalog: &collector.EntityCatalog{
+			GPUsByUUID: map[string]collector.GPUIdentity{
+				"GPU-abc-123": {
+					UUID:        "GPU-abc-123",
+					GPU:         "0",
+					PCIBusID:    "0000:01:00.0",
+					Device:      "nvidia0",
+					ModelName:   "NVIDIA H100",
+					GPUSerial:   "GPU-SERIAL-123",
+					ClusterUUID: "11111111-2222-3333-4444-555555555555",
+					CliqueID:    "7",
+				},
+			},
+			GPUUUIDByIndex: map[string]string{"0": "GPU-abc-123"},
+		},
 	}
 
 	t.Run("adds gpu label when uuid present but gpu absent", func(t *testing.T) {
@@ -592,8 +606,7 @@ func TestOTLPConverter_ConvertLabelsToOTLPAttributes_EnrichesGPUIndex(t *testing
 			"gpud_component": "accelerator-nvidia-utilization",
 		}
 
-		converter := &otlpConverter{}
-		attrs := converter.convertLabelsToOTLPAttributes(labels, gpuUUIDToIndex)
+		attrs := converter.convertLabelsToOTLPAttributes(labels, identity)
 
 		attrMap := make(map[string]string)
 		for _, attr := range attrs {
@@ -602,6 +615,13 @@ func TestOTLPConverter_ConvertLabelsToOTLPAttributes_EnrichesGPUIndex(t *testing
 
 		assert.Equal(t, "0", attrMap["gpu"], "should enrich with gpu index from machine info")
 		assert.Equal(t, "GPU-abc-123", attrMap["uuid"])
+		assert.Equal(t, "0000:01:00.0", attrMap["pci_bus_id"])
+		assert.Equal(t, "nvidia0", attrMap["device"])
+		assert.Equal(t, "NVIDIA H100", attrMap["model_name"])
+		assert.Equal(t, "GPU-SERIAL-123", attrMap["gpu_serial"])
+		assert.Equal(t, "11111111-2222-3333-4444-555555555555", attrMap["cluster_uuid"])
+		assert.Equal(t, "7", attrMap["clique_id"])
+		assert.NotContains(t, attrMap, "hostname")
 	})
 
 	t.Run("skips enrichment when gpu label already present (DCGM)", func(t *testing.T) {
@@ -611,8 +631,7 @@ func TestOTLPConverter_ConvertLabelsToOTLPAttributes_EnrichesGPUIndex(t *testing
 			"gpud_component": "accelerator-nvidia-dcgm-clock",
 		}
 
-		converter := &otlpConverter{}
-		attrs := converter.convertLabelsToOTLPAttributes(labels, gpuUUIDToIndex)
+		attrs := converter.convertLabelsToOTLPAttributes(labels, identity)
 
 		gpuCount := 0
 		for _, attr := range attrs {
@@ -629,8 +648,7 @@ func TestOTLPConverter_ConvertLabelsToOTLPAttributes_EnrichesGPUIndex(t *testing
 			"gpud_component": "accelerator-nvidia-utilization",
 		}
 
-		converter := &otlpConverter{}
-		attrs := converter.convertLabelsToOTLPAttributes(labels, gpuUUIDToIndex)
+		attrs := converter.convertLabelsToOTLPAttributes(labels, identity)
 
 		attrMap := make(map[string]string)
 		for _, attr := range attrs {
@@ -647,8 +665,7 @@ func TestOTLPConverter_ConvertLabelsToOTLPAttributes_EnrichesGPUIndex(t *testing
 			"mount_point":    "/",
 		}
 
-		converter := &otlpConverter{}
-		attrs := converter.convertLabelsToOTLPAttributes(labels, gpuUUIDToIndex)
+		attrs := converter.convertLabelsToOTLPAttributes(labels, identity)
 
 		attrMap := make(map[string]string)
 		for _, attr := range attrs {
@@ -665,8 +682,7 @@ func TestOTLPConverter_ConvertLabelsToOTLPAttributes_EnrichesGPUIndex(t *testing
 			"gpud_component": "accelerator-nvidia-utilization",
 		}
 
-		converter := &otlpConverter{}
-		attrs := converter.convertLabelsToOTLPAttributes(labels, nil)
+		attrs := converter.convertLabelsToOTLPAttributes(labels, identityContext{})
 
 		attrMap := make(map[string]string)
 		for _, attr := range attrs {
@@ -676,50 +692,121 @@ func TestOTLPConverter_ConvertLabelsToOTLPAttributes_EnrichesGPUIndex(t *testing
 		_, hasGPU := attrMap["gpu"]
 		assert.False(t, hasGPU, "should not add gpu label when mapping is nil")
 	})
+
+	t.Run("resolves GPU identity from gpu index", func(t *testing.T) {
+		attrs := converter.convertLabelsToOTLPAttributes(map[string]string{"gpu": "0"}, identity)
+		attrMap := make(map[string]string)
+		for _, attr := range attrs {
+			attrMap[attr.Key] = attr.Value.GetStringValue()
+		}
+
+		assert.Equal(t, "GPU-abc-123", attrMap["uuid"])
+		assert.Equal(t, "NVIDIA H100", attrMap["model_name"])
+		assert.Equal(t, "GPU-SERIAL-123", attrMap["gpu_serial"])
+		assert.Equal(t, "11111111-2222-3333-4444-555555555555", attrMap["cluster_uuid"])
+		assert.Equal(t, "7", attrMap["clique_id"])
+	})
+
+	t.Run("uses gpu_uuid contract for GPU-parent NVLink", func(t *testing.T) {
+		attrs := converter.convertLabelsToOTLPAttributes(map[string]string{
+			"gpu_uuid": "GPU-abc-123",
+			"nvlink":   "3",
+		}, identity)
+		attrMap := make(map[string]string)
+		for _, attr := range attrs {
+			attrMap[attr.Key] = attr.Value.GetStringValue()
+		}
+
+		assert.Equal(t, "GPU-abc-123", attrMap["gpu_uuid"])
+		assert.NotContains(t, attrMap, "uuid")
+		assert.Equal(t, "0", attrMap["gpu"])
+		assert.Equal(t, "3", attrMap["nvlink"])
+		assert.Equal(t, "NVIDIA H100", attrMap["model_name"])
+		assert.Equal(t, "GPU-SERIAL-123", attrMap["gpu_serial"])
+	})
+
+	t.Run("normalizes CPU identity without duplicating host name", func(t *testing.T) {
+		attrs := converter.convertLabelsToOTLPAttributes(map[string]string{"cpu_id": "1"}, identity)
+		attrMap := make(map[string]string)
+		for _, attr := range attrs {
+			attrMap[attr.Key] = attr.Value.GetStringValue()
+		}
+
+		assert.Equal(t, "1", attrMap["cpu"])
+		assert.Equal(t, "1", attrMap["cpu_id"])
+		assert.NotContains(t, attrMap, "hostname")
+	})
+
+	t.Run("does not overwrite source labels", func(t *testing.T) {
+		attrs := converter.convertLabelsToOTLPAttributes(map[string]string{
+			"uuid":         "GPU-abc-123",
+			"pci_bus_id":   "source-pci",
+			"device":       "source-device",
+			"model_name":   "source-model",
+			"gpu_serial":   "source-serial",
+			"cluster_uuid": "source-cluster",
+			"clique_id":    "9",
+			"hostname":     "source-host",
+		}, identity)
+		attrMap := make(map[string]string)
+		for _, attr := range attrs {
+			attrMap[attr.Key] = attr.Value.GetStringValue()
+		}
+
+		assert.Equal(t, "source-pci", attrMap["pci_bus_id"])
+		assert.Equal(t, "source-device", attrMap["device"])
+		assert.Equal(t, "source-model", attrMap["model_name"])
+		assert.Equal(t, "source-serial", attrMap["gpu_serial"])
+		assert.Equal(t, "source-cluster", attrMap["cluster_uuid"])
+		assert.Equal(t, "9", attrMap["clique_id"])
+		assert.Equal(t, "source-host", attrMap["hostname"])
+	})
 }
 
-func TestBuildGPUUUIDToIndexMap(t *testing.T) {
-	t.Run("builds map from machine info", func(t *testing.T) {
-		data := &collector.HealthData{
-			GPUUUIDToIndex: map[string]string{
-				"GPU-abc-123": "0",
-				"GPU-def-456": "1",
+func TestOTLPConverter_EnrichesGPUEventIdentity(t *testing.T) {
+	data := &collector.HealthData{
+		Timestamp: time.Now(),
+		MachineID: "test-machine",
+		EntityCatalog: &collector.EntityCatalog{
+			Hostname: "gpu-node-01",
+			GPUsByUUID: map[string]collector.GPUIdentity{
+				"GPU-abc": {
+					UUID:        "GPU-abc",
+					GPU:         "0",
+					PCIBusID:    "0000:01:00.0",
+					Device:      "nvidia0",
+					ModelName:   "NVIDIA H100",
+					GPUSerial:   "GPU-SERIAL-123",
+					ClusterUUID: "11111111-2222-3333-4444-555555555555",
+					CliqueID:    "7",
+				},
 			},
-		}
+			GPUUUIDByIndex: map[string]string{"0": "GPU-abc"},
+		},
+		Events: eventstore.Events{{
+			Time:      time.Now(),
+			Component: "accelerator-nvidia-error-xid",
+			Name:      "xid",
+			Type:      "critical",
+			ExtraInfo: map[string]string{"device_uuid": "GPU-abc"},
+		}},
+	}
 
-		m := buildGPUUUIDToIndexMap(data)
-		assert.Equal(t, "0", m["GPU-abc-123"])
-		assert.Equal(t, "1", m["GPU-def-456"])
-		assert.Len(t, m, 2)
-	})
+	logs := NewOTLPConverter().Convert(data).Logs.ResourceLogs[0].ScopeLogs[0].LogRecords
+	require.Len(t, logs, 1)
+	assert.Equal(t, "0", findAttribute(t, logs[0].Attributes, "gpu").GetStringValue())
+	assert.Equal(t, "NVIDIA H100", findAttribute(t, logs[0].Attributes, "model_name").GetStringValue())
+	assert.Equal(t, "GPU-SERIAL-123", findAttribute(t, logs[0].Attributes, "gpu_serial").GetStringValue())
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", findAttribute(t, logs[0].Attributes, "cluster_uuid").GetStringValue())
+	assert.Equal(t, "7", findAttribute(t, logs[0].Attributes, "clique_id").GetStringValue())
 
-	t.Run("returns empty map when machine info is nil", func(t *testing.T) {
-		data := &collector.HealthData{}
-		m := buildGPUUUIDToIndexMap(data)
-		assert.Empty(t, m)
-	})
-
-	t.Run("returns empty map when mapping is nil", func(t *testing.T) {
-		data := &collector.HealthData{
-			GPUUUIDToIndex: nil,
-		}
-		m := buildGPUUUIDToIndexMap(data)
-		assert.Empty(t, m)
-	})
-
-	t.Run("skips entries with empty uuid or index", func(t *testing.T) {
-		data := &collector.HealthData{
-			GPUUUIDToIndex: map[string]string{
-				"GPU-abc-123": "0",
-				"":            "1",
-				"GPU-ghi-789": "",
-			},
-		}
-
-		m := buildGPUUUIDToIndexMap(data)
-		assert.Equal(t, "0", m["GPU-abc-123"])
-		assert.Len(t, m, 1)
-	})
+	extraInfo := findAttribute(t, logs[0].Attributes, "extra_info").GetKvlistValue()
+	identity := findMapValue(t, extraInfo.Values, "identity").GetKvlistValue()
+	require.NotNil(t, identity)
+	assert.Equal(t, "GPU-abc", findMapValue(t, identity.Values, "uuid").GetStringValue())
+	for _, value := range identity.Values {
+		assert.NotEqual(t, "hostname", value.Key)
+	}
 }
 
 func TestOTLPConverter_SummaryMetric(t *testing.T) {
@@ -772,6 +859,10 @@ func TestOTLPConverter_SummaryMetric(t *testing.T) {
 
 func TestOTLPConverter_UpMetric(t *testing.T) {
 	timestamp := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	originalAgentStartTime := agentStartTime
+	agentStartTime = timestamp.Add(-15*time.Minute - 4*time.Second)
+	t.Cleanup(func() { agentStartTime = originalAgentStartTime })
+
 	data := &collector.HealthData{
 		Timestamp: timestamp,
 		MachineID: "test-machine",
@@ -802,6 +893,129 @@ func TestOTLPConverter_UpMetric(t *testing.T) {
 	assert.Equal(t, uint64(timestamp.UnixNano()), point.TimeUnixNano)
 	assert.Equal(t, int64(1), point.GetAsInt())
 	assert.Empty(t, point.Attributes)
+
+	uptimeMetric := findOTLPMetric(metrics, "fleetint_agent_uptime_seconds")
+	require.NotNil(t, uptimeMetric, "Should have fleetint_agent_uptime_seconds metric")
+	assert.Empty(t, uptimeMetric.Unit)
+	assert.Contains(t, uptimeMetric.Description, "process started")
+	require.Len(t, uptimeMetric.GetGauge().DataPoints, 1)
+	uptimePoint := uptimeMetric.GetGauge().DataPoints[0]
+	assert.Equal(t, uint64(timestamp.UnixNano()), uptimePoint.TimeUnixNano)
+	assert.Equal(t, 904.0, uptimePoint.GetAsDouble())
+	assert.Empty(t, uptimePoint.Attributes)
+}
+
+func TestOTLPConverter_AgentUptimeOmitsFutureStartTime(t *testing.T) {
+	timestamp := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	originalAgentStartTime := agentStartTime
+	agentStartTime = timestamp.Add(time.Second)
+	t.Cleanup(func() { agentStartTime = originalAgentStartTime })
+
+	converted := NewOTLPConverter().Convert(&collector.HealthData{
+		Timestamp: timestamp,
+		MachineID: "test-machine",
+	})
+	convertedMetrics := converted.Metrics.ResourceMetrics[0].ScopeMetrics[0].Metrics
+	assert.Nil(t, findOTLPMetric(convertedMetrics, "fleetint_agent_uptime_seconds"))
+}
+
+func TestOTLPConverter_InventoryMetrics(t *testing.T) {
+	timestamp := time.Date(2026, 8, 4, 14, 0, 0, 0, time.UTC)
+	data := &collector.HealthData{
+		Timestamp: timestamp,
+		MachineID: "test-machine",
+		EntityCatalog: &collector.EntityCatalog{
+			GPUDriverVersion:  "575.57.08",
+			CUDADriverVersion: "12.9",
+			BootTime:          timestamp.Add(-2*time.Hour - 3*time.Second),
+			GPUsByUUID: map[string]collector.GPUIdentity{
+				"GPU-b": {
+					UUID:         "GPU-b",
+					GPU:          "1",
+					GPUSerial:    "SERIAL-b",
+					VBIOSVersion: "97.00.82.00.5F",
+				},
+				"GPU-a": {
+					UUID:         "GPU-a",
+					GPU:          "0",
+					GPUSerial:    "SERIAL-a",
+					VBIOSVersion: "97.00.82.00.5E",
+				},
+				"GPU-no-firmware-data": {
+					UUID: "GPU-no-firmware-data",
+					GPU:  "2",
+				},
+			},
+		},
+	}
+
+	converted := NewOTLPConverter().Convert(data)
+	convertedMetrics := converted.Metrics.ResourceMetrics[0].ScopeMetrics[0].Metrics
+
+	software := findOTLPMetric(convertedMetrics, "fleetint_node_software_info")
+	require.NotNil(t, software)
+	require.Len(t, software.GetGauge().DataPoints, 1)
+	softwarePoint := software.GetGauge().DataPoints[0]
+	assert.Equal(t, 1.0, softwarePoint.GetAsDouble())
+	assert.Equal(t, map[string]string{
+		"cuda_driver_version": "12.9",
+		"gpu_driver_version":  "575.57.08",
+	}, stringAttributeMap(softwarePoint.Attributes))
+
+	uptime := findOTLPMetric(convertedMetrics, "fleetint_node_uptime_seconds")
+	require.NotNil(t, uptime)
+	assert.Empty(t, uptime.Unit)
+	require.Len(t, uptime.GetGauge().DataPoints, 1)
+	assert.Equal(t, 7203.0, uptime.GetGauge().DataPoints[0].GetAsDouble())
+	assert.Empty(t, uptime.GetGauge().DataPoints[0].Attributes)
+
+	firmware := findOTLPMetric(convertedMetrics, "fleetint_gpu_firmware_info")
+	require.NotNil(t, firmware)
+	require.Len(t, firmware.GetGauge().DataPoints, 2)
+	assert.Equal(t, map[string]string{
+		"gpu":           "0",
+		"gpu_serial":    "SERIAL-a",
+		"uuid":          "GPU-a",
+		"vbios_version": "97.00.82.00.5E",
+	}, stringAttributeMap(firmware.GetGauge().DataPoints[0].Attributes))
+	assert.Equal(t, map[string]string{
+		"gpu":           "1",
+		"gpu_serial":    "SERIAL-b",
+		"uuid":          "GPU-b",
+		"vbios_version": "97.00.82.00.5F",
+	}, stringAttributeMap(firmware.GetGauge().DataPoints[1].Attributes))
+	for _, point := range firmware.GetGauge().DataPoints {
+		assert.Equal(t, 1.0, point.GetAsDouble())
+		assert.Equal(t, uint64(timestamp.UnixNano()), point.TimeUnixNano)
+	}
+}
+
+func TestOTLPConverter_InventoryMetricsOmitUnavailableValues(t *testing.T) {
+	timestamp := time.Date(2026, 8, 4, 14, 0, 0, 0, time.UTC)
+	data := &collector.HealthData{
+		Timestamp: timestamp,
+		MachineID: "test-machine",
+		EntityCatalog: &collector.EntityCatalog{
+			BootTime: timestamp.Add(time.Minute),
+			GPUsByUUID: map[string]collector.GPUIdentity{
+				"GPU-a": {UUID: "GPU-a", GPU: "0"},
+			},
+		},
+	}
+
+	converted := NewOTLPConverter().Convert(data)
+	convertedMetrics := converted.Metrics.ResourceMetrics[0].ScopeMetrics[0].Metrics
+	assert.Nil(t, findOTLPMetric(convertedMetrics, "fleetint_node_software_info"))
+	assert.Nil(t, findOTLPMetric(convertedMetrics, "fleetint_node_uptime_seconds"))
+	assert.Nil(t, findOTLPMetric(convertedMetrics, "fleetint_gpu_firmware_info"))
+}
+
+func stringAttributeMap(attributes []*commonv1.KeyValue) map[string]string {
+	result := make(map[string]string, len(attributes))
+	for _, attribute := range attributes {
+		result[attribute.Key] = attribute.Value.GetStringValue()
+	}
+	return result
 }
 
 func findOTLPMetric(metrics []*metricsv1.Metric, name string) *metricsv1.Metric {
@@ -819,6 +1033,9 @@ func TestOTLPConverter_ResourceAttributes(t *testing.T) {
 		MachineID:   "test-machine-123",
 		NodeGroup:   "group-a",
 		ComputeZone: "zone-a",
+		EntityCatalog: &collector.EntityCatalog{
+			Hostname: "gpu-node-01",
+		},
 		ComponentData: map[string]interface{}{
 			"comp1": map[string]any{},
 			"comp2": map[string]any{},
@@ -843,6 +1060,8 @@ func TestOTLPConverter_ResourceAttributes(t *testing.T) {
 	assert.Equal(t, "test-machine-123", attrMap["machine.id"])
 	assert.Equal(t, "group-a", attrMap["node_group"])
 	assert.Equal(t, "zone-a", attrMap["compute_zone"])
+	assert.Equal(t, "gpu-node-01", attrMap["host.name"])
+	assert.NotContains(t, attrMap, "hostname")
 
 	logResourceAttrMap := make(map[string]string)
 	for _, attr := range otlpData.Logs.ResourceLogs[0].Resource.Attributes {
@@ -852,6 +1071,29 @@ func TestOTLPConverter_ResourceAttributes(t *testing.T) {
 	}
 	assert.Equal(t, "group-a", logResourceAttrMap["node_group"])
 	assert.Equal(t, "zone-a", logResourceAttrMap["compute_zone"])
+	assert.Equal(t, "gpu-node-01", logResourceAttrMap["host.name"])
+	assert.NotContains(t, logResourceAttrMap, "hostname")
+}
+
+func TestIdentityFromEntityID(t *testing.T) {
+	tests := []struct {
+		entityID string
+		wantKey  string
+		wantID   string
+	}{
+		{entityID: "Gpu-0", wantKey: "gpu", wantID: "0"},
+		{entityID: "NvSwitch-3", wantKey: "nvswitch", wantID: "3"},
+		{entityID: "CpuCore-7", wantKey: "cpucore", wantID: "7"},
+		{entityID: "unknown-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.entityID, func(t *testing.T) {
+			key, id := identityFromEntityID(tt.entityID)
+			assert.Equal(t, tt.wantKey, key)
+			assert.Equal(t, tt.wantID, id)
+		})
+	}
 }
 
 func TestOTLPConverter_ResourceAttributesOmitEmptyOptionalValues(t *testing.T) {

--- a/internal/exporter/converter/otlp_test.go
+++ b/internal/exporter/converter/otlp_test.go
@@ -893,23 +893,27 @@ func TestOTLPConverter_InventoryMetrics(t *testing.T) {
 		EntityCatalog: &collector.EntityCatalog{
 			GPUDriverVersion:  "575.57.08",
 			CUDADriverVersion: "12.9",
+			KernelVersion:     "6.14.0-27-generic",
 			BootTime:          timestamp.Add(-2*time.Hour - 3*time.Second),
 			GPUsByUUID: map[string]collector.GPUIdentity{
 				"GPU-b": {
 					UUID:         "GPU-b",
 					GPU:          "1",
+					Architecture: "blackwell",
 					GPUSerial:    "SERIAL-b",
 					VBIOSVersion: "97.00.82.00.5F",
 				},
 				"GPU-a": {
 					UUID:         "GPU-a",
 					GPU:          "0",
+					Architecture: "blackwell",
 					GPUSerial:    "SERIAL-a",
 					VBIOSVersion: "97.00.82.00.5E",
 				},
-				"GPU-no-firmware-data": {
-					UUID: "GPU-no-firmware-data",
-					GPU:  "2",
+				"GPU-architecture-only": {
+					UUID:         "GPU-architecture-only",
+					GPU:          "2",
+					Architecture: "blackwell",
 				},
 			},
 		},
@@ -926,6 +930,7 @@ func TestOTLPConverter_InventoryMetrics(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"cuda_driver_version": "12.9",
 		"gpu_driver_version":  "575.57.08",
+		"kernel_version":      "6.14.0-27-generic",
 	}, stringAttributeMap(softwarePoint.Attributes))
 
 	uptime := findOTLPMetric(convertedMetrics, "fleetint_node_uptime_seconds")
@@ -937,19 +942,26 @@ func TestOTLPConverter_InventoryMetrics(t *testing.T) {
 
 	firmware := findOTLPMetric(convertedMetrics, "fleetint_gpu_firmware_info")
 	require.NotNil(t, firmware)
-	require.Len(t, firmware.GetGauge().DataPoints, 2)
+	require.Len(t, firmware.GetGauge().DataPoints, 3)
 	assert.Equal(t, map[string]string{
-		"gpu":           "0",
-		"gpu_serial":    "SERIAL-a",
-		"uuid":          "GPU-a",
-		"vbios_version": "97.00.82.00.5E",
+		"gpu":              "0",
+		"gpu_architecture": "blackwell",
+		"gpu_serial":       "SERIAL-a",
+		"uuid":             "GPU-a",
+		"vbios_version":    "97.00.82.00.5E",
 	}, stringAttributeMap(firmware.GetGauge().DataPoints[0].Attributes))
 	assert.Equal(t, map[string]string{
-		"gpu":           "1",
-		"gpu_serial":    "SERIAL-b",
-		"uuid":          "GPU-b",
-		"vbios_version": "97.00.82.00.5F",
+		"gpu":              "2",
+		"gpu_architecture": "blackwell",
+		"uuid":             "GPU-architecture-only",
 	}, stringAttributeMap(firmware.GetGauge().DataPoints[1].Attributes))
+	assert.Equal(t, map[string]string{
+		"gpu":              "1",
+		"gpu_architecture": "blackwell",
+		"gpu_serial":       "SERIAL-b",
+		"uuid":             "GPU-b",
+		"vbios_version":    "97.00.82.00.5F",
+	}, stringAttributeMap(firmware.GetGauge().DataPoints[2].Attributes))
 	for _, point := range firmware.GetGauge().DataPoints {
 		assert.Equal(t, 1.0, point.GetAsDouble())
 		assert.Equal(t, uint64(timestamp.UnixNano()), point.TimeUnixNano)

--- a/internal/exporter/converter/otlp_test.go
+++ b/internal/exporter/converter/otlp_test.go
@@ -228,6 +228,11 @@ func TestOTLPConverter_Convert_WithEvents_StructuredExtraInfo(t *testing.T) {
 	data := &collector.HealthData{
 		Timestamp: time.Now(),
 		MachineID: "test-machine",
+		EntityCatalog: &collector.EntityCatalog{
+			GPUsByUUID: map[string]collector.GPUIdentity{
+				"GPU-abc": {UUID: "GPU-abc", GPU: "0", PCIBusID: "0000:04:00.0"},
+			},
+		},
 		Events: eventstore.Events{
 			{
 				Time:      time.Date(2025, 11, 5, 12, 0, 0, 0, time.UTC),
@@ -256,6 +261,12 @@ func TestOTLPConverter_Convert_WithEvents_StructuredExtraInfo(t *testing.T) {
 	extraInfo := findAttribute(t, logs[0].Attributes, "extra_info").GetKvlistValue()
 	require.NotNil(t, extraInfo)
 	assert.Equal(t, "PCI:0000:04:00", findMapValue(t, extraInfo.Values, "device_uuid").GetStringValue())
+	for _, attr := range logs[0].Attributes {
+		assert.NotContains(t, []string{"uuid", "gpu", "pci_bus_id", "gpu_serial", "model_name"}, attr.Key)
+	}
+	for _, value := range extraInfo.Values {
+		assert.NotEqual(t, "identity", value.Key)
+	}
 
 	dataValue := findMapValue(t, extraInfo.Values, "data").GetKvlistValue()
 	require.NotNil(t, dataValue)
@@ -358,6 +369,7 @@ func TestOTLPConverter_Convert_WithComponentData(t *testing.T) {
 			require.Len(t, incidents.Values, 1)
 			incident := incidents.Values[0].GetKvlistValue()
 			require.NotNil(t, incident)
+			assert.Len(t, incident.Values, 4, "incident logs should not receive metric identity labels")
 			assert.Equal(t, "GPU-1234", findMapValue(t, incident.Values, "entity_id").GetStringValue())
 			assert.Equal(t, "Clock throttled", findMapValue(t, incident.Values, "message").GetStringValue())
 			assert.Equal(t, "Degraded", findMapValue(t, incident.Values, "severity").GetStringValue())
@@ -763,52 +775,6 @@ func TestOTLPConverter_ConvertLabelsToOTLPAttributes_EnrichesGPUIndex(t *testing
 	})
 }
 
-func TestOTLPConverter_EnrichesGPUEventIdentity(t *testing.T) {
-	data := &collector.HealthData{
-		Timestamp: time.Now(),
-		MachineID: "test-machine",
-		EntityCatalog: &collector.EntityCatalog{
-			Hostname: "gpu-node-01",
-			GPUsByUUID: map[string]collector.GPUIdentity{
-				"GPU-abc": {
-					UUID:        "GPU-abc",
-					GPU:         "0",
-					PCIBusID:    "0000:01:00.0",
-					Device:      "nvidia0",
-					ModelName:   "NVIDIA H100",
-					GPUSerial:   "GPU-SERIAL-123",
-					ClusterUUID: "11111111-2222-3333-4444-555555555555",
-					CliqueID:    "7",
-				},
-			},
-			GPUUUIDByIndex: map[string]string{"0": "GPU-abc"},
-		},
-		Events: eventstore.Events{{
-			Time:      time.Now(),
-			Component: "accelerator-nvidia-error-xid",
-			Name:      "xid",
-			Type:      "critical",
-			ExtraInfo: map[string]string{"device_uuid": "GPU-abc"},
-		}},
-	}
-
-	logs := NewOTLPConverter().Convert(data).Logs.ResourceLogs[0].ScopeLogs[0].LogRecords
-	require.Len(t, logs, 1)
-	assert.Equal(t, "0", findAttribute(t, logs[0].Attributes, "gpu").GetStringValue())
-	assert.Equal(t, "NVIDIA H100", findAttribute(t, logs[0].Attributes, "model_name").GetStringValue())
-	assert.Equal(t, "GPU-SERIAL-123", findAttribute(t, logs[0].Attributes, "gpu_serial").GetStringValue())
-	assert.Equal(t, "11111111-2222-3333-4444-555555555555", findAttribute(t, logs[0].Attributes, "cluster_uuid").GetStringValue())
-	assert.Equal(t, "7", findAttribute(t, logs[0].Attributes, "clique_id").GetStringValue())
-
-	extraInfo := findAttribute(t, logs[0].Attributes, "extra_info").GetKvlistValue()
-	identity := findMapValue(t, extraInfo.Values, "identity").GetKvlistValue()
-	require.NotNil(t, identity)
-	assert.Equal(t, "GPU-abc", findMapValue(t, identity.Values, "uuid").GetStringValue())
-	for _, value := range identity.Values {
-		assert.NotEqual(t, "hostname", value.Key)
-	}
-}
-
 func TestOTLPConverter_SummaryMetric(t *testing.T) {
 	data := &collector.HealthData{
 		Timestamp: time.Now(),
@@ -1028,6 +994,8 @@ func findOTLPMetric(metrics []*metricsv1.Metric, name string) *metricsv1.Metric 
 }
 
 func TestOTLPConverter_ResourceAttributes(t *testing.T) {
+	t.Setenv("HOSTNAME", "resource-host")
+
 	data := &collector.HealthData{
 		Timestamp:   time.Now(),
 		MachineID:   "test-machine-123",
@@ -1060,7 +1028,7 @@ func TestOTLPConverter_ResourceAttributes(t *testing.T) {
 	assert.Equal(t, "test-machine-123", attrMap["machine.id"])
 	assert.Equal(t, "group-a", attrMap["node_group"])
 	assert.Equal(t, "zone-a", attrMap["compute_zone"])
-	assert.Equal(t, "gpu-node-01", attrMap["host.name"])
+	assert.Equal(t, "resource-host", attrMap["host.name"])
 	assert.NotContains(t, attrMap, "hostname")
 
 	logResourceAttrMap := make(map[string]string)
@@ -1071,29 +1039,8 @@ func TestOTLPConverter_ResourceAttributes(t *testing.T) {
 	}
 	assert.Equal(t, "group-a", logResourceAttrMap["node_group"])
 	assert.Equal(t, "zone-a", logResourceAttrMap["compute_zone"])
-	assert.Equal(t, "gpu-node-01", logResourceAttrMap["host.name"])
+	assert.Equal(t, "resource-host", logResourceAttrMap["host.name"])
 	assert.NotContains(t, logResourceAttrMap, "hostname")
-}
-
-func TestIdentityFromEntityID(t *testing.T) {
-	tests := []struct {
-		entityID string
-		wantKey  string
-		wantID   string
-	}{
-		{entityID: "Gpu-0", wantKey: "gpu", wantID: "0"},
-		{entityID: "NvSwitch-3", wantKey: "nvswitch", wantID: "3"},
-		{entityID: "CpuCore-7", wantKey: "cpucore", wantID: "7"},
-		{entityID: "unknown-1"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.entityID, func(t *testing.T) {
-			key, id := identityFromEntityID(tt.entityID)
-			assert.Equal(t, tt.wantKey, key)
-			assert.Equal(t, tt.wantID, id)
-		})
-	}
 }
 
 func TestOTLPConverter_ResourceAttributesOmitEmptyOptionalValues(t *testing.T) {
@@ -1118,6 +1065,7 @@ func TestOTLPConverter_ResourceAttributesOmitEmptyOptionalValues(t *testing.T) {
 }
 
 func TestOTLPConverter_ResourceAttributes_IncludesOnlyGPUInfoGPUs(t *testing.T) {
+	cliqueID := uint32(7)
 	data := &collector.HealthData{
 		Timestamp: time.Now(),
 		MachineID: "test-machine-123",
@@ -1132,6 +1080,9 @@ func TestOTLPConverter_ResourceAttributes_IncludesOnlyGPUInfoGPUs(t *testing.T) 
 						UUID:         "GPU-123",
 						GPUIndex:     "0",
 						BusID:        "0000:01:00.0",
+						ModelName:    "NVIDIA H100",
+						ClusterUUID:  "11111111-2222-3333-4444-555555555555",
+						CliqueID:     &cliqueID,
 						SN:           "serial-123",
 						MinorID:      "0",
 						BoardID:      7,

--- a/internal/inventory/hash_test.go
+++ b/internal/inventory/hash_test.go
@@ -127,6 +127,15 @@ func TestComputeHashDetectsInventoryItemChanges(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, baseHash, changedGPUHash)
 
+	changedNVLinkDomain := *base
+	changedNVLinkDomain.Resources.GPUInfo.GPUs = append([]GPUDevice(nil), base.Resources.GPUInfo.GPUs...)
+	cliqueID := uint32(0)
+	changedNVLinkDomain.Resources.GPUInfo.GPUs[0].ClusterUUID = "11111111-2222-3333-4444-555555555555"
+	changedNVLinkDomain.Resources.GPUInfo.GPUs[0].CliqueID = &cliqueID
+	changedNVLinkDomainHash, err := ComputeHash(&changedNVLinkDomain)
+	require.NoError(t, err)
+	require.NotEqual(t, baseHash, changedNVLinkDomainHash)
+
 	reorderedParents := *base
 	reorderedParents.Resources.DiskInfo.BlockDevices = append([]BlockDevice(nil), base.Resources.DiskInfo.BlockDevices...)
 	reorderedParents.Resources.DiskInfo.BlockDevices[0].Parents = []string{"root-parent", "immediate-parent"}

--- a/internal/inventory/mapper/backend.go
+++ b/internal/inventory/mapper/backend.go
@@ -31,9 +31,16 @@ func ToNodeUpsertRequest(s *inventory.Snapshot) *backendclient.NodeUpsertRequest
 	}
 	gpus := make([]backendclient.GPUDevice, 0, len(s.Resources.GPUInfo.GPUs))
 	for _, gpu := range s.Resources.GPUInfo.GPUs {
+		var cliqueID *uint32
+		if gpu.CliqueID != nil {
+			id := *gpu.CliqueID
+			cliqueID = &id
+		}
 		gpus = append(gpus, backendclient.GPUDevice{
 			UUID:         gpu.UUID,
 			BusID:        gpu.BusID,
+			ClusterUUID:  gpu.ClusterUUID,
+			CliqueID:     cliqueID,
 			SN:           gpu.SN,
 			MinorID:      gpu.MinorID,
 			BoardID:      gpu.BoardID,

--- a/internal/inventory/mapper/backend_test.go
+++ b/internal/inventory/mapper/backend_test.go
@@ -50,6 +50,7 @@ func TestToNodeUpsertRequestAgentConfigJSONIncludesZeroValues(t *testing.T) {
 
 func TestToNodeUpsertRequest(t *testing.T) {
 	bootTime := time.Date(2026, 4, 28, 12, 30, 0, 0, time.FixedZone("PDT", -7*60*60))
+	cliqueID := uint32(0)
 	req := ToNodeUpsertRequest(&inventory.Snapshot{
 		Hostname:                "host-a",
 		MachineID:               "machine-id",
@@ -94,6 +95,8 @@ func TestToNodeUpsertRequest(t *testing.T) {
 				GPUs: []inventory.GPUDevice{{
 					UUID:         "GPU-1",
 					BusID:        "0000:01:00.0",
+					ClusterUUID:  "11111111-2222-3333-4444-555555555555",
+					CliqueID:     &cliqueID,
 					SN:           "serial",
 					MinorID:      "1",
 					BoardID:      7,
@@ -145,6 +148,23 @@ func TestToNodeUpsertRequest(t *testing.T) {
 	require.Equal(t, "NVIDIA", req.Resources.GPUInfo.Manufacturer)
 	require.Len(t, req.Resources.GPUInfo.GPUs, 1)
 	require.Equal(t, 7, req.Resources.GPUInfo.GPUs[0].BoardID)
+	require.Equal(t, "11111111-2222-3333-4444-555555555555", req.Resources.GPUInfo.GPUs[0].ClusterUUID)
+	require.NotNil(t, req.Resources.GPUInfo.GPUs[0].CliqueID)
+	require.Equal(t, uint32(0), *req.Resources.GPUInfo.GPUs[0].CliqueID)
+	payload, err := json.Marshal(req.Resources.GPUInfo.GPUs[0])
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"uuid":"GPU-1",
+		"busID":"0000:01:00.0",
+		"clusterUUID":"11111111-2222-3333-4444-555555555555",
+		"cliqueID":0,
+		"sn":"serial",
+		"minorID":"1",
+		"boardID":7,
+		"vbiosVersion":"vbios",
+		"chassisSN":"chassis",
+		"gpuIndex":"0"
+	}`, string(payload))
 	require.Equal(t, "/dev/nvme0n1", req.Resources.DiskInfo.ContainerRootDisk)
 	require.Len(t, req.Resources.DiskInfo.BlockDevices, 1)
 	require.Equal(t, "parent0", req.Resources.DiskInfo.BlockDevices[0].Parents[0])

--- a/internal/inventory/source/source.go
+++ b/internal/inventory/source/source.go
@@ -105,9 +105,16 @@ func (s *machineInfoSource) Collect(ctx context.Context) (*inventory.Snapshot, e
 		if len(info.GPUInfo.GPUs) > 0 {
 			snap.Resources.GPUInfo.GPUs = make([]inventory.GPUDevice, 0, len(info.GPUInfo.GPUs))
 			for _, gpu := range info.GPUInfo.GPUs {
+				var cliqueID *uint32
+				if gpu.CliqueID != nil {
+					id := *gpu.CliqueID
+					cliqueID = &id
+				}
 				snap.Resources.GPUInfo.GPUs = append(snap.Resources.GPUInfo.GPUs, inventory.GPUDevice{
 					UUID:         gpu.UUID,
 					BusID:        gpu.BusID,
+					ClusterUUID:  gpu.ClusterUUID,
+					CliqueID:     cliqueID,
 					SN:           gpu.SN,
 					MinorID:      gpu.MinorID,
 					BoardID:      int(gpu.BoardID),

--- a/internal/inventory/source/source_test.go
+++ b/internal/inventory/source/source_test.go
@@ -39,6 +39,7 @@ func (f fakeMachineInfoCollector) Collect(context.Context) (*machineinfo.Machine
 
 func TestMachineInfoSourceCollect(t *testing.T) {
 	bootTime := time.Date(2026, 4, 28, 12, 30, 0, 0, time.UTC)
+	cliqueID := uint32(0)
 	src := NewMachineInfoSource(fakeMachineInfoCollector{
 		info: &machineinfo.MachineInfo{
 			AgentVersion:            "1.2.3",
@@ -72,6 +73,8 @@ func TestMachineInfoSourceCollect(t *testing.T) {
 					UUID:         "GPU-1",
 					GPUIndex:     "0",
 					BusID:        "0000:01:00.0",
+					ClusterUUID:  "11111111-2222-3333-4444-555555555555",
+					CliqueID:     &cliqueID,
 					SN:           "serial",
 					MinorID:      "1",
 					BoardID:      7,
@@ -114,6 +117,9 @@ func TestMachineInfoSourceCollect(t *testing.T) {
 	require.Equal(t, "H100", snap.Resources.GPUInfo.Product)
 	require.Len(t, snap.Resources.GPUInfo.GPUs, 1)
 	require.Equal(t, 7, snap.Resources.GPUInfo.GPUs[0].BoardID)
+	require.Equal(t, "11111111-2222-3333-4444-555555555555", snap.Resources.GPUInfo.GPUs[0].ClusterUUID)
+	require.NotNil(t, snap.Resources.GPUInfo.GPUs[0].CliqueID)
+	require.Equal(t, uint32(0), *snap.Resources.GPUInfo.GPUs[0].CliqueID)
 	require.Equal(t, "/dev/nvme0n1", snap.Resources.DiskInfo.ContainerRootDisk)
 	require.Len(t, snap.Resources.DiskInfo.BlockDevices, 1)
 	require.Equal(t, "eth0", snap.Resources.NICInfo.PrivateIPInterfaces[0].Interface)

--- a/internal/inventory/types.go
+++ b/internal/inventory/types.go
@@ -89,6 +89,8 @@ type GPUInfo struct {
 type GPUDevice struct {
 	UUID         string
 	BusID        string
+	ClusterUUID  string
+	CliqueID     *uint32
 	SN           string
 	MinorID      string
 	BoardID      int

--- a/internal/validation/outbound/validator.go
+++ b/internal/validation/outbound/validator.go
@@ -107,6 +107,7 @@ func ValidateNodeUpsertRequest(req *backendclient.NodeUpsertRequest) []Issue {
 		prefix := fmt.Sprintf("resources.gpuInfo.gpus[%d]", i)
 		validateLen(&issues, "length", prefix+".uuid", gpu.UUID, 255)
 		validateLen(&issues, "length", prefix+".gpuIndex", gpu.GPUIndex, 64)
+		validateLen(&issues, "length", prefix+".clusterUUID", gpu.ClusterUUID, 255)
 		validateGPUUUID(&issues, "format", prefix+".uuid", gpu.UUID)
 		if gpu.UUID != "" {
 			if _, exists := seenGPUUUID[gpu.UUID]; exists {

--- a/third_party/fleet-intelligence-sdk/api/v1/types.go
+++ b/third_party/fleet-intelligence-sdk/api/v1/types.go
@@ -414,13 +414,15 @@ type MachineGPUInstance struct {
 	BusID string `json:"busID,omitempty"`
 
 	// ModelName is the product name reported by NVML for this GPU.
-	ModelName string `json:"modelName,omitempty"`
+	// It is used for metric identity enrichment and intentionally excluded from
+	// the existing machine-info JSON contract.
+	ModelName string `json:"-"`
 
 	// ClusterUUID and CliqueID identify the GPU's NVLink fabric domain.
 	// CliqueID is a pointer so a valid value of zero remains distinguishable
 	// from an unavailable fabric identity.
-	ClusterUUID string  `json:"clusterUUID,omitempty"`
-	CliqueID    *uint32 `json:"cliqueID,omitempty"`
+	ClusterUUID string  `json:"-"`
+	CliqueID    *uint32 `json:"-"`
 
 	SN           string `json:"sn,omitempty"`
 	MinorID      string `json:"minorID,omitempty"`

--- a/third_party/fleet-intelligence-sdk/api/v1/types.go
+++ b/third_party/fleet-intelligence-sdk/api/v1/types.go
@@ -413,6 +413,15 @@ type MachineGPUInstance struct {
 	//  e.g., "0000:0f:00.0"
 	BusID string `json:"busID,omitempty"`
 
+	// ModelName is the product name reported by NVML for this GPU.
+	ModelName string `json:"modelName,omitempty"`
+
+	// ClusterUUID and CliqueID identify the GPU's NVLink fabric domain.
+	// CliqueID is a pointer so a valid value of zero remains distinguishable
+	// from an unavailable fabric identity.
+	ClusterUUID string  `json:"clusterUUID,omitempty"`
+	CliqueID    *uint32 `json:"cliqueID,omitempty"`
+
 	SN           string `json:"sn,omitempty"`
 	MinorID      string `json:"minorID,omitempty"`
 	BoardID      uint32 `json:"boardID,omitempty"`

--- a/third_party/fleet-intelligence-sdk/pkg/machine-info/machine_info.go
+++ b/third_party/fleet-intelligence-sdk/pkg/machine-info/machine_info.go
@@ -396,6 +396,27 @@ func GetMachineGPUInfo(nvmlInstance nvidianvml.Instance) (*apiv1.MachineGPUInfo,
 			appendCollectionError(uuid, "get_pci_bus_id", err.Error())
 		}
 
+		modelName, ret := dev.GetName()
+		if ret != nvml.SUCCESS {
+			if ret != nvml.ERROR_NOT_SUPPORTED {
+				appendCollectionError(uuid, "get_name", nvml.ErrorString(ret))
+			}
+			modelName = ""
+		}
+
+		var clusterUUID string
+		var cliqueID *uint32
+		if nvmlInstance.FabricStateSupported() {
+			fabricState, fabricErr := dev.GetFabricState()
+			if fabricErr != nil {
+				log.Logger.Debugw("failed to get NVLink fabric identity", "uuid", uuid, "error", fabricErr)
+			} else {
+				clusterUUID = fabricState.ClusterUUID
+				id := fabricState.CliqueID
+				cliqueID = &id
+			}
+		}
+
 		vbios, ret := dev.GetVbiosVersion()
 		vbiosVersion := ""
 		if ret != nvml.SUCCESS {
@@ -417,6 +438,9 @@ func GetMachineGPUInfo(nvmlInstance nvidianvml.Instance) (*apiv1.MachineGPUInfo,
 		info.GPUs = append(info.GPUs, apiv1.MachineGPUInstance{
 			UUID:         uuid,
 			GPUIndex:     gpuIndex,
+			ModelName:    modelName,
+			ClusterUUID:  clusterUUID,
+			CliqueID:     cliqueID,
 			SN:           serialID,
 			MinorID:      strconv.Itoa(minorID),
 			BoardID:      boardID,

--- a/third_party/fleet-intelligence-sdk/pkg/machine-info/machine_info_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/machine-info/machine_info_test.go
@@ -478,6 +478,18 @@ func TestGetMachineGPUInfo_PartialNVMLFailureIsNonFatal(t *testing.T) {
 	require.Equal(t, "GPU-failing-device", info.GPUs[0].UUID)
 }
 
+func TestGetMachineGPUInfo_CollectsFabricIdentity(t *testing.T) {
+	t.Parallel()
+
+	info, err := GetMachineGPUInfo(&fabricIdentityMockNVMLInstance{})
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.Len(t, info.GPUs, 1)
+	require.NotNil(t, info.GPUs[0].CliqueID)
+	assert.Equal(t, uint32(0), *info.GPUs[0].CliqueID)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", info.GPUs[0].ClusterUUID)
+}
+
 type partialFailureMockNVMLInstance struct {
 	nvidianvml.Instance
 }
@@ -492,6 +504,10 @@ func (m *partialFailureMockNVMLInstance) Brand() string {
 
 func (m *partialFailureMockNVMLInstance) Architecture() string {
 	return "hopper"
+}
+
+func (m *partialFailureMockNVMLInstance) FabricStateSupported() bool {
+	return false
 }
 
 func (m *partialFailureMockNVMLInstance) Devices() map[string]nvmldevice.Device {
@@ -536,12 +552,41 @@ func (d *partialFailureMockGPUDevice) GetPCIBusID() (string, error) {
 	return "0000:01:00.0", fmt.Errorf("gpu lost")
 }
 
+func (d *partialFailureMockGPUDevice) GetName() (string, nvml.Return) {
+	return "", nvml.ERROR_GPU_IS_LOST
+}
+
 func (d *partialFailureMockGPUDevice) GetVbiosVersion() (string, nvml.Return) {
 	return "", nvml.ERROR_GPU_IS_LOST
 }
 
 func (d *partialFailureMockGPUDevice) GetIndex() (int, nvml.Return) {
 	return 0, nvml.ERROR_GPU_IS_LOST
+}
+
+type fabricIdentityMockNVMLInstance struct {
+	partialFailureMockNVMLInstance
+}
+
+func (m *fabricIdentityMockNVMLInstance) FabricStateSupported() bool {
+	return true
+}
+
+func (m *fabricIdentityMockNVMLInstance) Devices() map[string]nvmldevice.Device {
+	return map[string]nvmldevice.Device{
+		"GPU-fabric-device": &fabricIdentityMockGPUDevice{},
+	}
+}
+
+type fabricIdentityMockGPUDevice struct {
+	partialFailureMockGPUDevice
+}
+
+func (d *fabricIdentityMockGPUDevice) GetFabricState() (nvmldevice.FabricState, error) {
+	return nvmldevice.FabricState{
+		CliqueID:    0,
+		ClusterUUID: "11111111-2222-3333-4444-555555555555",
+	}, nil
 }
 
 // TestGetSystemResourceRootVolumeTotal_Validation tests root volume total validation


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer hardware identity information for GPUs, CPUs, NVLink, and NVSwitch resources.
  * Added hardware inventory and agent uptime metrics.
  * Enhanced metrics, events, and incidents with consistent resource identity details.
  * Improved hostname handling and deterministic metric labels.

* **Bug Fixes**
  * Preserved original event metadata when adding identity information.
  * Omitted unavailable inventory values and invalid future start times.
  * Improved GPU model and fabric information collection when supported.

* **Tests**
  * Added coverage for hardware identity mapping, inventory metrics, hostname normalization, and event enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->