### PR TITLE
docs: add enrollment endpoints

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -15,9 +15,10 @@
 
 # Workflow 1 of 2 for Fern doc previews.
 #
-# Collects the fern/ and docs/ sources plus PR metadata from the PR branch and
-# uploads them as an artifact. Both directories are needed because
-# fern/docs.yml references ../docs/index.yml; omitting docs/ causes
+# Collects the fern/ and docs/ sources, the root README.md and CONTRIBUTING.md,
+# plus PR metadata from the PR branch, and uploads them as an artifact.
+# README.md and CONTRIBUTING.md are needed because fern/docs.yml references
+# ../README.md and ../CONTRIBUTING.md directly; omitting them causes
 # `fern generate --docs` to fail in the companion workflow. No secrets are
 # used here, so this is safe to run on fork PRs via the regular pull_request
 # trigger.
@@ -32,6 +33,8 @@ on:
     paths:
       - 'docs/**'
       - 'fern/**'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
       - '.github/workflows/fern-docs-preview-build.yml'
   ## --- OPTION: NVIDIA copy-PR-bot trigger ---
   ## Replace the pull_request block above with:
@@ -117,5 +120,7 @@ jobs:
           path: |
             fern/
             docs/
+            README.md
+            CONTRIBUTING.md
             preview-metadata/
           retention-days: 1

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ For the broader Fleet Intelligence platform documentation, see [docs.nvidia.com/
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+See [CONTRIBUTING.md](https://github.com/dsx-ai-factory/fleet-intelligence-agent/blob/main/CONTRIBUTING.md) for development setup and guidelines.
 
 Related: [leptonai/gpud](https://github.com/leptonai/gpud) (upstream dependency)
 
 ## License
 
-Apache License 2.0 - see [LICENSE](LICENSE) for details.
+Apache License 2.0 - see [LICENSE](https://github.com/dsx-ai-factory/fleet-intelligence-agent/blob/main/LICENSE) for details.

--- a/deployments/helm/fleet-intelligence-agent/README.md
+++ b/deployments/helm/fleet-intelligence-agent/README.md
@@ -47,7 +47,7 @@ Common values (defaults from `values.yaml`):
 | `enroll.enabled` | `false` | Enable enrollment init container. |
 | `enroll.unenroll` | `false` | Run explicit unenroll init container (cleanup persisted enrollment metadata). |
 | `enroll.force` | `false` | Append `--force` to the enrollment command. |
-| `enroll.endpoint` | `""` | Enrollment endpoint. |
+| `enroll.endpoint` | `""` | Enrollment endpoint. (Default: https://data.fleet-intelligence.nvidia.com) |
 | `enroll.tokenSecretName` | `""` | Secret name for enrollment token. |
 | `enroll.tokenSecretKey` | `token` | Secret key for enrollment token. |
 | `enroll.tokenValue` | `""` | Inline token value (optional). |

--- a/deployments/helm/fleet-intelligence-agent/values.yaml
+++ b/deployments/helm/fleet-intelligence-agent/values.yaml
@@ -123,7 +123,7 @@ otelGateway:
   # The gateway is the only component that holds these; agents never see them.
   enroll:
     # endpoint is the backend enrollment URL.
-    # Example: https://backend/api/v1/agent/enroll
+    # Example: https://data.fleet-intelligence.nvidia.com
     endpoint: ""
     # sakToken is the Service API Key used to authenticate with the API gateway
     # on enrollment. Stored in a Kubernetes Secret; never put in plain values files.

--- a/docs/install-helm.md
+++ b/docs/install-helm.md
@@ -22,6 +22,8 @@ DCGM_URL='nvidia-dcgm.gpu-operator.svc:5555'
 # Enrollment configuration - Go to the Fleet Intelligence UI to:
 #   1. Generate an enrollment token (ENROLL_TOKEN)
 #   2. Get the enrollment endpoint URL (ENROLL_ENDPOINT)
+#      Note: Default is https://data.fleet-intelligence.nvidia.com
+#            Check the 'Add New Node' page for your organiztaion. 
 ENROLL_ENDPOINT='<enroll-endpoint>'
 ENROLL_TOKEN='<enroll-token>'
 ENROLL_TOKEN_SECRET_NAME='fleet-intelligence-enroll-token'  # Recommended secret name

--- a/docs/install-helm.md
+++ b/docs/install-helm.md
@@ -23,7 +23,7 @@ DCGM_URL='nvidia-dcgm.gpu-operator.svc:5555'
 #   1. Generate an enrollment token (ENROLL_TOKEN)
 #   2. Get the enrollment endpoint URL (ENROLL_ENDPOINT)
 #      Note: Default is https://data.fleet-intelligence.nvidia.com
-#            Check the 'Add New Node' page for your organiztaion. 
+#            Check the 'Add New Node' page for your organization. 
 ENROLL_ENDPOINT='<enroll-endpoint>'
 ENROLL_TOKEN='<enroll-token>'
 ENROLL_TOKEN_SECRET_NAME='fleet-intelligence-enroll-token'  # Recommended secret name

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -19,6 +19,9 @@ metadata:
 # it is entirely CI-managed. Update this navigation: block when pages are added
 # or removed from docs/.
 navigation:
+  - page: Overview
+    path: ../README.md
+    slug: overview
   - page: Architecture
     path: ../docs/architecture.md
     slug: architecture
@@ -40,6 +43,9 @@ navigation:
   - page: Development
     path: ../docs/development.md
     slug: development
+  - page: Contributing
+    path: ../CONTRIBUTING.md
+    slug: contributing
 
 redirects:
   - source: "/fleet-intel/agent/index.html"

--- a/scripts/docs-fetch-versions.py
+++ b/scripts/docs-fetch-versions.py
@@ -47,6 +47,7 @@ SPDX = (
 # Human-readable page titles. Files not listed here fall back to title-casing
 # the filename stem (e.g. "troubleshooting.md" → "Troubleshooting").
 TITLE_MAP: dict[str, str] = {
+    "overview.md": "Overview",
     "architecture.md": "Architecture",
     "usage.md": "Usage",
     "configuration.md": "Configuration",
@@ -54,10 +55,12 @@ TITLE_MAP: dict[str, str] = {
     "install-rpm.md": "RPM Installation",
     "install-helm.md": "Helm Installation",
     "development.md": "Development",
+    "contributing.md": "Contributing",
 }
 
 # Preferred page order. Files absent from this list are appended alphabetically.
 PAGE_ORDER = [
+    "overview.md",
     "architecture.md",
     "usage.md",
     "configuration.md",
@@ -65,6 +68,15 @@ PAGE_ORDER = [
     "install-rpm.md",
     "install-helm.md",
     "development.md",
+    "contributing.md",
+]
+
+# Root-level files mirrored into fern/docs.yml's HEAD navigation as pages
+# (Overview <- README.md, Contributing <- CONTRIBUTING.md). Mapped to the
+# staged filename so slugs match the HEAD nav (slug = filename stem).
+ROOT_PAGES: list[tuple[str, str]] = [
+    ("README.md", "overview.md"),
+    ("CONTRIBUTING.md", "contributing.md"),
 ]
 
 
@@ -104,6 +116,19 @@ def fix_mdx(content: str) -> str:
             )
         result.append(line)
     return "\n".join(result)
+
+
+def get_git_file(tag: str, path: str) -> str | None:
+    """Return the content of `path` at `tag`, or None if it doesn't exist there."""
+    result = subprocess.run(
+        ["git", "show", f"{tag}:{path}"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
 
 
 def discover_versions(keep: int) -> list[tuple[str, str]]:
@@ -165,6 +190,12 @@ def fetch_version(version_label: str, tag: str) -> list[str]:
                 dest.write_text(fix_mdx(src.read_text()))
                 md_files.append(src.name)
         shutil.rmtree(docs_subdir)
+
+    for src_name, dest_name in ROOT_PAGES:
+        content = get_git_file(tag, src_name)
+        if content is not None:
+            (content_dir / dest_name).write_text(fix_mdx(content))
+            md_files.append(dest_name)
 
     return sort_files(md_files)
 


### PR DESCRIPTION
1) Fix add enrollment endpoint references to have the real production
   endpoint listed somwhere. Many users stumble on this, so we're trying
   to solve the stuble.
2) Add an overview section which has all the information from README.md 
3) Fix up README.md so when it's rendered in Fern it still links to the
   absolute paths of the License and Contributing pages.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributing and license links to direct GitHub URLs.
  * Clarified the default enrollment endpoint and corrected related terminology.
  * Updated Helm examples with the production Fleet Intelligence enrollment URL.
  * Added Overview and Contributing pages to documentation navigation.
  * Included root documentation pages in versioned documentation and preview builds.
  * Updated preview build triggers and artifacts for documentation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->