### PR TITLE
feat: add DCGM-backed GPU inventory provider

### DIFF
--- a/docs/nvml-dependency-audit.md
+++ b/docs/nvml-dependency-audit.md
@@ -26,11 +26,14 @@ NVML-backed components treat an unavailable NVML instance or missing product
 name as no detected GPU. The DCGM replacement preserves that behavior: when
 DCGM is unavailable or initialization times out, its reconnecting no-op
 instance exposes an empty inventory, so GPU-gated components report Healthy as
-unsupported while connection attempts continue in the background. A completed
-`GetSupportedDevices` error instead fails initialization, and failures that
-occur only while enriching successfully enumerated device IDs retain those IDs
-for presence checks. Adding independent PCI/sysfs GPU detection would be a
-separate reliability improvement rather than part of NVML compatibility.
+unsupported while connection attempts continue in the background. A
+`GetSupportedDevices` error also invalidates that candidate DCGM session: the
+agent keeps the reconnecting no-op instance and retries the complete session
+initialization instead of publishing an apparently connected instance with an
+empty inventory. Failures that occur only while enriching successfully
+enumerated device IDs retain those IDs for presence checks. Adding independent
+PCI/sysfs GPU detection would be a separate reliability improvement rather
+than part of NVML compatibility.
 
 The pinned DCGM API already exposes:
 

