### PR TITLE
ci: pin goreleaser-action to v5.1.0 SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           rm -rf ./dist || true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:
           distribution: goreleaser
           version: v2.4.1


### PR DESCRIPTION
## Summary
- Pins `goreleaser/goreleaser-action` from `@v5` to `5742e2a039330cbb23ebf35f046f814d4c6ff811` (v5.1.0) so the release workflow satisfies the `dsx-ai-factory` Actions allowlist after the NVIDIA org transfer.

## Test plan
- [ ] Confirm the SHA matches goreleaser-action v5.1.0
- [ ] After merge, a `v*` tag still runs `.github/workflows/release.yml` without an allowlist failure on that step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation tooling to a pinned, verified version for more consistent releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->