### PR TITLE
fix: set default log level to warn

### DIFF
--- a/cmd/fleetint/root.go
+++ b/cmd/fleetint/root.go
@@ -24,6 +24,8 @@ import (
 	"github.com/dsx-ai-factory/fleet-intelligence-agent/internal/version"
 )
 
+const defaultLogLevel = "warn"
+
 func App() *cli.App {
 	app := cli.NewApp()
 
@@ -51,6 +53,7 @@ func App() *cli.App {
 				&cli.StringFlag{
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error]",
+					Value: defaultLogLevel,
 				},
 				&cli.StringFlag{
 					Name:   "infiniband-expected-port-states",
@@ -73,6 +76,7 @@ func App() *cli.App {
 				&cli.StringFlag{
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error]",
+					Value: defaultLogLevel,
 				},
 				&cli.StringFlag{
 					Name:  "log-file",
@@ -137,6 +141,7 @@ func App() *cli.App {
 				&cli.StringFlag{
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error]",
+					Value: defaultLogLevel,
 				},
 				&cli.StringFlag{
 					Name:  "server-url",
@@ -154,6 +159,7 @@ func App() *cli.App {
 				&cli.StringFlag{
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error]",
+					Value: defaultLogLevel,
 				},
 			},
 		},
@@ -165,6 +171,7 @@ func App() *cli.App {
 				&cli.StringFlag{
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error]",
+					Value: defaultLogLevel,
 				},
 				&cli.StringFlag{
 					Name:  "set-key",
@@ -184,6 +191,7 @@ func App() *cli.App {
 				&cli.StringFlag{
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error]",
+					Value: defaultLogLevel,
 				},
 			},
 		},

--- a/cmd/fleetint/root_test.go
+++ b/cmd/fleetint/root_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
+)
+
+func TestLogLevelDefaultsToWarn(t *testing.T) {
+	var commandsWithLogLevel []string
+
+	for _, command := range App().Commands {
+		for _, flag := range command.Flags {
+			logLevelFlag, ok := flag.(*cli.StringFlag)
+			if !ok || logLevelFlag.Name != "log-level,l" {
+				continue
+			}
+
+			commandsWithLogLevel = append(commandsWithLogLevel, command.Name)
+			require.Equal(t, "warn", logLevelFlag.Value, "command %q", command.Name)
+		}
+	}
+
+	require.ElementsMatch(t, []string{"scan", "run", "status", "machine-info", "metadata", "compact"}, commandsWithLogLevel)
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,7 @@ These are the `fleetint run` flags supported by the CLI.
 
 | Flag | Description | Default | Bare metal | Kubernetes |
 | --- | --- | --- | --- | --- |
-| `--log-level` | Log level: `debug`, `info`, `warn`, `error`. | unset by CLI; packaged bare-metal default is `warn` via `FLEETINT_FLAGS` | `FLEETINT_FLAGS="--log-level=..."` | `logLevel` |
+| `--log-level` | Log level: `debug`, `info`, `warn`, `error`. | `warn` | `FLEETINT_FLAGS="--log-level=..."` | `logLevel` |
 | `--log-file` | Log file path. Leave empty to log to stdout/stderr. | empty | `FLEETINT_FLAGS="--log-file=..."` | not exposed by chart by default |
 | `--listen-address` | Listen address for the agent API server. An absolute path creates a Unix socket; a `host:port` value opens a TCP listener. | `/run/fleetint/fleetint.sock` | `FLEETINT_FLAGS="--listen-address=..."` | `listenAddress` |
 | `--retention-period` | Retention period for stored metrics and events. Minimum `1m`. | `24h` | `FLEETINT_FLAGS="--retention-period=..."` | `retentionPeriod` |


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/dsx-ai-factory/fleet-intelligence-agent/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The `--log-level` option now defaults to `warn` across scanning, execution, status, machine information, metadata, and compaction commands.
  * Updated configuration documentation to reflect the explicit `warn` default.

* **Tests**
  * Added coverage confirming the default log level is consistently applied across supported commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->