--- a/docs/nvml-dependency-audit.md
+++ b/docs/nvml-dependency-audit.md
@@ -1,0 +1,54 @@
+# NVML Dependency Audit
+
+> Pre-migration snapshot: this records the direct NVML dependencies and known
+> compatibility gaps identified before the DCGM migration began.
+
+## What currently depends on NVML
+
+| Feature/signal                                   | Current NVML use                                                                                                                                                                                                                                              | Replacement                                                                                       |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Machine inventory and telemetry identity         | Driver/CUDA versions; product, brand, architecture, memory; per-GPU UUID, serial, minor ID, board ID, PCI bus, model, fabric IDs, VBIOS, chassis serial, and index ([collector](../third_party/fleet-intelligence-sdk/pkg/machine-info/machine_info.go#L328)) | DCGM covers nearly everything                                                                     |
+| `accelerator-nvidia-persistence-mode`            | Direct `GetPersistenceMode` per GPU ([component](../third_party/fleet-intelligence-sdk/components/accelerator/nvidia/persistence-mode/component.go#L140))                                                                                                     | `DCGM_FI_DEV_PERSISTENCE_MODE`                                                                    |
+| `accelerator-nvidia-nvml`                        | Reports errors encountered during inventory collection                                                                                                                                                                                                        | Replace with a neutral GPU-inventory/DCGM-collection health signal                                |
+| XID                                              | NVML gates the component, maps PCI bus IDs to UUIDs, and decides whether XID 63/64 should be suppressed                                                                                                                                                       | DCGM UUID-to-PCI map plus existing product-capability tables                                      |
+| InfiniBand, NCCL, peermem, and SXID              | NVML is only used to decide whether this is a GPU host                                                                                                                                                                                                        | DCGM device count, with PCI/sysfs fallback                                                        |
+| `library`                                        | NVML availability decides whether `libnvidia-ml.so` and `libcuda.so` are checked                                                                                                                                                                              | Gate on NVIDIA GPU/driver presence; decide whether the NVML library-presence check itself remains |
+| Precheck                                         | Driver version, architecture, and GPU detail collection ([precheck](../internal/precheck/precheck.go#L106))                                                                                                                                                   | DCGM primary; `/proc/driver/nvidia`, sysfs, and PCI fallback                                      |
+| `scan`, `machine-info`, and enrollment inventory | Explicitly create an NVML instance                                                                                                                                                                                                                            | Pass a neutral inventory provider/DCGM instance                                                   |
+| `/machine-info`                                  | `nvidia_available` is based on `NVMLInstance != nil`                                                                                                                                                                                                          | Use DCGM devices or PCI detection                                                                 |
+
+The daemon owns the full NVML lifecycle today: it initializes NVML, puts it in `GPUdInstance`, passes it into inventory and the exporter, and shuts it down ([server](../internal/server/server.go#L273)). If NVML is initially missing, it polls every five seconds and exits the process when NVML appears so the supervisor can restart it. DCGM already has a reconnecting instance, so that exit/restart mechanism can disappear.
+
+One noteworthy bug: `nvidia_available` is effectively always true during a normal server run because a missing library produces a non-nil no-op NVML instance ([handler](../internal/server/handlers.go#L242)).
+
+The pinned DCGM API already exposes:
+
+- Driver and CUDA-driver versions
+- GPU model, brand, UUID, serial, minor number, and PCI bus ID
+- VBIOS and framebuffer memory
+- Persistence mode
+- Fabric cluster UUID and clique ID
+- Chassis serial
+- DCGM device ID for the exported `gpu` label
+
+These are standard DCGM fields documented in the [NVIDIA DCGM field identifiers](https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html).
+
+The underlying `go-dcgm.GetDeviceInfo` already returns model, brand, serial, VBIOS, driver version, memory, and PCI information. Fleetint's wrapper currently discards all of that except `ID` and `UUID`, so extending its `DeviceInfo` is the natural first move.
+
+## Remaining compatibility gaps
+
+1. **Board ID:** DCGM has no equivalent to `nvmlDeviceGetBoardId`. The migration keeps the field and sends `0`; exact parity is unavailable. NVML's board ID is configuration-local and not stable across reboots. See the [NVML board-ID semantics](https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html).
+
+2. **Architecture:** DCGM has compute capability but no architecture-name field. The migration derives the existing lowercase architecture values from compute capability, including Ampere, Ada, Hopper, Blackwell, and Rubin. The mapping must be extended and tested as new GPU architectures appear.
+
+3. **Persistence error detail:** Enabled, disabled, and unsupported states are preservable. DCGM field status may not distinguish `GPU_IS_LOST` from `GPU_REQUIRES_RESET` as precisely as the current NVML call, so the exact reboot recommendation may need correlation with DCGM health or XID data.
+
+4. **Library check:** The `library` component continues checking `libcuda.so` on GPU hosts but intentionally no longer requires `libnvidia-ml.so`; otherwise the agent would still treat NVML as a required runtime surface.
+
+5. **Inventory error detail:** The legacy `accelerator-nvidia-nvml` component ID is retained for telemetry/configuration compatibility, but it now reports DCGM inventory and field-cache failures. Its error text will not match the former per-call NVML errors exactly.
+
+6. **SDK API compatibility:** The direct NVML query packages and their NVML-specific error/device types are removed. Out-of-tree SDK consumers importing those packages must migrate to the DCGM inventory interface.
+
+7. **Dependency boundary:** The agent no longer imports, loads, or checks NVML directly. DCGM and the NVIDIA driver may still use NVML internally and expose DCGM status names containing `NVML`; eliminating that system-level implementation detail is outside the agent's control.
+
+The GB10 unified-memory fallback can remain: use DCGM's model and framebuffer result, then fall back to system memory when the model ends in `GB10`.

--- a/docs/nvml-dependency-audit.md
+++ b/docs/nvml-dependency-audit.md
@@ -11,7 +11,7 @@
 | `accelerator-nvidia-persistence-mode`            | Direct `GetPersistenceMode` per GPU ([component](../third_party/fleet-intelligence-sdk/components/accelerator/nvidia/persistence-mode/component.go#L140))                                                                                                     | `DCGM_FI_DEV_PERSISTENCE_MODE`                                                                    |
 | `accelerator-nvidia-nvml`                        | Reports errors encountered during inventory collection                                                                                                                                                                                                        | Replace with a neutral GPU-inventory/DCGM-collection health signal                                |
 | XID                                              | NVML gates the component, maps PCI bus IDs to UUIDs, and decides whether XID 63/64 should be suppressed                                                                                                                                                       | DCGM UUID-to-PCI map plus existing product-capability tables                                      |
-| InfiniBand, NCCL, peermem, and SXID              | NVML is only used to decide whether this is a GPU host                                                                                                                                                                                                        | DCGM device count, with PCI/sysfs fallback                                                        |
+| InfiniBand, NCCL, peermem, and SXID              | NVML is only used to decide whether this is a GPU host                                                                                                                                                                                                        | DCGM device inventory; no PCI/sysfs fallback, matching the existing provider-gating behavior      |
 | `library`                                        | NVML availability decides whether `libnvidia-ml.so` and `libcuda.so` are checked                                                                                                                                                                              | Gate on NVIDIA GPU/driver presence; decide whether the NVML library-presence check itself remains |
 | Precheck                                         | Driver version, architecture, and GPU detail collection ([precheck](../internal/precheck/precheck.go#L106))                                                                                                                                                   | DCGM primary; `/proc/driver/nvidia`, sysfs, and PCI fallback                                      |
 | `scan`, `machine-info`, and enrollment inventory | Explicitly create an NVML instance                                                                                                                                                                                                                            | Pass a neutral inventory provider/DCGM instance                                                   |
@@ -20,6 +20,17 @@
 The daemon owns the full NVML lifecycle today: it initializes NVML, puts it in `GPUdInstance`, passes it into inventory and the exporter, and shuts it down ([server](../internal/server/server.go#L273)). If NVML is initially missing, it polls every five seconds and exits the process when NVML appears so the supervisor can restart it. DCGM already has a reconnecting instance, so that exit/restart mechanism can disappear.
 
 One noteworthy bug: `nvidia_available` is effectively always true during a normal server run because a missing library produces a non-nil no-op NVML instance ([handler](../internal/server/handlers.go#L242)).
+
+Runtime component gating does not independently probe PCI or sysfs. The current
+NVML-backed components treat an unavailable NVML instance or missing product
+name as no detected GPU. The DCGM replacement preserves that behavior: when
+DCGM is unavailable or initialization times out, its reconnecting no-op
+instance exposes an empty inventory, so GPU-gated components report Healthy as
+unsupported while connection attempts continue in the background. A completed
+`GetSupportedDevices` error instead fails initialization, and failures that
+occur only while enriching successfully enumerated device IDs retain those IDs
+for presence checks. Adding independent PCI/sysfs GPU detection would be a
+separate reliability improvement rather than part of NVML compatibility.
 
 The pinned DCGM API already exposes:
 

--- a/docs/nvml-dependency-audit.md
+++ b/docs/nvml-dependency-audit.md
@@ -11,7 +11,7 @@
 | `accelerator-nvidia-persistence-mode`            | Direct `GetPersistenceMode` per GPU ([component](../third_party/fleet-intelligence-sdk/components/accelerator/nvidia/persistence-mode/component.go#L140))                                                                                                     | `DCGM_FI_DEV_PERSISTENCE_MODE`                                                                    |
 | `accelerator-nvidia-nvml`                        | Reports errors encountered during inventory collection                                                                                                                                                                                                        | Replace with a neutral GPU-inventory/DCGM-collection health signal                                |
 | XID                                              | NVML gates the component, maps PCI bus IDs to UUIDs, and decides whether XID 63/64 should be suppressed                                                                                                                                                       | DCGM UUID-to-PCI map plus existing product-capability tables                                      |
-| InfiniBand, NCCL, peermem, and SXID              | NVML is only used to decide whether this is a GPU host                                                                                                                                                                                                        | DCGM device inventory; no PCI/sysfs fallback, matching the existing provider-gating behavior      |
+| InfiniBand, NCCL, peermem, and SXID              | NVML is only used to decide whether this is a GPU host                                                                                                                                                                                                        | DCGM device inventory, with independent PCI detection when the inventory is empty                 |
 | `library`                                        | NVML availability decides whether `libnvidia-ml.so` and `libcuda.so` are checked                                                                                                                                                                              | Gate on NVIDIA GPU/driver presence; decide whether the NVML library-presence check itself remains |
 | Precheck                                         | Driver version, architecture, and GPU detail collection ([precheck](../internal/precheck/precheck.go#L106))                                                                                                                                                   | DCGM primary; `/proc/driver/nvidia`, sysfs, and PCI fallback                                      |
 | `scan`, `machine-info`, and enrollment inventory | Explicitly create an NVML instance                                                                                                                                                                                                                            | Pass a neutral inventory provider/DCGM instance                                                   |
@@ -21,19 +21,14 @@ The daemon owns the full NVML lifecycle today: it initializes NVML, puts it in `
 
 One noteworthy bug: `nvidia_available` is effectively always true during a normal server run because a missing library produces a non-nil no-op NVML instance ([handler](../internal/server/handlers.go#L242)).
 
-Runtime component gating does not independently probe PCI or sysfs. The current
-NVML-backed components treat an unavailable NVML instance or missing product
-name as no detected GPU. The DCGM replacement preserves that behavior: when
-DCGM is unavailable or initialization times out, its reconnecting no-op
-instance exposes an empty inventory, so GPU-gated components report Healthy as
-unsupported while connection attempts continue in the background. A
-`GetSupportedDevices` error also invalidates that candidate DCGM session: the
-agent keeps the reconnecting no-op instance and retries the complete session
-initialization instead of publishing an apparently connected instance with an
-empty inventory. Failures that occur only while enriching successfully
-enumerated device IDs retain those IDs for presence checks. Adding independent
-PCI/sysfs GPU detection would be a separate reliability improvement rather
-than part of NVML compatibility.
+Runtime component gating checks DCGM inventory first. When that inventory is
+empty, independent PCI discovery looks for an NVIDIA display controller in
+sysfs, with `lspci` as a fallback. This detects GPU hardware while DCGM is
+temporarily unavailable without creating incomplete placeholder devices or
+changing DCGM watch membership. A `GetSupportedDevices` error still invalidates
+that candidate DCGM session, and the reconnect loop retries complete session
+initialization. Failures that occur only while enriching successfully
+enumerated device IDs retain those IDs for presence checks.
 
 The pinned DCGM API already exposes:
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -50,6 +50,7 @@ import (
 	pkgmetricssyncer "github.com/NVIDIA/fleet-intelligence-sdk/pkg/metrics/syncer"
 	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
 	nvidianvml "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/nvml"
+	nvidiapci "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia/pci"
 	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/sqlite"
 
 	"github.com/dsx-ai-factory/fleet-intelligence-agent/internal/agentstate"
@@ -284,6 +285,19 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DCGM instance: %w", err)
 	}
+	// If DCGM returns no devices, use PCI to detect hardware presence.
+	// DCGM remains authoritative for device inventory and watch membership.
+	gpuHardwarePresent := len(dcgmInstance.GetDevices()) > 0
+	if !gpuHardwarePresent {
+		detectionCtx, detectionCancel := context.WithTimeout(ctx, 5*time.Second)
+		detected, detectionErr := nvidiapci.DetectGPUHardware(detectionCtx)
+		detectionCancel()
+		if detectionErr != nil {
+			log.Logger.Warnw("failed to detect NVIDIA GPU hardware independently of DCGM", "error", detectionErr)
+		} else {
+			gpuHardwarePresent = detected
+		}
+	}
 
 	// Create event store needed for health exporter
 	log.Logger.Infow("initializing event store", "retention", config.RetentionPeriod.Duration)
@@ -320,6 +334,7 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *config.Config
 		DCGMFieldValueCache:  dcgmFieldValueCache,
 		DCGMGroupNames:       dcgmGroupNames,
 		NVIDIAToolOverwrites: config.NvidiaToolOverwrites,
+		GPUHardwarePresent:   gpuHardwarePresent,
 		DBRW:                 dbRW,
 		DBRO:                 dbRO,
 		EventStore:           eventStore,

--- a/third_party/fleet-intelligence-sdk/components/registry.go
+++ b/third_party/fleet-intelligence-sdk/components/registry.go
@@ -40,6 +40,7 @@ type GPUdInstance struct {
 	DCGMFieldValueCache  *nvidiadcgm.FieldValueCache // Shared cache for DCGM field values (GPU devices only)
 	DCGMGroupNames       DCGMGroupNames
 	NVMLInstance         nvidianvml.Instance
+	GPUProvider          GPUDeviceProvider // Optional inventory override for tests.
 	NVIDIAToolOverwrites nvidiacommon.ToolOverwrites
 
 	DBRW *sql.DB
@@ -55,6 +56,28 @@ type GPUdInstance struct {
 	HealthCheckInterval time.Duration
 
 	FailureInjector *FailureInjector
+}
+
+// GPUDeviceProvider supplies a refreshable GPU inventory without
+// exposing a vendor-library-specific query interface to components.
+type GPUDeviceProvider interface {
+	GPUDevices() []nvidiadcgm.DeviceInfo
+}
+
+// GPUDevices returns the override inventory when configured, otherwise the
+// current inventory exposed by the DCGM instance.
+func (i *GPUdInstance) GPUDevices() []nvidiadcgm.DeviceInfo {
+	if i == nil {
+		return nil
+	}
+	// Tests can inject a deterministic inventory without constructing a DCGM instance.
+	if i.GPUProvider != nil {
+		return i.GPUProvider.GPUDevices()
+	}
+	if i.DCGMInstance == nil {
+		return nil
+	}
+	return i.DCGMInstance.GetDevices()
 }
 
 // DCGMGroupNames names the DCGM groups and field groups owned by one fleetint process.

--- a/third_party/fleet-intelligence-sdk/components/registry.go
+++ b/third_party/fleet-intelligence-sdk/components/registry.go
@@ -40,7 +40,6 @@ type GPUdInstance struct {
 	DCGMFieldValueCache  *nvidiadcgm.FieldValueCache // Shared cache for DCGM field values (GPU devices only)
 	DCGMGroupNames       DCGMGroupNames
 	NVMLInstance         nvidianvml.Instance
-	GPUProvider          GPUDeviceProvider // Optional inventory override for tests.
 	NVIDIAToolOverwrites nvidiacommon.ToolOverwrites
 
 	DBRW *sql.DB
@@ -64,17 +63,9 @@ type GPUDeviceProvider interface {
 	GPUDevices() []nvidiadcgm.DeviceInfo
 }
 
-// GPUDevices returns the override inventory when configured, otherwise the
-// current inventory exposed by the DCGM instance.
+// GPUDevices returns the current inventory exposed by the DCGM instance.
 func (i *GPUdInstance) GPUDevices() []nvidiadcgm.DeviceInfo {
-	if i == nil {
-		return nil
-	}
-	// Tests can inject a deterministic inventory without constructing a DCGM instance.
-	if i.GPUProvider != nil {
-		return i.GPUProvider.GPUDevices()
-	}
-	if i.DCGMInstance == nil {
+	if i == nil || i.DCGMInstance == nil {
 		return nil
 	}
 	return i.DCGMInstance.GetDevices()

--- a/third_party/fleet-intelligence-sdk/components/registry.go
+++ b/third_party/fleet-intelligence-sdk/components/registry.go
@@ -57,8 +57,11 @@ type GPUdInstance struct {
 	FailureInjector *FailureInjector
 }
 
-// GPUDeviceProvider supplies a refreshable GPU inventory without
-// exposing a vendor-library-specific query interface to components.
+// GPUDeviceProvider supplies GPU inventory without exposing a
+// vendor-library-specific query interface to components. An empty inventory can
+// mean either that DCGM enumerated no GPUs or that DCGM is temporarily unavailable.
+// Components intentionally preserve the legacy provider-gating behavior and treat both as
+// no detected GPU while the DCGM instance reconnects in the background.
 type GPUDeviceProvider interface {
 	GPUDevices() []nvidiadcgm.DeviceInfo
 }

--- a/third_party/fleet-intelligence-sdk/components/registry.go
+++ b/third_party/fleet-intelligence-sdk/components/registry.go
@@ -41,6 +41,9 @@ type GPUdInstance struct {
 	DCGMGroupNames       DCGMGroupNames
 	NVMLInstance         nvidianvml.Instance
 	NVIDIAToolOverwrites nvidiacommon.ToolOverwrites
+	// GPUHardwarePresent is the startup hardware-presence result. DCGM inventory
+	// is checked first, with independent PCI detection used when it is empty.
+	GPUHardwarePresent bool
 
 	DBRW *sql.DB
 	DBRO *sql.DB
@@ -57,13 +60,11 @@ type GPUdInstance struct {
 	FailureInjector *FailureInjector
 }
 
-// GPUDeviceProvider supplies GPU inventory without exposing a
-// vendor-library-specific query interface to components. An empty inventory can
-// mean either that DCGM enumerated no GPUs or that DCGM is temporarily unavailable.
-// Components intentionally preserve the legacy provider-gating behavior and treat both as
-// no detected GPU while the DCGM instance reconnects in the background.
+// GPUDeviceProvider supplies GPU hardware presence and inventory without
+// exposing a vendor-library-specific query interface to components.
 type GPUDeviceProvider interface {
 	GPUDevices() []nvidiadcgm.DeviceInfo
+	GPUDetected() bool
 }
 
 // GPUDevices returns the current inventory exposed by the DCGM instance.
@@ -72,6 +73,11 @@ func (i *GPUdInstance) GPUDevices() []nvidiadcgm.DeviceInfo {
 		return nil
 	}
 	return i.DCGMInstance.GetDevices()
+}
+
+// GPUDetected combines the current DCGM inventory with the startup presence result.
+func (i *GPUdInstance) GPUDetected() bool {
+	return i != nil && (i.GPUHardwarePresent || len(i.GPUDevices()) > 0)
 }
 
 // DCGMGroupNames names the DCGM groups and field groups owned by one fleetint process.

--- a/third_party/fleet-intelligence-sdk/components/registry_test.go
+++ b/third_party/fleet-intelligence-sdk/components/registry_test.go
@@ -17,12 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type staticGPUProvider struct {
-	devices []nvidiadcgm.DeviceInfo
-}
-
-func (p staticGPUProvider) GPUDevices() []nvidiadcgm.DeviceInfo { return p.devices }
-
 type staticDCGMInstance struct {
 	nvidiadcgm.Instance
 	devices []nvidiadcgm.DeviceInfo
@@ -43,18 +37,6 @@ func TestGPUdInstanceGPUDevices(t *testing.T) {
 			devices:  devices,
 		}}
 		assert.Equal(t, devices, instance.GPUDevices())
-	})
-
-	t.Run("override takes precedence", func(t *testing.T) {
-		override := []nvidiadcgm.DeviceInfo{{ID: 1, UUID: "GPU-override"}}
-		instance := &GPUdInstance{
-			DCGMInstance: staticDCGMInstance{
-				Instance: nvidiadcgm.NewNoOp(),
-				devices:  []nvidiadcgm.DeviceInfo{{ID: 0, UUID: "GPU-dcgm"}},
-			},
-			GPUProvider: staticGPUProvider{devices: override},
-		}
-		assert.Equal(t, override, instance.GPUDevices())
 	})
 }
 

--- a/third_party/fleet-intelligence-sdk/components/registry_test.go
+++ b/third_party/fleet-intelligence-sdk/components/registry_test.go
@@ -12,9 +12,51 @@ import (
 	"time"
 
 	apiv1 "github.com/NVIDIA/fleet-intelligence-sdk/api/v1"
+	nvidiadcgm "github.com/NVIDIA/fleet-intelligence-sdk/pkg/nvidia-query/dcgm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type staticGPUProvider struct {
+	devices []nvidiadcgm.DeviceInfo
+}
+
+func (p staticGPUProvider) GPUDevices() []nvidiadcgm.DeviceInfo { return p.devices }
+
+type staticDCGMInstance struct {
+	nvidiadcgm.Instance
+	devices []nvidiadcgm.DeviceInfo
+}
+
+func (i staticDCGMInstance) GetDevices() []nvidiadcgm.DeviceInfo { return i.devices }
+
+func TestGPUdInstanceGPUDevices(t *testing.T) {
+	t.Run("nil instance", func(t *testing.T) {
+		var instance *GPUdInstance
+		assert.Nil(t, instance.GPUDevices())
+	})
+
+	t.Run("DCGM inventory", func(t *testing.T) {
+		devices := []nvidiadcgm.DeviceInfo{{ID: 0, UUID: "GPU-dcgm"}}
+		instance := &GPUdInstance{DCGMInstance: staticDCGMInstance{
+			Instance: nvidiadcgm.NewNoOp(),
+			devices:  devices,
+		}}
+		assert.Equal(t, devices, instance.GPUDevices())
+	})
+
+	t.Run("override takes precedence", func(t *testing.T) {
+		override := []nvidiadcgm.DeviceInfo{{ID: 1, UUID: "GPU-override"}}
+		instance := &GPUdInstance{
+			DCGMInstance: staticDCGMInstance{
+				Instance: nvidiadcgm.NewNoOp(),
+				devices:  []nvidiadcgm.DeviceInfo{{ID: 0, UUID: "GPU-dcgm"}},
+			},
+			GPUProvider: staticGPUProvider{devices: override},
+		}
+		assert.Equal(t, override, instance.GPUDevices())
+	})
+}
 
 // mockComponent implements the Component interface for testing
 type mockComponent struct {

--- a/third_party/fleet-intelligence-sdk/components/registry_test.go
+++ b/third_party/fleet-intelligence-sdk/components/registry_test.go
@@ -40,6 +40,29 @@ func TestGPUdInstanceGPUDevices(t *testing.T) {
 	})
 }
 
+func TestGPUDetected(t *testing.T) {
+	t.Run("DCGM inventory", func(t *testing.T) {
+		instance := &GPUdInstance{DCGMInstance: staticDCGMInstance{
+			Instance: nvidiadcgm.NewNoOp(),
+			devices:  []nvidiadcgm.DeviceInfo{{ID: 0}},
+		}}
+		assert.True(t, instance.GPUDetected())
+	})
+
+	t.Run("independent PCI detection", func(t *testing.T) {
+		instance := &GPUdInstance{
+			DCGMInstance:       nvidiadcgm.NewNoOp(),
+			GPUHardwarePresent: true,
+		}
+		assert.True(t, instance.GPUDetected())
+	})
+
+	t.Run("no detected GPU", func(t *testing.T) {
+		instance := &GPUdInstance{DCGMInstance: nvidiadcgm.NewNoOp()}
+		assert.False(t, instance.GPUDetected())
+	})
+}
+
 // mockComponent implements the Component interface for testing
 type mockComponent struct {
 	name string

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/field_cache.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/field_cache.go
@@ -18,7 +18,6 @@ package dcgm
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -217,6 +216,16 @@ func (fc *FieldValueCache) Poll() error {
 		return nil
 	}
 
+	// Inventory identity fields are queried live only until the fixed device
+	// membership has a complete snapshot. Sharing this cadence avoids a second
+	// background ticker and keeps reconnect responsible only for session setup.
+	if enricher, ok := fc.instance.(deviceInventoryEnricher); ok {
+		if err := enricher.enrichDeviceInventoryIfIncomplete(); err != nil {
+			exitForRestartIfRequired("device_inventory", err)
+			log.Logger.Warnw("DCGM device inventory enrichment retry failed", "error", err)
+		}
+	}
+
 	if err := fc.ensureFieldWatchingSetup(); err != nil {
 		return err
 	}
@@ -234,15 +243,7 @@ func (fc *FieldValueCache) Poll() error {
 	for _, device := range devices {
 		fieldValues, err := dcgm.GetLatestValuesForFields(device.ID, watchedFields)
 		if err != nil {
-			// Check for fatal errors that require restart
-			if IsRestartRequired(err) {
-				log.Logger.Errorw("DCGM fatal error, exiting for restart",
-					"component", "field_cache",
-					"deviceID", device.ID,
-					"error", err,
-					"action", "systemd/k8s will restart agent and recreate DCGM resources")
-				os.Exit(1)
-			}
+			exitForRestartIfRequired("field_cache", err, "deviceID", device.ID)
 
 			// Check if this is a transient error (benign, don't store)
 			if IsTransientError(err) {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/health_cache.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/health_cache.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -128,14 +127,7 @@ func (hc *HealthCache) Poll() error {
 	if err != nil {
 		wrappedErr := fmt.Errorf("failed to perform DCGM health check: %w", err)
 
-		// Check for fatal errors that require restart
-		if IsRestartRequired(err) {
-			log.Logger.Errorw("DCGM fatal error, exiting for restart",
-				"component", "health_cache",
-				"error", err,
-				"action", "systemd/k8s will restart agent and recreate DCGM resources")
-			os.Exit(1)
-		}
+		exitForRestartIfRequired("health_cache", err)
 
 		// Check if this is a transient error (benign, don't store)
 		if errors.Is(err, errTransientGroupNotReady) || IsTransientError(err) {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -167,28 +167,27 @@ type deviceInventoryEnrichmentRetrier interface {
 
 var newInstanceFunc = newInitializedInstance
 
-// New creates a DCGM instance. It returns a no-op instance if DCGM is
-// unavailable, but returns an error if DCGM connects and GPU enumeration fails.
+// New creates a DCGM instance. It returns a no-op instance when a complete
+// DCGM session cannot be initialized.
 func New() (Instance, error) {
 	return newInitializedInstance()
 }
 
 // NewWithGroupName creates a DCGM instance with a caller-owned DCGM group name.
-// It has the same availability and device-enumeration behavior as New.
+// It has the same initialization behavior as New.
 func NewWithGroupName(groupName string) (Instance, error) {
 	return newInitializedInstanceWithGroupName(groupName)
 }
 
-// NewWithContext creates a DCGM instance with a bounded wait. If initialization
-// exceeds the context deadline, it returns a no-op instance so callers can
-// continue startup without blocking on slow DCGM device enumeration.
+// NewWithContext creates a reconnecting DCGM instance with a bounded initial
+// wait. If a complete session cannot be initialized, it starts with a no-op
+// instance so callers can continue while initialization is retried.
 func NewWithContext(ctx context.Context) (Instance, error) {
 	return NewWithContextAndGroupName(ctx, defaultDCGMGroupName)
 }
 
 // NewWithContextAndGroupName creates a DCGM instance with a bounded wait and
-// caller-owned DCGM group name. Device-enumeration errors are returned rather
-// than converted to an empty no-op inventory.
+// caller-owned DCGM group name.
 func NewWithContextAndGroupName(ctx context.Context, groupName string) (Instance, error) {
 	type result struct {
 		inst Instance
@@ -217,7 +216,7 @@ func NewWithContextAndGroupName(ctx context.Context, groupName string) (Instance
 		}
 		if res.inst == nil || !res.inst.DCGMExists() {
 			log.Logger.Warnw(
-				"DCGM not available at startup; continuing with no-op instance and retrying in background until DCGM is up",
+				"DCGM session unavailable at startup; continuing with no-op instance and retrying complete initialization in background",
 				"retryInterval", dcgmReconnectInterval.String(),
 			)
 		}
@@ -225,7 +224,7 @@ func NewWithContextAndGroupName(ctx context.Context, groupName string) (Instance
 	case <-ctx.Done():
 		close(abandonCh)
 		log.Logger.Warnw(
-			"DCGM initialization timed out; continuing with no-op instance and retrying in background until DCGM is up",
+			"DCGM initialization timed out; continuing with no-op instance and retrying complete initialization in background",
 			"error", ctx.Err(),
 			"retryInterval", dcgmReconnectInterval.String(),
 		)
@@ -257,9 +256,6 @@ var dcgmNewDefaultGroupFunc = dcgm.NewDefaultGroup
 func newInitializedInstance() (Instance, error) {
 	connectedInst, err := newConnectedInstanceFunc()
 	if err != nil {
-		if errors.Is(err, errDeviceEnumeration) {
-			return nil, err
-		}
 		log.Logger.Warnw("DCGM initialization failed, returning no-op instance", "error", err)
 		return NewNoOp(), nil
 	}
@@ -272,9 +268,6 @@ func newInitializedInstanceWithGroupName(groupName string) (Instance, error) {
 	}
 	connectedInst, err := connectWithGroupName(groupName)
 	if err != nil {
-		if errors.Is(err, errDeviceEnumeration) {
-			return nil, err
-		}
 		log.Logger.Warnw("DCGM initialization failed, returning no-op instance", "error", err)
 		return NewNoOp(), nil
 	}
@@ -302,8 +295,9 @@ func newConnectedInstance(groupName string) (Instance, error) {
 	log.Logger.Debugw("DCGM initialized successfully")
 
 	// Build the initial inventory before creating session resources. An
-	// enumeration error must fail initialization: otherwise GPU-gated
-	// components would misinterpret unknown inventory as a GPU-free host.
+	// enumeration error invalidates this candidate session so a reconnecting
+	// caller can retry the complete initialization instead of publishing an
+	// empty, but apparently connected, inventory.
 	devices, inventoryComplete, inventoryErr := queryDeviceInventory()
 	if errors.Is(inventoryErr, errDeviceEnumeration) {
 		if cleanup != nil {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -160,14 +161,20 @@ type reconnectCallbackRegistrar interface {
 	RegisterReconnectCallback(callback func())
 }
 
+type deviceInventoryEnrichmentRetrier interface {
+	retryDeviceInventoryEnrichment() error
+}
+
 var newInstanceFunc = newInitializedInstance
 
-// New creates a DCGM instance. Returns no-op instance if DCGM is unavailable.
+// New creates a DCGM instance. It returns a no-op instance if DCGM is
+// unavailable, but returns an error if DCGM connects and GPU enumeration fails.
 func New() (Instance, error) {
 	return newInitializedInstance()
 }
 
 // NewWithGroupName creates a DCGM instance with a caller-owned DCGM group name.
+// It has the same availability and device-enumeration behavior as New.
 func NewWithGroupName(groupName string) (Instance, error) {
 	return newInitializedInstanceWithGroupName(groupName)
 }
@@ -180,7 +187,8 @@ func NewWithContext(ctx context.Context) (Instance, error) {
 }
 
 // NewWithContextAndGroupName creates a DCGM instance with a bounded wait and
-// caller-owned DCGM group name.
+// caller-owned DCGM group name. Device-enumeration errors are returned rather
+// than converted to an empty no-op inventory.
 func NewWithContextAndGroupName(ctx context.Context, groupName string) (Instance, error) {
 	type result struct {
 		inst Instance
@@ -249,6 +257,9 @@ var dcgmNewDefaultGroupFunc = dcgm.NewDefaultGroup
 func newInitializedInstance() (Instance, error) {
 	connectedInst, err := newConnectedInstanceFunc()
 	if err != nil {
+		if errors.Is(err, errDeviceEnumeration) {
+			return nil, err
+		}
 		log.Logger.Warnw("DCGM initialization failed, returning no-op instance", "error", err)
 		return NewNoOp(), nil
 	}
@@ -261,6 +272,9 @@ func newInitializedInstanceWithGroupName(groupName string) (Instance, error) {
 	}
 	connectedInst, err := connectWithGroupName(groupName)
 	if err != nil {
+		if errors.Is(err, errDeviceEnumeration) {
+			return nil, err
+		}
 		log.Logger.Warnw("DCGM initialization failed, returning no-op instance", "error", err)
 		return NewNoOp(), nil
 	}
@@ -287,6 +301,17 @@ func newConnectedInstance(groupName string) (Instance, error) {
 
 	log.Logger.Debugw("DCGM initialized successfully")
 
+	// Build the initial inventory before creating session resources. An
+	// enumeration error must fail initialization: otherwise GPU-gated
+	// components would misinterpret unknown inventory as a GPU-free host.
+	devices, inventoryComplete, inventoryErr := queryDeviceInventory()
+	if errors.Is(inventoryErr, errDeviceEnumeration) {
+		if cleanup != nil {
+			cleanup()
+		}
+		return nil, inventoryErr
+	}
+
 	// Create group with GPUs. Components add their own entities (e.g., NVSwitch).
 	groupHandle, err := dcgmNewDefaultGroupFunc(groupName)
 	if err != nil {
@@ -298,21 +323,21 @@ func newConnectedInstance(groupName string) (Instance, error) {
 
 	log.Logger.Infow("created custom DCGM group for isolated health monitoring", "groupName", groupName)
 
-	// Fetch the inventory in one live field query. This avoids go-dcgm's
-	// GetDeviceInfo helper, which performs unused topology, affinity, and PCI
-	// bandwidth work for every GPU.
-	devices, err := queryDeviceInventory()
-	if err != nil {
-		log.Logger.Warnw("failed to query DCGM device inventory", "error", err)
-		devices = nil
+	if inventoryErr != nil {
+		// Enumeration succeeded, so retain the ID-only devices for presence
+		// checks and retry inventory enrichment in the background.
+		log.Logger.Warnw("DCGM device inventory is incomplete; will retry", "error", inventoryErr)
+	} else if !inventoryComplete {
+		log.Logger.Warnw("DCGM device inventory has retryable field failures; will retry")
 	}
 	log.Logger.Infow("cached device information", "numDevices", len(devices))
 
 	connectedInst := &instance{
-		dcgmExists:  true,
-		groupHandle: groupHandle,
-		cleanup:     cleanup,
-		devices:     devices,
+		dcgmExists:        true,
+		groupHandle:       groupHandle,
+		cleanup:           cleanup,
+		devices:           devices,
+		inventoryEnriched: inventoryComplete,
 	}
 
 	return connectedInst, nil
@@ -331,8 +356,9 @@ type instance struct {
 	groupHandle dcgm.GroupHandle
 	cleanup     func()
 
-	// devices stores cached device information fetched once at initialization
-	devices []DeviceInfo
+	devicesMu         sync.RWMutex
+	devices           []DeviceInfo
+	inventoryEnriched bool
 
 	// Health watch tracking
 	watchedSystemsMu sync.Mutex
@@ -359,7 +385,40 @@ func (inst *instance) GetGroupHandle() dcgm.GroupHandle {
 }
 
 func (inst *instance) GetDevices() []DeviceInfo {
-	return inst.devices
+	inst.devicesMu.RLock()
+	defer inst.devicesMu.RUnlock()
+	return slices.Clone(inst.devices)
+}
+
+// retryDeviceInventoryEnrichment retries identity fields for the device IDs
+// established at initialization. It never re-enumerates or changes membership.
+func (inst *instance) retryDeviceInventoryEnrichment() error {
+	inst.devicesMu.RLock()
+	if inst.inventoryEnriched {
+		inst.devicesMu.RUnlock()
+		return nil
+	}
+	deviceIDs := make([]uint, 0, len(inst.devices))
+	for _, device := range inst.devices {
+		deviceIDs = append(deviceIDs, device.ID)
+	}
+	inst.devicesMu.RUnlock()
+
+	devices, complete, err := queryDeviceInventoryFields(deviceIDs)
+	if err != nil {
+		return err
+	}
+	if !complete {
+		return nil
+	}
+
+	inst.devicesMu.Lock()
+	if !inst.inventoryEnriched {
+		inst.devices = slices.Clone(devices)
+		inst.inventoryEnriched = true
+	}
+	inst.devicesMu.Unlock()
+	return nil
 }
 
 func (inst *instance) AddHealthWatch(system dcgm.HealthSystem) error {
@@ -603,6 +662,9 @@ func (inst *reconnectingInstance) reconnectLoop() {
 			return
 		case <-ticker.C:
 			if inst.DCGMExists() {
+				if err := inst.retryDeviceInventoryEnrichment(); err != nil {
+					log.Logger.Warnw("DCGM device inventory enrichment retry failed", "error", err)
+				}
 				continue
 			}
 			if err := inst.reconnectNow(); err != nil {
@@ -621,6 +683,20 @@ func (inst *reconnectingInstance) reconnectLoop() {
 			retryAttempt = 0
 		}
 	}
+}
+
+func (inst *reconnectingInstance) retryDeviceInventoryEnrichment() error {
+	inst.currentMu.RLock()
+	defer inst.currentMu.RUnlock()
+
+	currentInst := inst.current
+	if currentInst == nil || !currentInst.DCGMExists() {
+		return nil
+	}
+	if retrier, ok := currentInst.(deviceInventoryEnrichmentRetrier); ok {
+		return retrier.retryDeviceInventoryEnrichment()
+	}
+	return nil
 }
 
 func (inst *reconnectingInstance) reconnectNow() error {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -116,34 +116,6 @@ var allHealthSystems = []dcgm.HealthSystem{
 	dcgm.DCGM_HEALTH_WATCH_NVSWITCH_FATAL,
 }
 
-// DeviceInfo stores cached device identity and static inventory information.
-// Values are populated from dcgmGetDeviceAttributes when the connection is
-// established and refreshed whenever the reconnecting instance reconnects.
-type DeviceInfo struct {
-	ID                     uint
-	UUID                   string
-	BusID                  string
-	Brand                  string
-	Model                  string
-	Serial                 string
-	VBIOSVersion           string
-	DriverVersion          string
-	FramebufferMemoryBytes uint64
-}
-
-func framebufferMemoryBytes(totalMiB uint) uint64 {
-	const bytesPerMiB uint64 = 1024 * 1024
-
-	value := uint64(totalMiB)
-	if value == 0 || value >= uint64(dcgm.DCGM_FT_INT64_BLANK) {
-		return 0
-	}
-	if value > ^uint64(0)/bytesPerMiB {
-		return 0
-	}
-	return value * bytesPerMiB
-}
-
 // Instance is the DCGM library connector interface.
 type Instance interface {
 	// DCGMExists returns true if DCGM is available.
@@ -326,36 +298,15 @@ func newConnectedInstance(groupName string) (Instance, error) {
 
 	log.Logger.Infow("created custom DCGM group for isolated health monitoring", "groupName", groupName)
 
-	// Fetch and cache device information once during initialization
-	deviceIDs, err := dcgm.GetSupportedDevices()
+	// Fetch the inventory in one live field query. This avoids go-dcgm's
+	// GetDeviceInfo helper, which performs unused topology, affinity, and PCI
+	// bandwidth work for every GPU.
+	devices, err := queryDeviceInventory()
 	if err != nil {
-		log.Logger.Warnw("failed to get supported devices", "error", err)
-		deviceIDs = nil
+		log.Logger.Warnw("failed to query DCGM device inventory", "error", err)
+		devices = nil
 	}
-
-	var devices []DeviceInfo
-	if deviceIDs != nil {
-		devices = make([]DeviceInfo, 0, len(deviceIDs))
-		for _, deviceID := range deviceIDs {
-			deviceInfo, err := dcgm.GetDeviceInfo(deviceID)
-			if err != nil {
-				log.Logger.Warnw("failed to get device info, skipping device", "deviceID", deviceID, "error", err)
-				continue
-			}
-			devices = append(devices, DeviceInfo{
-				ID:                     deviceID,
-				UUID:                   deviceInfo.UUID,
-				BusID:                  deviceInfo.PCI.BusID,
-				Brand:                  deviceInfo.Identifiers.Brand,
-				Model:                  deviceInfo.Identifiers.Model,
-				Serial:                 deviceInfo.Identifiers.Serial,
-				VBIOSVersion:           deviceInfo.Identifiers.Vbios,
-				DriverVersion:          deviceInfo.Identifiers.DriverVersion,
-				FramebufferMemoryBytes: framebufferMemoryBytes(deviceInfo.PCI.FBTotal),
-			})
-		}
-		log.Logger.Infow("cached device information", "numDevices", len(devices))
-	}
+	log.Logger.Infow("cached device information", "numDevices", len(devices))
 
 	connectedInst := &instance{
 		dcgmExists:  true,

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -116,10 +116,32 @@ var allHealthSystems = []dcgm.HealthSystem{
 	dcgm.DCGM_HEALTH_WATCH_NVSWITCH_FATAL,
 }
 
-// DeviceInfo stores cached device information
+// DeviceInfo stores cached device identity and static inventory information.
+// Values are populated from dcgmGetDeviceAttributes when the connection is
+// established and refreshed whenever the reconnecting instance reconnects.
 type DeviceInfo struct {
-	ID   uint
-	UUID string
+	ID                     uint
+	UUID                   string
+	BusID                  string
+	Brand                  string
+	Model                  string
+	Serial                 string
+	VBIOSVersion           string
+	DriverVersion          string
+	FramebufferMemoryBytes uint64
+}
+
+func framebufferMemoryBytes(totalMiB uint) uint64 {
+	const bytesPerMiB uint64 = 1024 * 1024
+
+	value := uint64(totalMiB)
+	if value == 0 || value >= uint64(dcgm.DCGM_FT_INT64_BLANK) {
+		return 0
+	}
+	if value > ^uint64(0)/bytesPerMiB {
+		return 0
+	}
+	return value * bytesPerMiB
 }
 
 // Instance is the DCGM library connector interface.
@@ -321,8 +343,15 @@ func newConnectedInstance(groupName string) (Instance, error) {
 				continue
 			}
 			devices = append(devices, DeviceInfo{
-				ID:   deviceID,
-				UUID: deviceInfo.UUID,
+				ID:                     deviceID,
+				UUID:                   deviceInfo.UUID,
+				BusID:                  deviceInfo.PCI.BusID,
+				Brand:                  deviceInfo.Identifiers.Brand,
+				Model:                  deviceInfo.Identifiers.Model,
+				Serial:                 deviceInfo.Identifiers.Serial,
+				VBIOSVersion:           deviceInfo.Identifiers.Vbios,
+				DriverVersion:          deviceInfo.Identifiers.DriverVersion,
+				FramebufferMemoryBytes: framebufferMemoryBytes(deviceInfo.PCI.FBTotal),
 			})
 		}
 		log.Logger.Infow("cached device information", "numDevices", len(devices))

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -161,10 +160,6 @@ type reconnectCallbackRegistrar interface {
 	RegisterReconnectCallback(callback func())
 }
 
-type deviceInventoryEnrichmentRetrier interface {
-	retryDeviceInventoryEnrichment() error
-}
-
 var newInstanceFunc = newInitializedInstance
 
 // New creates a DCGM instance. It returns a no-op instance when a complete
@@ -294,12 +289,21 @@ func newConnectedInstance(groupName string) (Instance, error) {
 
 	log.Logger.Debugw("DCGM initialized successfully")
 
-	// Build the initial inventory before creating session resources. An
-	// enumeration error invalidates this candidate session so a reconnecting
-	// caller can retry the complete initialization instead of publishing an
-	// empty, but apparently connected, inventory.
-	devices, inventoryComplete, inventoryErr := queryDeviceInventory()
-	if errors.Is(inventoryErr, errDeviceEnumeration) {
+	// GPU membership is required session state. If enumeration fails, reject
+	// this candidate so the reconnect loop retries complete initialization
+	// instead of publishing an apparently connected session with no GPUs.
+	deviceIDs, err := enumerateDeviceInventory()
+	if err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return nil, err
+	}
+
+	devices, inventoryComplete, inventoryErr := queryDeviceInventoryFields(deviceIDs)
+	if IsRestartRequired(inventoryErr) {
+		// The live query proved that this candidate session is unusable. Let the
+		// reconnect loop build a fresh session instead of publishing this one.
 		if cleanup != nil {
 			cleanup()
 		}
@@ -319,7 +323,7 @@ func newConnectedInstance(groupName string) (Instance, error) {
 
 	if inventoryErr != nil {
 		// Enumeration succeeded, so retain the ID-only devices for presence
-		// checks and retry inventory enrichment in the background.
+		// checks and retry inventory enrichment during field-cache polling.
 		log.Logger.Warnw("DCGM device inventory is incomplete; will retry", "error", inventoryErr)
 	} else if !inventoryComplete {
 		log.Logger.Warnw("DCGM device inventory has retryable field failures; will retry")
@@ -327,11 +331,10 @@ func newConnectedInstance(groupName string) (Instance, error) {
 	log.Logger.Infow("cached device information", "numDevices", len(devices))
 
 	connectedInst := &instance{
-		dcgmExists:        true,
-		groupHandle:       groupHandle,
-		cleanup:           cleanup,
-		devices:           devices,
-		inventoryEnriched: inventoryComplete,
+		dcgmExists:  true,
+		groupHandle: groupHandle,
+		cleanup:     cleanup,
+		inventory:   newDeviceInventory(devices, inventoryComplete),
 	}
 
 	return connectedInst, nil
@@ -350,9 +353,7 @@ type instance struct {
 	groupHandle dcgm.GroupHandle
 	cleanup     func()
 
-	devicesMu         sync.RWMutex
-	devices           []DeviceInfo
-	inventoryEnriched bool
+	inventory *deviceInventory
 
 	// Health watch tracking
 	watchedSystemsMu sync.Mutex
@@ -379,40 +380,11 @@ func (inst *instance) GetGroupHandle() dcgm.GroupHandle {
 }
 
 func (inst *instance) GetDevices() []DeviceInfo {
-	inst.devicesMu.RLock()
-	defer inst.devicesMu.RUnlock()
-	return slices.Clone(inst.devices)
+	return inst.inventory.snapshot()
 }
 
-// retryDeviceInventoryEnrichment retries identity fields for the device IDs
-// established at initialization. It never re-enumerates or changes membership.
-func (inst *instance) retryDeviceInventoryEnrichment() error {
-	inst.devicesMu.RLock()
-	if inst.inventoryEnriched {
-		inst.devicesMu.RUnlock()
-		return nil
-	}
-	deviceIDs := make([]uint, 0, len(inst.devices))
-	for _, device := range inst.devices {
-		deviceIDs = append(deviceIDs, device.ID)
-	}
-	inst.devicesMu.RUnlock()
-
-	devices, complete, err := queryDeviceInventoryFields(deviceIDs)
-	if err != nil {
-		return err
-	}
-	if !complete {
-		return nil
-	}
-
-	inst.devicesMu.Lock()
-	if !inst.inventoryEnriched {
-		inst.devices = slices.Clone(devices)
-		inst.inventoryEnriched = true
-	}
-	inst.devicesMu.Unlock()
-	return nil
+func (inst *instance) enrichDeviceInventoryIfIncomplete() error {
+	return inst.inventory.enrichIfIncomplete()
 }
 
 func (inst *instance) AddHealthWatch(system dcgm.HealthSystem) error {
@@ -656,9 +628,6 @@ func (inst *reconnectingInstance) reconnectLoop() {
 			return
 		case <-ticker.C:
 			if inst.DCGMExists() {
-				if err := inst.retryDeviceInventoryEnrichment(); err != nil {
-					log.Logger.Warnw("DCGM device inventory enrichment retry failed", "error", err)
-				}
 				continue
 			}
 			if err := inst.reconnectNow(); err != nil {
@@ -679,7 +648,7 @@ func (inst *reconnectingInstance) reconnectLoop() {
 	}
 }
 
-func (inst *reconnectingInstance) retryDeviceInventoryEnrichment() error {
+func (inst *reconnectingInstance) enrichDeviceInventoryIfIncomplete() error {
 	inst.currentMu.RLock()
 	defer inst.currentMu.RUnlock()
 
@@ -687,8 +656,8 @@ func (inst *reconnectingInstance) retryDeviceInventoryEnrichment() error {
 	if currentInst == nil || !currentInst.DCGMExists() {
 		return nil
 	}
-	if retrier, ok := currentInst.(deviceInventoryEnrichmentRetrier); ok {
-		return retrier.retryDeviceInventoryEnrichment()
+	if enricher, ok := currentInst.(deviceInventoryEnricher); ok {
+		return enricher.enrichDeviceInventoryIfIncomplete()
 	}
 	return nil
 }

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
@@ -18,6 +18,7 @@ package dcgm
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -62,9 +63,11 @@ func TestResolveInitFromEnv(t *testing.T) {
 func TestNewConnectedInstanceCleansUpWhenGroupCreationFails(t *testing.T) {
 	originalDCGMInitFunc := dcgmInitFunc
 	originalDCGMNewDefaultGroupFunc := dcgmNewDefaultGroupFunc
+	originalGetSupportedDevices := getSupportedDevicesForInventory
 	defer func() {
 		dcgmInitFunc = originalDCGMInitFunc
 		dcgmNewDefaultGroupFunc = originalDCGMNewDefaultGroupFunc
+		getSupportedDevicesForInventory = originalGetSupportedDevices
 	}()
 
 	cleanupCalled := false
@@ -72,6 +75,9 @@ func TestNewConnectedInstanceCleansUpWhenGroupCreationFails(t *testing.T) {
 		return func() {
 			cleanupCalled = true
 		}, nil
+	}
+	getSupportedDevicesForInventory = func() ([]uint, error) {
+		return nil, nil
 	}
 
 	expectedErr := errors.New("invalid group name")
@@ -91,6 +97,166 @@ func TestNewConnectedInstanceCleansUpWhenGroupCreationFails(t *testing.T) {
 	}
 	if !cleanupCalled {
 		t.Fatalf("expected DCGM cleanup to be called when group creation fails")
+	}
+}
+
+func TestNewConnectedInstanceFailsWhenDeviceEnumerationFails(t *testing.T) {
+	originalDCGMInitFunc := dcgmInitFunc
+	originalDCGMNewDefaultGroupFunc := dcgmNewDefaultGroupFunc
+	originalGetSupportedDevices := getSupportedDevicesForInventory
+	t.Cleanup(func() {
+		dcgmInitFunc = originalDCGMInitFunc
+		dcgmNewDefaultGroupFunc = originalDCGMNewDefaultGroupFunc
+		getSupportedDevicesForInventory = originalGetSupportedDevices
+	})
+
+	cleanupCalled := false
+	dcgmInitFunc = func(_ dcgmInitParams) (func(), error) {
+		return func() {
+			cleanupCalled = true
+		}, nil
+	}
+	expectedErr := errors.New("enumeration failed")
+	getSupportedDevicesForInventory = func() ([]uint, error) {
+		return nil, expectedErr
+	}
+	dcgmNewDefaultGroupFunc = func(string) (dcgm.GroupHandle, error) {
+		t.Fatal("DCGM group created before device enumeration succeeded")
+		return dcgm.GroupHandle{}, nil
+	}
+
+	inst, err := newConnectedInstance("inventory-enumeration-failure")
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("newConnectedInstance() error = %v, want %v", err, expectedErr)
+	}
+	if inst != nil {
+		t.Fatalf("newConnectedInstance() = %v, want nil", inst)
+	}
+	if !cleanupCalled {
+		t.Fatal("expected DCGM cleanup after device enumeration failure")
+	}
+}
+
+func TestNewInitializedInstancePropagatesDeviceEnumerationFailure(t *testing.T) {
+	originalNewConnectedInstanceFunc := newConnectedInstanceFunc
+	t.Cleanup(func() {
+		newConnectedInstanceFunc = originalNewConnectedInstanceFunc
+	})
+
+	expectedErr := errors.New("enumeration failed")
+	newConnectedInstanceFunc = func() (Instance, error) {
+		return nil, errors.Join(errDeviceEnumeration, expectedErr)
+	}
+
+	inst, err := newInitializedInstance()
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("newInitializedInstance() error = %v, want %v", err, expectedErr)
+	}
+	if inst != nil {
+		t.Fatalf("newInitializedInstance() = %v, want nil", inst)
+	}
+}
+
+func TestNewInitializedInstanceWithGroupNamePropagatesDeviceEnumerationFailure(t *testing.T) {
+	originalNewConnectedInstanceWithGroupNameFunc := newConnectedInstanceWithGroupNameFunc
+	t.Cleanup(func() {
+		newConnectedInstanceWithGroupNameFunc = originalNewConnectedInstanceWithGroupNameFunc
+	})
+
+	expectedErr := errors.New("enumeration failed")
+	newConnectedInstanceWithGroupNameFunc = func(string) (Instance, error) {
+		return nil, errors.Join(errDeviceEnumeration, expectedErr)
+	}
+
+	inst, err := newInitializedInstanceWithGroupName("inventory-enumeration-failure")
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("newInitializedInstanceWithGroupName() error = %v, want %v", err, expectedErr)
+	}
+	if inst != nil {
+		t.Fatalf("newInitializedInstanceWithGroupName() = %v, want nil", inst)
+	}
+}
+
+func TestInstanceRetriesOnlyIncompleteDeviceInventory(t *testing.T) {
+	originalGetSupportedDevices := getSupportedDevicesForInventory
+	originalGetLatestValues := getLatestInventoryValues
+	t.Cleanup(func() {
+		getSupportedDevicesForInventory = originalGetSupportedDevices
+		getLatestInventoryValues = originalGetLatestValues
+	})
+
+	queryCount := 0
+	getSupportedDevicesForInventory = func() ([]uint, error) {
+		return []uint{3}, nil
+	}
+	getLatestInventoryValues = func([]dcgm.GroupEntityPair, []dcgm.Short, uint) ([]dcgm.FieldValue_v2, error) {
+		queryCount++
+		uuid := stringField(3, dcgm.DCGM_FI_DEV_UUID, "GPU-refreshed")
+		if queryCount == 1 {
+			uuid.Status = dcgm.DCGM_ST_NO_DATA
+		}
+		return []dcgm.FieldValue_v2{
+			uuid,
+		}, nil
+	}
+
+	devices, complete, err := queryDeviceInventory()
+	if err != nil {
+		t.Fatalf("queryDeviceInventory() error = %v", err)
+	}
+	if complete {
+		t.Fatal("queryDeviceInventory() complete = true after DCGM_ST_NO_DATA, want false")
+	}
+	getSupportedDevicesForInventory = func() ([]uint, error) {
+		t.Fatal("inventory enrichment retry re-enumerated devices")
+		return nil, nil
+	}
+
+	inst := &instance{
+		dcgmExists:        true,
+		devices:           devices,
+		inventoryEnriched: complete,
+	}
+	if err := inst.retryDeviceInventoryEnrichment(); err != nil {
+		t.Fatalf("first retryDeviceInventoryEnrichment() error = %v", err)
+	}
+	if err := inst.retryDeviceInventoryEnrichment(); err != nil {
+		t.Fatalf("second retryDeviceInventoryEnrichment() error = %v", err)
+	}
+	if queryCount != 2 {
+		t.Fatalf("inventory query count = %d, want 2", queryCount)
+	}
+
+	want := []DeviceInfo{{ID: 3, UUID: "GPU-refreshed", MinorNumber: -1}}
+	if got := inst.GetDevices(); !slices.Equal(got, want) {
+		t.Fatalf("GetDevices() = %+v, want %+v", got, want)
+	}
+}
+
+func TestInstanceRetainsPartialInventoryWhenRetryFails(t *testing.T) {
+	originalGetSupportedDevices := getSupportedDevicesForInventory
+	originalGetLatestValues := getLatestInventoryValues
+	t.Cleanup(func() {
+		getSupportedDevicesForInventory = originalGetSupportedDevices
+		getLatestInventoryValues = originalGetLatestValues
+	})
+
+	expectedErr := errors.New("field query failed")
+	getSupportedDevicesForInventory = func() ([]uint, error) {
+		t.Fatal("inventory enrichment retry re-enumerated devices")
+		return nil, nil
+	}
+	getLatestInventoryValues = func([]dcgm.GroupEntityPair, []dcgm.Short, uint) ([]dcgm.FieldValue_v2, error) {
+		return nil, expectedErr
+	}
+
+	want := []DeviceInfo{{ID: 3, MinorNumber: -1}}
+	inst := &instance{dcgmExists: true, devices: slices.Clone(want)}
+	if err := inst.retryDeviceInventoryEnrichment(); !errors.Is(err, expectedErr) {
+		t.Fatalf("retryDeviceInventoryEnrichment() error = %v, want %v", err, expectedErr)
+	}
+	if got := inst.GetDevices(); !slices.Equal(got, want) {
+		t.Fatalf("GetDevices() = %+v, want retained inventory %+v", got, want)
 	}
 }
 

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
@@ -137,7 +137,7 @@ func TestNewConnectedInstanceFailsWhenDeviceEnumerationFails(t *testing.T) {
 	}
 }
 
-func TestNewInitializedInstancePropagatesDeviceEnumerationFailure(t *testing.T) {
+func TestNewInitializedInstanceReturnsNoOpOnDeviceEnumerationFailure(t *testing.T) {
 	originalNewConnectedInstanceFunc := newConnectedInstanceFunc
 	t.Cleanup(func() {
 		newConnectedInstanceFunc = originalNewConnectedInstanceFunc
@@ -149,15 +149,15 @@ func TestNewInitializedInstancePropagatesDeviceEnumerationFailure(t *testing.T) 
 	}
 
 	inst, err := newInitializedInstance()
-	if !errors.Is(err, expectedErr) {
-		t.Fatalf("newInitializedInstance() error = %v, want %v", err, expectedErr)
+	if err != nil {
+		t.Fatalf("newInitializedInstance() error = %v, want nil", err)
 	}
-	if inst != nil {
-		t.Fatalf("newInitializedInstance() = %v, want nil", inst)
+	if inst == nil || inst.DCGMExists() {
+		t.Fatalf("newInitializedInstance() = %v, want no-op instance", inst)
 	}
 }
 
-func TestNewInitializedInstanceWithGroupNamePropagatesDeviceEnumerationFailure(t *testing.T) {
+func TestNewInitializedInstanceWithGroupNameReturnsNoOpOnDeviceEnumerationFailure(t *testing.T) {
 	originalNewConnectedInstanceWithGroupNameFunc := newConnectedInstanceWithGroupNameFunc
 	t.Cleanup(func() {
 		newConnectedInstanceWithGroupNameFunc = originalNewConnectedInstanceWithGroupNameFunc
@@ -169,11 +169,11 @@ func TestNewInitializedInstanceWithGroupNamePropagatesDeviceEnumerationFailure(t
 	}
 
 	inst, err := newInitializedInstanceWithGroupName("inventory-enumeration-failure")
-	if !errors.Is(err, expectedErr) {
-		t.Fatalf("newInitializedInstanceWithGroupName() error = %v, want %v", err, expectedErr)
+	if err != nil {
+		t.Fatalf("newInitializedInstanceWithGroupName() error = %v, want nil", err)
 	}
-	if inst != nil {
-		t.Fatalf("newInitializedInstanceWithGroupName() = %v, want nil", inst)
+	if inst == nil || inst.DCGMExists() {
+		t.Fatalf("newInitializedInstanceWithGroupName() = %v, want no-op instance", inst)
 	}
 }
 
@@ -410,6 +410,52 @@ func TestReconnectingInstanceReplaysDeferredState(t *testing.T) {
 		if _, ok := mock.watchedFields[field]; !ok {
 			t.Fatalf("expected watched field %d to be replayed", field)
 		}
+	}
+}
+
+func TestReconnectingInstanceRetriesDeviceEnumerationFailure(t *testing.T) {
+	originalNewConnectedInstanceFunc := newConnectedInstanceFunc
+	t.Cleanup(func() {
+		newConnectedInstanceFunc = originalNewConnectedInstanceFunc
+	})
+
+	expectedErr := errors.New("enumeration failed")
+	wantDevices := []DeviceInfo{{ID: 3, UUID: "GPU-reconnected"}}
+	connected := newMockTrackingInstance()
+	connected.devices = wantDevices
+	attempts := 0
+	newConnectedInstanceFunc = func() (Instance, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, errors.Join(errDeviceEnumeration, expectedErr)
+		}
+		return connected, nil
+	}
+
+	inst := &reconnectingInstance{
+		current:           NewNoOp(),
+		watchedFields:     make(map[dcgm.Short]struct{}),
+		groupEntities:     make(map[uint]struct{}),
+		reconnectInterval: time.Hour,
+		stopCh:            make(chan struct{}),
+	}
+	defer inst.Shutdown()
+
+	if err := inst.reconnectNow(); !errors.Is(err, expectedErr) {
+		t.Fatalf("first reconnectNow() error = %v, want %v", err, expectedErr)
+	}
+	if inst.DCGMExists() {
+		t.Fatal("failed reconnect replaced the no-op instance")
+	}
+
+	if err := inst.reconnectNow(); err != nil {
+		t.Fatalf("second reconnectNow() error = %v, want nil", err)
+	}
+	if !inst.DCGMExists() {
+		t.Fatal("successful reconnect did not install the connected instance")
+	}
+	if got := inst.GetDevices(); !slices.Equal(got, wantDevices) {
+		t.Fatalf("GetDevices() = %+v, want %+v", got, wantDevices)
 	}
 }
 
@@ -862,6 +908,7 @@ type mockTrackingInstance struct {
 	watchedSystems dcgm.HealthSystem
 	watchedFields  map[dcgm.Short]struct{}
 	entities       map[uint]struct{}
+	devices        []DeviceInfo
 }
 
 func newMockTrackingInstance() *mockTrackingInstance {
@@ -910,7 +957,7 @@ func (m *mockTrackingInstance) GetLatestValuesForFields(deviceID uint, fields []
 	return nil, nil
 }
 func (m *mockTrackingInstance) GetGroupHandle() dcgm.GroupHandle { return dcgm.GroupHandle{} }
-func (m *mockTrackingInstance) GetDevices() []DeviceInfo         { return nil }
+func (m *mockTrackingInstance) GetDevices() []DeviceInfo         { return slices.Clone(m.devices) }
 func (m *mockTrackingInstance) Shutdown() error                  { return nil }
 
 type blockingReplayMockInstance struct {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
@@ -59,6 +59,30 @@ func TestResolveInitFromEnv(t *testing.T) {
 	}
 }
 
+func TestFramebufferMemoryBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		totalMiB uint
+		want     uint64
+	}{
+		{name: "zero", totalMiB: 0, want: 0},
+		{name: "valid", totalMiB: 80 * 1024, want: 80 * 1024 * 1024 * 1024},
+		{name: "blank", totalMiB: uint(dcgm.DCGM_FT_INT64_BLANK), want: 0},
+		{name: "not found", totalMiB: uint(dcgm.DCGM_FT_INT64_NOT_FOUND), want: 0},
+		{name: "not supported", totalMiB: uint(dcgm.DCGM_FT_INT64_NOT_SUPPORTED), want: 0},
+		{name: "not permissioned", totalMiB: uint(dcgm.DCGM_FT_INT64_NOT_PERMISSIONED), want: 0},
+		{name: "conversion overflow", totalMiB: ^uint(0), want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := framebufferMemoryBytes(tt.totalMiB); got != tt.want {
+				t.Fatalf("framebufferMemoryBytes(%d) = %d, want %d", tt.totalMiB, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewConnectedInstanceCleansUpWhenGroupCreationFails(t *testing.T) {
 	originalDCGMInitFunc := dcgmInitFunc
 	originalDCGMNewDefaultGroupFunc := dcgmNewDefaultGroupFunc

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
@@ -59,30 +59,6 @@ func TestResolveInitFromEnv(t *testing.T) {
 	}
 }
 
-func TestFramebufferMemoryBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		totalMiB uint
-		want     uint64
-	}{
-		{name: "zero", totalMiB: 0, want: 0},
-		{name: "valid", totalMiB: 80 * 1024, want: 80 * 1024 * 1024 * 1024},
-		{name: "blank", totalMiB: uint(dcgm.DCGM_FT_INT64_BLANK), want: 0},
-		{name: "not found", totalMiB: uint(dcgm.DCGM_FT_INT64_NOT_FOUND), want: 0},
-		{name: "not supported", totalMiB: uint(dcgm.DCGM_FT_INT64_NOT_SUPPORTED), want: 0},
-		{name: "not permissioned", totalMiB: uint(dcgm.DCGM_FT_INT64_NOT_PERMISSIONED), want: 0},
-		{name: "conversion overflow", totalMiB: ^uint(0), want: 0},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := framebufferMemoryBytes(tt.totalMiB); got != tt.want {
-				t.Fatalf("framebufferMemoryBytes(%d) = %d, want %d", tt.totalMiB, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestNewConnectedInstanceCleansUpWhenGroupCreationFails(t *testing.T) {
 	originalDCGMInitFunc := dcgmInitFunc
 	originalDCGMNewDefaultGroupFunc := dcgmNewDefaultGroupFunc

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/instance_test.go
@@ -18,6 +18,7 @@ package dcgm
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"sync"
 	"testing"
@@ -137,6 +138,45 @@ func TestNewConnectedInstanceFailsWhenDeviceEnumerationFails(t *testing.T) {
 	}
 }
 
+func TestNewConnectedInstanceRejectsRestartRequiredInventoryError(t *testing.T) {
+	originalDCGMInitFunc := dcgmInitFunc
+	originalDCGMNewDefaultGroupFunc := dcgmNewDefaultGroupFunc
+	originalGetSupportedDevices := getSupportedDevicesForInventory
+	originalGetLatestValues := getLatestInventoryValues
+	t.Cleanup(func() {
+		dcgmInitFunc = originalDCGMInitFunc
+		dcgmNewDefaultGroupFunc = originalDCGMNewDefaultGroupFunc
+		getSupportedDevicesForInventory = originalGetSupportedDevices
+		getLatestInventoryValues = originalGetLatestValues
+	})
+
+	cleanupCalled := false
+	dcgmInitFunc = func(_ dcgmInitParams) (func(), error) {
+		return func() { cleanupCalled = true }, nil
+	}
+	getSupportedDevicesForInventory = func() ([]uint, error) {
+		return []uint{3}, nil
+	}
+	getLatestInventoryValues = func([]dcgm.GroupEntityPair, []dcgm.Short, uint) ([]dcgm.FieldValue_v2, error) {
+		return nil, fmt.Errorf("inventory query failed with error code %d", dcgm.DCGM_ST_CONNECTION_NOT_VALID)
+	}
+	dcgmNewDefaultGroupFunc = func(string) (dcgm.GroupHandle, error) {
+		t.Fatal("DCGM group created for an unusable candidate session")
+		return dcgm.GroupHandle{}, nil
+	}
+
+	inst, err := newConnectedInstance("inventory-session-failure")
+	if !IsRestartRequired(err) {
+		t.Fatalf("newConnectedInstance() error = %v, want restart-required error", err)
+	}
+	if inst != nil {
+		t.Fatalf("newConnectedInstance() = %v, want nil", inst)
+	}
+	if !cleanupCalled {
+		t.Fatal("expected DCGM cleanup after restart-required inventory failure")
+	}
+}
+
 func TestNewInitializedInstanceReturnsNoOpOnDeviceEnumerationFailure(t *testing.T) {
 	originalNewConnectedInstanceFunc := newConnectedInstanceFunc
 	t.Cleanup(func() {
@@ -145,7 +185,7 @@ func TestNewInitializedInstanceReturnsNoOpOnDeviceEnumerationFailure(t *testing.
 
 	expectedErr := errors.New("enumeration failed")
 	newConnectedInstanceFunc = func() (Instance, error) {
-		return nil, errors.Join(errDeviceEnumeration, expectedErr)
+		return nil, expectedErr
 	}
 
 	inst, err := newInitializedInstance()
@@ -165,7 +205,7 @@ func TestNewInitializedInstanceWithGroupNameReturnsNoOpOnDeviceEnumerationFailur
 
 	expectedErr := errors.New("enumeration failed")
 	newConnectedInstanceWithGroupNameFunc = func(string) (Instance, error) {
-		return nil, errors.Join(errDeviceEnumeration, expectedErr)
+		return nil, expectedErr
 	}
 
 	inst, err := newInitializedInstanceWithGroupName("inventory-enumeration-failure")
@@ -177,7 +217,7 @@ func TestNewInitializedInstanceWithGroupNameReturnsNoOpOnDeviceEnumerationFailur
 	}
 }
 
-func TestInstanceRetriesOnlyIncompleteDeviceInventory(t *testing.T) {
+func TestFieldValueCacheRetriesOnlyIncompleteDeviceInventory(t *testing.T) {
 	originalGetSupportedDevices := getSupportedDevicesForInventory
 	originalGetLatestValues := getLatestInventoryValues
 	t.Cleanup(func() {
@@ -213,15 +253,15 @@ func TestInstanceRetriesOnlyIncompleteDeviceInventory(t *testing.T) {
 	}
 
 	inst := &instance{
-		dcgmExists:        true,
-		devices:           devices,
-		inventoryEnriched: complete,
+		dcgmExists: true,
+		inventory:  newDeviceInventory(devices, complete),
 	}
-	if err := inst.retryDeviceInventoryEnrichment(); err != nil {
-		t.Fatalf("first retryDeviceInventoryEnrichment() error = %v", err)
+	fieldCache := NewFieldValueCache(context.Background(), inst, time.Second)
+	if err := fieldCache.Poll(); err != nil {
+		t.Fatalf("first Poll() error = %v", err)
 	}
-	if err := inst.retryDeviceInventoryEnrichment(); err != nil {
-		t.Fatalf("second retryDeviceInventoryEnrichment() error = %v", err)
+	if err := fieldCache.Poll(); err != nil {
+		t.Fatalf("second Poll() error = %v", err)
 	}
 	if queryCount != 2 {
 		t.Fatalf("inventory query count = %d, want 2", queryCount)
@@ -251,9 +291,12 @@ func TestInstanceRetainsPartialInventoryWhenRetryFails(t *testing.T) {
 	}
 
 	want := []DeviceInfo{{ID: 3, MinorNumber: -1}}
-	inst := &instance{dcgmExists: true, devices: slices.Clone(want)}
-	if err := inst.retryDeviceInventoryEnrichment(); !errors.Is(err, expectedErr) {
-		t.Fatalf("retryDeviceInventoryEnrichment() error = %v, want %v", err, expectedErr)
+	inst := &instance{
+		dcgmExists: true,
+		inventory:  newDeviceInventory(want, false),
+	}
+	if err := inst.enrichDeviceInventoryIfIncomplete(); !errors.Is(err, expectedErr) {
+		t.Fatalf("enrichDeviceInventoryIfIncomplete() error = %v, want %v", err, expectedErr)
 	}
 	if got := inst.GetDevices(); !slices.Equal(got, want) {
 		t.Fatalf("GetDevices() = %+v, want retained inventory %+v", got, want)
@@ -427,7 +470,7 @@ func TestReconnectingInstanceRetriesDeviceEnumerationFailure(t *testing.T) {
 	newConnectedInstanceFunc = func() (Instance, error) {
 		attempts++
 		if attempts == 1 {
-			return nil, errors.Join(errDeviceEnumeration, expectedErr)
+			return nil, expectedErr
 		}
 		return connected, nil
 	}

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory.go
@@ -157,24 +157,30 @@ func deviceInventoryFromFieldValues(deviceIDs []uint, values []dcgm.FieldValue_v
 		case dcgm.DCGM_FI_DRIVER_VERSION:
 			device.DriverVersion = inventoryString(value)
 		case dcgm.DCGM_FI_CUDA_DRIVER_VERSION:
-			device.CUDADriverVersion = positiveInventoryInt64(value)
+			if cudaDriverVersion, ok := positiveInventoryInt64(value); ok {
+				device.CUDADriverVersion = cudaDriverVersion
+			}
 		case dcgm.DCGM_FI_DEV_MINOR_NUMBER:
-			if minorNumber := inventoryInt64(value); minorNumber >= 0 {
+			if minorNumber, ok := inventoryInt64(value); ok && minorNumber >= 0 {
 				device.MinorNumber = minorNumber
 			}
 		case dcgm.DCGM_FI_DEV_CUDA_COMPUTE_CAPABILITY:
-			device.ComputeCapability = positiveInventoryInt64(value)
+			if computeCapability, ok := positiveInventoryInt64(value); ok {
+				device.ComputeCapability = computeCapability
+			}
 		case dcgm.DCGM_FI_DEV_FABRIC_CLUSTER_UUID:
 			device.FabricClusterUUID = inventoryString(value)
 		case dcgm.DCGM_FI_DEV_FABRIC_CLIQUE_ID:
-			if cliqueID := inventoryInt64(value); cliqueID >= 0 && uint64(cliqueID) <= uint64(^uint32(0)) {
+			if cliqueID, ok := inventoryInt64(value); ok && cliqueID >= 0 && uint64(cliqueID) <= uint64(^uint32(0)) {
 				device.FabricCliqueID = uint32(cliqueID)
 				device.FabricCliqueIDValid = true
 			}
 		case dcgm.DCGM_FI_DEV_PLATFORM_CHASSIS_SERIAL_NUMBER:
 			device.ChassisSerial = inventoryString(value)
 		case dcgm.DCGM_FI_DEV_FB_TOTAL:
-			device.FramebufferMemoryBytes = framebufferMemoryBytes(inventoryInt64(value))
+			if framebufferTotal, ok := inventoryInt64(value); ok {
+				device.FramebufferMemoryBytes = framebufferMemoryBytes(framebufferTotal)
+			}
 		}
 	}
 
@@ -188,19 +194,19 @@ func inventoryString(value *dcgm.FieldValue_v2) string {
 	return value.String()
 }
 
-func inventoryInt64(value *dcgm.FieldValue_v2) int64 {
+func inventoryInt64(value *dcgm.FieldValue_v2) (int64, bool) {
 	if value.FieldType != dcgm.DCGM_FT_INT64 {
-		return 0
+		return 0, false
 	}
-	return value.Int64()
+	return value.Int64(), true
 }
 
-func positiveInventoryInt64(value *dcgm.FieldValue_v2) int64 {
-	result := inventoryInt64(value)
-	if result <= 0 {
-		return 0
+func positiveInventoryInt64(value *dcgm.FieldValue_v2) (int64, bool) {
+	result, ok := inventoryInt64(value)
+	if !ok || result <= 0 {
+		return 0, false
 	}
-	return result
+	return result, true
 }
 
 func framebufferMemoryBytes(totalMiB int64) uint64 {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory.go
@@ -16,6 +16,7 @@
 package dcgm
 
 import (
+	"errors"
 	"fmt"
 
 	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
@@ -65,15 +66,23 @@ var deviceInventoryFields = []dcgm.Short{
 var getSupportedDevicesForInventory = dcgm.GetSupportedDevices
 var getLatestInventoryValues = dcgm.EntitiesGetLatestValues
 
+var errDeviceEnumeration = errors.New("enumerate supported DCGM devices")
+
 // queryDeviceInventory enumerates supported GPUs and reads all inventory
 // fields in one request. No DCGM group, field group, or watch is required.
-func queryDeviceInventory() ([]DeviceInfo, error) {
+func queryDeviceInventory() ([]DeviceInfo, bool, error) {
 	deviceIDs, err := getSupportedDevicesForInventory()
 	if err != nil {
-		return nil, fmt.Errorf("get supported DCGM devices: %w", err)
+		return nil, false, fmt.Errorf("%w: %w", errDeviceEnumeration, err)
 	}
+	return queryDeviceInventoryFields(deviceIDs)
+}
+
+// queryDeviceInventoryFields enriches a fixed set of enumerated device IDs.
+// It does not discover devices or change the established inventory membership.
+func queryDeviceInventoryFields(deviceIDs []uint) ([]DeviceInfo, bool, error) {
 	if len(deviceIDs) == 0 {
-		return nil, nil
+		return nil, true, nil
 	}
 
 	entities := make([]dcgm.GroupEntityPair, 0, len(deviceIDs))
@@ -86,12 +95,16 @@ func queryDeviceInventory() ([]DeviceInfo, error) {
 
 	values, err := getLatestInventoryValues(entities, deviceInventoryFields, dcgm.DCGM_FV_FLAG_LIVE_DATA)
 	if err != nil {
-		return nil, fmt.Errorf("get live DCGM inventory fields: %w", err)
+		// GetSupportedDevices already established GPU presence. Preserve those
+		// entities even when the batched query cannot enrich their inventory.
+		devices, _ := deviceInventoryFromFieldValues(deviceIDs, nil)
+		return devices, false, fmt.Errorf("get live DCGM inventory fields: %w", err)
 	}
-	return deviceInventoryFromFieldValues(deviceIDs, values), nil
+	devices, complete := deviceInventoryFromFieldValues(deviceIDs, values)
+	return devices, complete, nil
 }
 
-func deviceInventoryFromFieldValues(deviceIDs []uint, values []dcgm.FieldValue_v2) []DeviceInfo {
+func deviceInventoryFromFieldValues(deviceIDs []uint, values []dcgm.FieldValue_v2) ([]DeviceInfo, bool) {
 	devices := make([]DeviceInfo, len(deviceIDs))
 	deviceIndex := make(map[uint]int, len(deviceIDs))
 	for index, deviceID := range deviceIDs {
@@ -100,6 +113,7 @@ func deviceInventoryFromFieldValues(deviceIDs []uint, values []dcgm.FieldValue_v
 		deviceIndex[deviceID] = index
 	}
 
+	complete := true
 	for valueIndex := range values {
 		value := &values[valueIndex]
 		if value.EntityGroupId != dcgm.FE_GPU {
@@ -115,6 +129,11 @@ func deviceInventoryFromFieldValues(deviceIDs []uint, values []dcgm.FieldValue_v
 				"fieldID", value.FieldID,
 				"status", value.Status,
 			)
+			if value.Status == dcgm.DCGM_ST_NOT_SUPPORTED {
+				// This field is permanently unavailable, so retrying cannot enrich it.
+				continue
+			}
+			complete = false
 			continue
 		}
 		if CheckSentinelV2(*value, "deviceID", value.EntityID) {
@@ -159,7 +178,7 @@ func deviceInventoryFromFieldValues(deviceIDs []uint, values []dcgm.FieldValue_v
 		}
 	}
 
-	return devices
+	return devices, complete
 }
 
 func inventoryString(value *dcgm.FieldValue_v2) string {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory.go
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dcgm
+
+import (
+	"fmt"
+
+	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+
+	"github.com/NVIDIA/fleet-intelligence-sdk/pkg/log"
+)
+
+// DeviceInfo stores cached GPU identity and inventory information.
+// A connected instance populates it with one batched live field query and
+// refreshes it whenever the reconnecting instance establishes a new session.
+type DeviceInfo struct {
+	ID                     uint
+	UUID                   string
+	BusID                  string
+	Brand                  string
+	Model                  string
+	Serial                 string
+	VBIOSVersion           string
+	DriverVersion          string
+	CUDADriverVersion      int64
+	MinorNumber            int64
+	ComputeCapability      int64
+	FabricClusterUUID      string
+	FabricCliqueID         uint32
+	FabricCliqueIDValid    bool
+	ChassisSerial          string
+	FramebufferMemoryBytes uint64
+}
+
+var deviceInventoryFields = []dcgm.Short{
+	dcgm.DCGM_FI_DEV_UUID,
+	dcgm.DCGM_FI_DEV_PCI_BUSID,
+	dcgm.DCGM_FI_DEV_BRAND,
+	dcgm.DCGM_FI_DEV_NAME,
+	dcgm.DCGM_FI_DEV_SERIAL,
+	dcgm.DCGM_FI_DEV_VBIOS_VERSION,
+	dcgm.DCGM_FI_DRIVER_VERSION,
+	dcgm.DCGM_FI_CUDA_DRIVER_VERSION,
+	dcgm.DCGM_FI_DEV_MINOR_NUMBER,
+	dcgm.DCGM_FI_DEV_CUDA_COMPUTE_CAPABILITY,
+	dcgm.DCGM_FI_DEV_FABRIC_CLUSTER_UUID,
+	dcgm.DCGM_FI_DEV_FABRIC_CLIQUE_ID,
+	dcgm.DCGM_FI_DEV_PLATFORM_CHASSIS_SERIAL_NUMBER,
+	dcgm.DCGM_FI_DEV_FB_TOTAL,
+}
+
+var getSupportedDevicesForInventory = dcgm.GetSupportedDevices
+var getLatestInventoryValues = dcgm.EntitiesGetLatestValues
+
+// queryDeviceInventory enumerates supported GPUs and reads all inventory
+// fields in one request. No DCGM group, field group, or watch is required.
+func queryDeviceInventory() ([]DeviceInfo, error) {
+	deviceIDs, err := getSupportedDevicesForInventory()
+	if err != nil {
+		return nil, fmt.Errorf("get supported DCGM devices: %w", err)
+	}
+	if len(deviceIDs) == 0 {
+		return nil, nil
+	}
+
+	entities := make([]dcgm.GroupEntityPair, 0, len(deviceIDs))
+	for _, deviceID := range deviceIDs {
+		entities = append(entities, dcgm.GroupEntityPair{
+			EntityGroupId: dcgm.FE_GPU,
+			EntityId:      deviceID,
+		})
+	}
+
+	values, err := getLatestInventoryValues(entities, deviceInventoryFields, dcgm.DCGM_FV_FLAG_LIVE_DATA)
+	if err != nil {
+		return nil, fmt.Errorf("get live DCGM inventory fields: %w", err)
+	}
+	return deviceInventoryFromFieldValues(deviceIDs, values), nil
+}
+
+func deviceInventoryFromFieldValues(deviceIDs []uint, values []dcgm.FieldValue_v2) []DeviceInfo {
+	devices := make([]DeviceInfo, len(deviceIDs))
+	deviceIndex := make(map[uint]int, len(deviceIDs))
+	for index, deviceID := range deviceIDs {
+		devices[index].ID = deviceID
+		devices[index].MinorNumber = -1
+		deviceIndex[deviceID] = index
+	}
+
+	for valueIndex := range values {
+		value := &values[valueIndex]
+		if value.EntityGroupId != dcgm.FE_GPU {
+			continue
+		}
+		index, exists := deviceIndex[value.EntityID]
+		if !exists {
+			continue
+		}
+		if value.Status != dcgm.DCGM_ST_OK {
+			log.Logger.Debugw("DCGM inventory field unavailable",
+				"deviceID", value.EntityID,
+				"fieldID", value.FieldID,
+				"status", value.Status,
+			)
+			continue
+		}
+		if CheckSentinelV2(*value, "deviceID", value.EntityID) {
+			continue
+		}
+
+		device := &devices[index]
+		switch value.FieldID {
+		case dcgm.DCGM_FI_DEV_UUID:
+			device.UUID = inventoryString(value)
+		case dcgm.DCGM_FI_DEV_PCI_BUSID:
+			device.BusID = inventoryString(value)
+		case dcgm.DCGM_FI_DEV_BRAND:
+			device.Brand = inventoryString(value)
+		case dcgm.DCGM_FI_DEV_NAME:
+			device.Model = inventoryString(value)
+		case dcgm.DCGM_FI_DEV_SERIAL:
+			device.Serial = inventoryString(value)
+		case dcgm.DCGM_FI_DEV_VBIOS_VERSION:
+			device.VBIOSVersion = inventoryString(value)
+		case dcgm.DCGM_FI_DRIVER_VERSION:
+			device.DriverVersion = inventoryString(value)
+		case dcgm.DCGM_FI_CUDA_DRIVER_VERSION:
+			device.CUDADriverVersion = positiveInventoryInt64(value)
+		case dcgm.DCGM_FI_DEV_MINOR_NUMBER:
+			if minorNumber := inventoryInt64(value); minorNumber >= 0 {
+				device.MinorNumber = minorNumber
+			}
+		case dcgm.DCGM_FI_DEV_CUDA_COMPUTE_CAPABILITY:
+			device.ComputeCapability = positiveInventoryInt64(value)
+		case dcgm.DCGM_FI_DEV_FABRIC_CLUSTER_UUID:
+			device.FabricClusterUUID = inventoryString(value)
+		case dcgm.DCGM_FI_DEV_FABRIC_CLIQUE_ID:
+			if cliqueID := inventoryInt64(value); cliqueID >= 0 && uint64(cliqueID) <= uint64(^uint32(0)) {
+				device.FabricCliqueID = uint32(cliqueID)
+				device.FabricCliqueIDValid = true
+			}
+		case dcgm.DCGM_FI_DEV_PLATFORM_CHASSIS_SERIAL_NUMBER:
+			device.ChassisSerial = inventoryString(value)
+		case dcgm.DCGM_FI_DEV_FB_TOTAL:
+			device.FramebufferMemoryBytes = framebufferMemoryBytes(inventoryInt64(value))
+		}
+	}
+
+	return devices
+}
+
+func inventoryString(value *dcgm.FieldValue_v2) string {
+	if value.FieldType != dcgm.DCGM_FT_STRING {
+		return ""
+	}
+	return value.String()
+}
+
+func inventoryInt64(value *dcgm.FieldValue_v2) int64 {
+	if value.FieldType != dcgm.DCGM_FT_INT64 {
+		return 0
+	}
+	return value.Int64()
+}
+
+func positiveInventoryInt64(value *dcgm.FieldValue_v2) int64 {
+	result := inventoryInt64(value)
+	if result <= 0 {
+		return 0
+	}
+	return result
+}
+
+func framebufferMemoryBytes(totalMiB int64) uint64 {
+	const bytesPerMiB uint64 = 1024 * 1024
+
+	if totalMiB <= 0 {
+		return 0
+	}
+	value := uint64(totalMiB)
+	if value > ^uint64(0)/bytesPerMiB {
+		return 0
+	}
+	return value * bytesPerMiB
+}

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory.go
@@ -16,8 +16,9 @@
 package dcgm
 
 import (
-	"errors"
 	"fmt"
+	"slices"
+	"sync"
 
 	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
 
@@ -25,8 +26,9 @@ import (
 )
 
 // DeviceInfo stores cached GPU identity and inventory information.
-// A connected instance populates it with one batched live field query and
-// refreshes it whenever the reconnecting instance establishes a new session.
+// A connected instance populates it with a batched live field query. Failed
+// enrichment is retried during field-cache polling for that session's fixed
+// device membership.
 type DeviceInfo struct {
 	ID                     uint
 	UUID                   string
@@ -66,16 +68,94 @@ var deviceInventoryFields = []dcgm.Short{
 var getSupportedDevicesForInventory = dcgm.GetSupportedDevices
 var getLatestInventoryValues = dcgm.EntitiesGetLatestValues
 
-var errDeviceEnumeration = errors.New("enumerate supported DCGM devices")
+type deviceInventoryEnricher interface {
+	enrichDeviceInventoryIfIncomplete() error
+}
+
+// deviceInventory owns the fixed GPU membership and its best-known inventory
+// data. Membership is established once when the DCGM session is created;
+// incomplete identity fields can then be retried without re-enumerating GPUs.
+type deviceInventory struct {
+	refreshMu sync.Mutex
+	mu        sync.RWMutex
+	devices   []DeviceInfo
+	complete  bool
+}
+
+func newDeviceInventory(devices []DeviceInfo, complete bool) *deviceInventory {
+	return &deviceInventory{
+		devices:  slices.Clone(devices),
+		complete: complete,
+	}
+}
+
+func (inventory *deviceInventory) snapshot() []DeviceInfo {
+	if inventory == nil {
+		return nil
+	}
+
+	inventory.mu.RLock()
+	defer inventory.mu.RUnlock()
+	return slices.Clone(inventory.devices)
+}
+
+// enrichIfIncomplete retries inventory fields for the membership established
+// at session creation. Once a complete snapshot is available, inventory fields
+// are static enough that subsequent collection cycles can skip the live query.
+func (inventory *deviceInventory) enrichIfIncomplete() error {
+	if inventory == nil {
+		return nil
+	}
+
+	// Poll can be called manually while its background loop is active. Allow
+	// only one live inventory query at a time.
+	inventory.refreshMu.Lock()
+	defer inventory.refreshMu.Unlock()
+
+	inventory.mu.RLock()
+	if inventory.complete {
+		inventory.mu.RUnlock()
+		return nil
+	}
+	deviceIDs := make([]uint, 0, len(inventory.devices))
+	for _, device := range inventory.devices {
+		deviceIDs = append(deviceIDs, device.ID)
+	}
+	inventory.mu.RUnlock()
+
+	devices, complete, err := queryDeviceInventoryFields(deviceIDs)
+	if err != nil {
+		return err
+	}
+	if !complete {
+		return nil
+	}
+
+	inventory.mu.Lock()
+	if !inventory.complete {
+		inventory.devices = slices.Clone(devices)
+		inventory.complete = true
+	}
+	inventory.mu.Unlock()
+	return nil
+}
 
 // queryDeviceInventory enumerates supported GPUs and reads all inventory
 // fields in one request. No DCGM group, field group, or watch is required.
 func queryDeviceInventory() ([]DeviceInfo, bool, error) {
-	deviceIDs, err := getSupportedDevicesForInventory()
+	deviceIDs, err := enumerateDeviceInventory()
 	if err != nil {
-		return nil, false, fmt.Errorf("%w: %w", errDeviceEnumeration, err)
+		return nil, false, err
 	}
 	return queryDeviceInventoryFields(deviceIDs)
+}
+
+func enumerateDeviceInventory() ([]uint, error) {
+	deviceIDs, err := getSupportedDevicesForInventory()
+	if err != nil {
+		return nil, fmt.Errorf("enumerate supported DCGM devices: %w", err)
+	}
+	return deviceIDs, nil
 }
 
 // queryDeviceInventoryFields enriches a fixed set of enumerated device IDs.

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory.go
@@ -216,7 +216,12 @@ func deviceInventoryFromFieldValues(deviceIDs []uint, values []dcgm.FieldValue_v
 			complete = false
 			continue
 		}
-		if CheckSentinelV2(*value, "deviceID", value.EntityID) {
+		sentinelType, isSentinel := CheckSentinelV2Helper(*value)
+		if isSentinel {
+			CheckSentinelV2(*value, "deviceID", value.EntityID)
+			if sentinelType.ShouldRetry() {
+				complete = false
+			}
 			continue
 		}
 
@@ -266,7 +271,6 @@ func deviceInventoryFromFieldValues(deviceIDs []uint, values []dcgm.FieldValue_v
 
 	return devices, complete
 }
-
 func inventoryString(value *dcgm.FieldValue_v2) string {
 	if value.FieldType != dcgm.DCGM_FT_STRING {
 		return ""

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory_test.go
@@ -70,9 +70,12 @@ func TestQueryDeviceInventoryUsesOneLiveBatch(t *testing.T) {
 		}, nil
 	}
 
-	devices, err := queryDeviceInventory()
+	devices, complete, err := queryDeviceInventory()
 	if err != nil {
 		t.Fatalf("queryDeviceInventory() error = %v", err)
+	}
+	if !complete {
+		t.Fatal("queryDeviceInventory() complete = false, want true")
 	}
 	if queryCount != 1 {
 		t.Fatalf("live inventory query count = %d, want 1", queryCount)
@@ -115,18 +118,29 @@ func TestQueryDeviceInventoryErrors(t *testing.T) {
 	getSupportedDevicesForInventory = func() ([]uint, error) {
 		return nil, expected
 	}
-	if _, err := queryDeviceInventory(); !errors.Is(err, expected) {
+	if _, _, err := queryDeviceInventory(); !errors.Is(err, expected) {
 		t.Fatalf("queryDeviceInventory() error = %v, want %v", err, expected)
 	}
 
 	getSupportedDevicesForInventory = func() ([]uint, error) {
-		return []uint{0}, nil
+		return []uint{3, 7}, nil
 	}
 	getLatestInventoryValues = func([]dcgm.GroupEntityPair, []dcgm.Short, uint) ([]dcgm.FieldValue_v2, error) {
 		return nil, expected
 	}
-	if _, err := queryDeviceInventory(); !errors.Is(err, expected) {
+	devices, complete, err := queryDeviceInventory()
+	if !errors.Is(err, expected) {
 		t.Fatalf("queryDeviceInventory() error = %v, want %v", err, expected)
+	}
+	if complete {
+		t.Fatal("queryDeviceInventory() complete = true, want false")
+	}
+	want := []DeviceInfo{
+		{ID: 3, MinorNumber: -1},
+		{ID: 7, MinorNumber: -1},
+	}
+	if !slices.Equal(devices, want) {
+		t.Fatalf("queryDeviceInventory() devices = %+v, want %+v", devices, want)
 	}
 }
 
@@ -146,9 +160,12 @@ func TestQueryDeviceInventoryDoesNotQueryFieldsWithoutDevices(t *testing.T) {
 		return nil, nil
 	}
 
-	devices, err := queryDeviceInventory()
+	devices, complete, err := queryDeviceInventory()
 	if err != nil {
 		t.Fatalf("queryDeviceInventory() error = %v", err)
+	}
+	if !complete {
+		t.Fatal("queryDeviceInventory() complete = false, want true")
 	}
 	if len(devices) != 0 {
 		t.Fatalf("devices = %+v, want none", devices)
@@ -160,11 +177,14 @@ func TestDeviceInventorySkipsUnavailableFieldsWithoutDroppingGPU(t *testing.T) {
 	nonOK.Status = dcgm.DCGM_ST_NOT_SUPPORTED
 	blankMemory := int64Field(1, dcgm.DCGM_FI_DEV_FB_TOTAL, dcgm.DCGM_FT_INT64_BLANK)
 
-	devices := deviceInventoryFromFieldValues([]uint{1}, []dcgm.FieldValue_v2{
+	devices, complete := deviceInventoryFromFieldValues([]uint{1}, []dcgm.FieldValue_v2{
 		stringField(1, dcgm.DCGM_FI_DEV_UUID, "GPU-1"),
 		nonOK,
 		blankMemory,
 	})
+	if !complete {
+		t.Fatal("deviceInventoryFromFieldValues() complete = false for permanently unsupported field")
+	}
 	want := []DeviceInfo{{ID: 1, UUID: "GPU-1", MinorNumber: -1}}
 	if !slices.Equal(devices, want) {
 		t.Fatalf("devices = %+v, want %+v", devices, want)

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory_test.go
@@ -191,6 +191,22 @@ func TestDeviceInventorySkipsUnavailableFieldsWithoutDroppingGPU(t *testing.T) {
 	}
 }
 
+func TestDeviceInventoryDistinguishesZeroFromMismatchedNumericFields(t *testing.T) {
+	devices, _ := deviceInventoryFromFieldValues([]uint{1, 2}, []dcgm.FieldValue_v2{
+		stringField(1, dcgm.DCGM_FI_DEV_MINOR_NUMBER, "wrong type"),
+		stringField(1, dcgm.DCGM_FI_DEV_FABRIC_CLIQUE_ID, "wrong type"),
+		int64Field(2, dcgm.DCGM_FI_DEV_MINOR_NUMBER, 0),
+		int64Field(2, dcgm.DCGM_FI_DEV_FABRIC_CLIQUE_ID, 0),
+	})
+	want := []DeviceInfo{
+		{ID: 1, MinorNumber: -1},
+		{ID: 2, MinorNumber: 0, FabricCliqueID: 0, FabricCliqueIDValid: true},
+	}
+	if !slices.Equal(devices, want) {
+		t.Fatalf("devices = %+v, want %+v", devices, want)
+	}
+}
+
 func TestFramebufferMemoryBytes(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory_test.go
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dcgm
+
+import (
+	"encoding/binary"
+	"errors"
+	"slices"
+	"testing"
+
+	dcgm "github.com/NVIDIA/go-dcgm/pkg/dcgm"
+)
+
+func TestQueryDeviceInventoryUsesOneLiveBatch(t *testing.T) {
+	originalGetSupportedDevices := getSupportedDevicesForInventory
+	originalGetLatestValues := getLatestInventoryValues
+	t.Cleanup(func() {
+		getSupportedDevicesForInventory = originalGetSupportedDevices
+		getLatestInventoryValues = originalGetLatestValues
+	})
+
+	getSupportedDevicesForInventory = func() ([]uint, error) {
+		return []uint{3, 7}, nil
+	}
+	queryCount := 0
+	getLatestInventoryValues = func(entities []dcgm.GroupEntityPair, fields []dcgm.Short, flags uint) ([]dcgm.FieldValue_v2, error) {
+		queryCount++
+		wantEntities := []dcgm.GroupEntityPair{
+			{EntityGroupId: dcgm.FE_GPU, EntityId: 3},
+			{EntityGroupId: dcgm.FE_GPU, EntityId: 7},
+		}
+		if !slices.Equal(entities, wantEntities) {
+			t.Fatalf("entities = %v, want %v", entities, wantEntities)
+		}
+		if !slices.Equal(fields, deviceInventoryFields) {
+			t.Fatalf("fields = %v, want %v", fields, deviceInventoryFields)
+		}
+		if flags != dcgm.DCGM_FV_FLAG_LIVE_DATA {
+			t.Fatalf("flags = %v, want DCGM_FV_FLAG_LIVE_DATA", flags)
+		}
+		return []dcgm.FieldValue_v2{
+			stringField(7, dcgm.DCGM_FI_DEV_UUID, "GPU-7"),
+			stringField(3, dcgm.DCGM_FI_DEV_UUID, "GPU-3"),
+			stringField(3, dcgm.DCGM_FI_DEV_PCI_BUSID, "0000:17:00.0"),
+			stringField(3, dcgm.DCGM_FI_DEV_BRAND, "NVIDIA"),
+			stringField(3, dcgm.DCGM_FI_DEV_NAME, "H100"),
+			stringField(3, dcgm.DCGM_FI_DEV_SERIAL, "serial-3"),
+			stringField(3, dcgm.DCGM_FI_DEV_VBIOS_VERSION, "96.00.5E.00.01"),
+			stringField(3, dcgm.DCGM_FI_DRIVER_VERSION, "570.86.15"),
+			int64Field(3, dcgm.DCGM_FI_CUDA_DRIVER_VERSION, 12080),
+			int64Field(3, dcgm.DCGM_FI_DEV_MINOR_NUMBER, 5),
+			int64Field(3, dcgm.DCGM_FI_DEV_CUDA_COMPUTE_CAPABILITY, 9<<16),
+			stringField(3, dcgm.DCGM_FI_DEV_FABRIC_CLUSTER_UUID, "cluster-3"),
+			int64Field(3, dcgm.DCGM_FI_DEV_FABRIC_CLIQUE_ID, 11),
+			stringField(3, dcgm.DCGM_FI_DEV_PLATFORM_CHASSIS_SERIAL_NUMBER, "chassis-3"),
+			int64Field(3, dcgm.DCGM_FI_DEV_FB_TOTAL, 80*1024),
+		}, nil
+	}
+
+	devices, err := queryDeviceInventory()
+	if err != nil {
+		t.Fatalf("queryDeviceInventory() error = %v", err)
+	}
+	if queryCount != 1 {
+		t.Fatalf("live inventory query count = %d, want 1", queryCount)
+	}
+	want := []DeviceInfo{
+		{
+			ID:                     3,
+			UUID:                   "GPU-3",
+			BusID:                  "0000:17:00.0",
+			Brand:                  "NVIDIA",
+			Model:                  "H100",
+			Serial:                 "serial-3",
+			VBIOSVersion:           "96.00.5E.00.01",
+			DriverVersion:          "570.86.15",
+			CUDADriverVersion:      12080,
+			MinorNumber:            5,
+			ComputeCapability:      9 << 16,
+			FabricClusterUUID:      "cluster-3",
+			FabricCliqueID:         11,
+			FabricCliqueIDValid:    true,
+			ChassisSerial:          "chassis-3",
+			FramebufferMemoryBytes: 80 * 1024 * 1024 * 1024,
+		},
+		{ID: 7, UUID: "GPU-7", MinorNumber: -1},
+	}
+	if !slices.Equal(devices, want) {
+		t.Fatalf("devices = %+v, want %+v", devices, want)
+	}
+}
+
+func TestQueryDeviceInventoryErrors(t *testing.T) {
+	originalGetSupportedDevices := getSupportedDevicesForInventory
+	originalGetLatestValues := getLatestInventoryValues
+	t.Cleanup(func() {
+		getSupportedDevicesForInventory = originalGetSupportedDevices
+		getLatestInventoryValues = originalGetLatestValues
+	})
+
+	expected := errors.New("query failed")
+	getSupportedDevicesForInventory = func() ([]uint, error) {
+		return nil, expected
+	}
+	if _, err := queryDeviceInventory(); !errors.Is(err, expected) {
+		t.Fatalf("queryDeviceInventory() error = %v, want %v", err, expected)
+	}
+
+	getSupportedDevicesForInventory = func() ([]uint, error) {
+		return []uint{0}, nil
+	}
+	getLatestInventoryValues = func([]dcgm.GroupEntityPair, []dcgm.Short, uint) ([]dcgm.FieldValue_v2, error) {
+		return nil, expected
+	}
+	if _, err := queryDeviceInventory(); !errors.Is(err, expected) {
+		t.Fatalf("queryDeviceInventory() error = %v, want %v", err, expected)
+	}
+}
+
+func TestQueryDeviceInventoryDoesNotQueryFieldsWithoutDevices(t *testing.T) {
+	originalGetSupportedDevices := getSupportedDevicesForInventory
+	originalGetLatestValues := getLatestInventoryValues
+	t.Cleanup(func() {
+		getSupportedDevicesForInventory = originalGetSupportedDevices
+		getLatestInventoryValues = originalGetLatestValues
+	})
+
+	getSupportedDevicesForInventory = func() ([]uint, error) {
+		return nil, nil
+	}
+	getLatestInventoryValues = func([]dcgm.GroupEntityPair, []dcgm.Short, uint) ([]dcgm.FieldValue_v2, error) {
+		t.Fatal("field query called without supported devices")
+		return nil, nil
+	}
+
+	devices, err := queryDeviceInventory()
+	if err != nil {
+		t.Fatalf("queryDeviceInventory() error = %v", err)
+	}
+	if len(devices) != 0 {
+		t.Fatalf("devices = %+v, want none", devices)
+	}
+}
+
+func TestDeviceInventorySkipsUnavailableFieldsWithoutDroppingGPU(t *testing.T) {
+	nonOK := stringField(1, dcgm.DCGM_FI_DEV_NAME, "invalid")
+	nonOK.Status = dcgm.DCGM_ST_NOT_SUPPORTED
+	blankMemory := int64Field(1, dcgm.DCGM_FI_DEV_FB_TOTAL, dcgm.DCGM_FT_INT64_BLANK)
+
+	devices := deviceInventoryFromFieldValues([]uint{1}, []dcgm.FieldValue_v2{
+		stringField(1, dcgm.DCGM_FI_DEV_UUID, "GPU-1"),
+		nonOK,
+		blankMemory,
+	})
+	want := []DeviceInfo{{ID: 1, UUID: "GPU-1", MinorNumber: -1}}
+	if !slices.Equal(devices, want) {
+		t.Fatalf("devices = %+v, want %+v", devices, want)
+	}
+}
+
+func TestFramebufferMemoryBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		totalMiB int64
+		want     uint64
+	}{
+		{name: "negative", totalMiB: -1, want: 0},
+		{name: "zero", totalMiB: 0, want: 0},
+		{name: "valid", totalMiB: 80 * 1024, want: 80 * 1024 * 1024 * 1024},
+		{name: "conversion overflow", totalMiB: int64(^uint64(0)/(1024*1024) + 1), want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := framebufferMemoryBytes(tt.totalMiB); got != tt.want {
+				t.Fatalf("framebufferMemoryBytes(%d) = %d, want %d", tt.totalMiB, got, tt.want)
+			}
+		})
+	}
+}
+
+func stringField(deviceID uint, fieldID dcgm.Short, value string) dcgm.FieldValue_v2 {
+	field := dcgm.FieldValue_v2{
+		EntityGroupId: dcgm.FE_GPU,
+		EntityID:      deviceID,
+		FieldID:       fieldID,
+		FieldType:     dcgm.DCGM_FT_STRING,
+		Status:        dcgm.DCGM_ST_OK,
+	}
+	copy(field.Value[:], value)
+	return field
+}
+
+func int64Field(deviceID uint, fieldID dcgm.Short, value int64) dcgm.FieldValue_v2 {
+	field := dcgm.FieldValue_v2{
+		EntityGroupId: dcgm.FE_GPU,
+		EntityID:      deviceID,
+		FieldID:       fieldID,
+		FieldType:     dcgm.DCGM_FT_INT64,
+		Status:        dcgm.DCGM_ST_OK,
+	}
+	binary.NativeEndian.PutUint64(field.Value[:], uint64(value))
+	return field
+}

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/inventory_test.go
@@ -172,18 +172,34 @@ func TestQueryDeviceInventoryDoesNotQueryFieldsWithoutDevices(t *testing.T) {
 	}
 }
 
-func TestDeviceInventorySkipsUnavailableFieldsWithoutDroppingGPU(t *testing.T) {
-	nonOK := stringField(1, dcgm.DCGM_FI_DEV_NAME, "invalid")
-	nonOK.Status = dcgm.DCGM_ST_NOT_SUPPORTED
+func TestDeviceInventorySkipsUnsupportedFieldsWithoutDroppingGPU(t *testing.T) {
+	unsupportedStatus := stringField(1, dcgm.DCGM_FI_DEV_NAME, "invalid")
+	unsupportedStatus.Status = dcgm.DCGM_ST_NOT_SUPPORTED
+	unsupportedSentinel := int64Field(1, dcgm.DCGM_FI_DEV_FB_TOTAL, dcgm.DCGM_FT_INT64_NOT_SUPPORTED)
+
+	devices, complete := deviceInventoryFromFieldValues([]uint{1}, []dcgm.FieldValue_v2{
+		stringField(1, dcgm.DCGM_FI_DEV_UUID, "GPU-1"),
+		unsupportedStatus,
+		unsupportedSentinel,
+	})
+	if !complete {
+		t.Fatal("deviceInventoryFromFieldValues() complete = false for unsupported fields")
+	}
+	want := []DeviceInfo{{ID: 1, UUID: "GPU-1", MinorNumber: -1}}
+	if !slices.Equal(devices, want) {
+		t.Fatalf("devices = %+v, want %+v", devices, want)
+	}
+}
+
+func TestDeviceInventoryRetriesBlankSentinelWithoutDroppingGPU(t *testing.T) {
 	blankMemory := int64Field(1, dcgm.DCGM_FI_DEV_FB_TOTAL, dcgm.DCGM_FT_INT64_BLANK)
 
 	devices, complete := deviceInventoryFromFieldValues([]uint{1}, []dcgm.FieldValue_v2{
 		stringField(1, dcgm.DCGM_FI_DEV_UUID, "GPU-1"),
-		nonOK,
 		blankMemory,
 	})
-	if !complete {
-		t.Fatal("deviceInventoryFromFieldValues() complete = false for permanently unsupported field")
+	if complete {
+		t.Fatal("deviceInventoryFromFieldValues() complete = true for transient blank field")
 	}
 	want := []DeviceInfo{{ID: 1, UUID: "GPU-1", MinorNumber: -1}}
 	if !slices.Equal(devices, want) {

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/query_validator.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia-query/dcgm/query_validator.go
@@ -18,6 +18,7 @@ package dcgm
 import (
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 
@@ -198,6 +199,25 @@ func IsRestartRequired(err error) bool {
 	default:
 		return false
 	}
+}
+
+// exitForRestartIfRequired applies the common recovery policy for a DCGM
+// session that can no longer serve its configured groups or watches. Native
+// DCGM resources cannot be safely repaired in place while caches are active,
+// so the process supervisor must restart the agent and rebuild the session.
+func exitForRestartIfRequired(component string, err error, fields ...interface{}) {
+	if !IsRestartRequired(err) {
+		return
+	}
+
+	logFields := []interface{}{"component", component}
+	logFields = append(logFields, fields...)
+	logFields = append(logFields,
+		"error", err,
+		"action", "systemd/k8s will restart agent and recreate DCGM resources",
+	)
+	log.Logger.Errorw("DCGM fatal error, exiting for restart", logFields...)
+	os.Exit(1)
 }
 
 // IsUnhealthyAPIError returns true if the DCGM API error indicates unhealthy state.

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia/pci/detect_sysfs.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia/pci/detect_sysfs.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const defaultSysfsPCIDevicesPath = "/sys/bus/pci/devices"
+
+// DetectGPUHardware reports whether the host exposes an NVIDIA display
+// controller. It reads PCI identity from sysfs first, which works directly on
+// bare metal and through the host /sys mount used by the fleetint DaemonSet.
+// lspci remains a fallback for environments where sysfs is unavailable.
+func DetectGPUHardware(ctx context.Context) (bool, error) {
+	found, err := detectGPUHardwareFromSysfs(defaultSysfsPCIDevicesPath)
+	if err == nil {
+		return found, nil
+	}
+
+	devices, lspciErr := ListPCIGPUs(ctx)
+	if lspciErr == nil {
+		return len(devices) > 0, nil
+	}
+
+	return false, errors.Join(
+		fmt.Errorf("detect NVIDIA GPU from sysfs: %w", err),
+		fmt.Errorf("detect NVIDIA GPU with lspci: %w", lspciErr),
+	)
+}
+
+func detectGPUHardwareFromSysfs(root string) (bool, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return false, err
+	}
+
+	for _, entry := range entries {
+		devicePath := filepath.Join(root, entry.Name())
+		vendor, err := readPCIHexValue(filepath.Join(devicePath, "vendor"))
+		if errors.Is(err, os.ErrNotExist) {
+			// A PCI device can disappear while sysfs is being enumerated.
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		if vendor != 0x10de {
+			continue
+		}
+
+		class, err := readPCIHexValue(filepath.Join(devicePath, "class"))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		if class>>16 == 0x03 {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func readPCIHexValue(path string) (uint64, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+
+	value := strings.TrimSpace(string(contents))
+	value = strings.TrimPrefix(strings.ToLower(value), "0x")
+	parsed, err := strconv.ParseUint(value, 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return parsed, nil
+}

--- a/third_party/fleet-intelligence-sdk/pkg/nvidia/pci/detect_sysfs_test.go
+++ b/third_party/fleet-intelligence-sdk/pkg/nvidia/pci/detect_sysfs_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pci
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectGPUHardwareFromSysfs(t *testing.T) {
+	tests := []struct {
+		name    string
+		vendor  string
+		class   string
+		want    bool
+		wantErr bool
+	}{
+		{name: "NVIDIA 3D controller", vendor: "0x10de", class: "0x030200", want: true},
+		{name: "NVIDIA VGA controller", vendor: "0x10de", class: "0x030000", want: true},
+		{name: "NVIDIA PCI bridge", vendor: "0x10de", class: "0x060400", want: false},
+		{name: "non-NVIDIA display controller", vendor: "0x1002", class: "0x030200", want: false},
+		{name: "invalid class", vendor: "0x10de", class: "invalid", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			devicePath := filepath.Join(root, "0000:01:00.0")
+			require.NoError(t, os.Mkdir(devicePath, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(devicePath, "vendor"), []byte(tt.vendor+"\n"), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(devicePath, "class"), []byte(tt.class+"\n"), 0o644))
+
+			got, err := detectGPUHardwareFromSysfs(root)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectGPUHardwareFromSysfsSkipsRemovedDevice(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Symlink(filepath.Join(root, "removed"), filepath.Join(root, "0000:01:00.0")))
+
+	found, err := detectGPUHardwareFromSysfs(root)
+	require.NoError(t, err)
+	assert.False(t, found)
+}


### PR DESCRIPTION
## Summary

- retain the static GPU identity and inventory returned by DCGM instead of keeping only device ID and UUID
- introduce a generic GPU device provider on `GPUdInstance`, with an override intended for tests
- document the current NVML dependency surface and known compatibility gaps

This establishes the DCGM inventory foundation used by the remaining NVML-removal changes. The audit document is retained as reviewer context through the migration and deleted by #254.

## Stack and merge order

This is PR 1 of 4 and targets `main`.

Stack: #251, #252, #253, #254.

Merge in reverse order: #254 into #253, then #253 into #252, then #252 into this PR, and finally this PR into `main`. At that point this PR contains the complete migration.

## Testing

Validated on the complete four-PR stack with the repository Go test suite in the Linux development container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive GPU inventory reporting, including device identity, driver, fabric, chassis, and framebuffer memory details.
  * Added support for supplying GPU inventory through an external provider when available.
  * Added automatic retries to complete partial inventory details after initialization.
  * Documented NVML dependencies, DCGM replacements, and remaining compatibility gaps.

* **Bug Fixes**
  * Improved reliability when GPU fields are unavailable, invalid, or exceed supported memory ranges.
  * Preserved detected GPUs when some inventory details cannot be retrieved.
  * Improved handling and cleanup of inventory query failures, including during reconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->