### PR TITLE
fix(helm): mount host identity files during enrollment

### DIFF
--- a/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
+++ b/deployments/helm/fleet-intelligence-agent/templates/daemonset.yaml
@@ -104,6 +104,12 @@ spec:
             - name: sys
               mountPath: /sys
               readOnly: true
+            - name: os-release
+              mountPath: /etc/os-release
+              readOnly: true
+            - name: machine-id
+              mountPath: /etc/machine-id
+              readOnly: true
             - name: state
               mountPath: /var/lib/fleetint
       {{- else if .Values.enroll.unenroll }}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/dsx-ai-factory/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent enrollment by making the host operating system and machine identity information available to the enrollment process.
  - Mounted these system files in read-only mode to preserve host integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->